### PR TITLE
Succeed with loading from solr even if the object was missing a declared datastream

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -387,8 +387,8 @@ module ActiveFedora
       #need to call rels_ext once so it exists when iterating over datastreams
       obj.rels_ext
       obj.datastreams.each_value do |ds|
-        if ds.respond_to?(:profile_from_hash)
-          ds.profile_from_hash(profile_hash['datastreams'][ds.dsid])
+        if ds.respond_to?(:profile_from_hash) and (ds_prof = profile_hash['datastreams'][ds.dsid])
+          ds.profile_from_hash(ds_prof)
         end
         if ds.respond_to?(:from_solr)
           ds.from_solr(solr_doc) if ds.kind_of?(ActiveFedora::MetadataDatastream) || ds.kind_of?(ActiveFedora::NokogiriDatastream) || ( ds.kind_of?(ActiveFedora::RelsExtDatastream))

--- a/spec/unit/solr_digital_object_spec.rb
+++ b/spec/unit/solr_digital_object_spec.rb
@@ -33,6 +33,21 @@ describe ActiveFedora::SolrDigitalObject do
         subject.datastreams['properties'].should be_kind_of ActiveFedora::NokogiriDatastream
       end
     end
+    
+    describe "with a ds spec that's not part of the solrized object" do
+      before do
+        class MissingMetadataDs < ActiveFedora::Base
+          has_metadata :name => "foo", :type => ActiveFedora::NokogiriDatastream, :label => 'Foo Data'
+        end
+        after do
+          Object.send(:remove_const, MissingMetadataDs)
+        end
+        subject { ActiveFedora::SolrDigitalObject.new({}, {'datastreams'=>{'properties'=>{'dsMIME'=>'text/xml'}}},MissingMetadataDs) }
+        it "should have a foo datastream" do
+          subject.datastreams['foo'].label.should == 'Foo Data'
+        end
+      end
+    end
   end
 
 


### PR DESCRIPTION
This commit fixes the case where an object with a declared but unsaved datastream was solrized and then loaded from solr, resulting in a call to `nil.each_pair`.
