### PR TITLE
#delegate_to method and unit test

### DIFF
--- a/lib/active_fedora/delegating.rb
+++ b/lib/active_fedora/delegating.rb
@@ -1,18 +1,18 @@
 module ActiveFedora
   module Delegating
     extend ActiveSupport::Concern
-    
+
     module ClassMethods
       # Provides a delegate class method to expose methods in metadata streams
-      # as member of the base object. Pass the target datastream via the 
-      # <tt>:to</tt> argument. If you want to return a unique result, (e.g. string 
+      # as member of the base object. Pass the target datastream via the
+      # <tt>:to</tt> argument. If you want to return a unique result, (e.g. string
       # instead of an array) set the <tt>:unique</tt> argument to true.
       #
       # The optional <tt>:at</tt> argument provides a terminology that the delegate will point to.
-      #   
+      #
       #   class Foo < ActiveFedora::Base
-      #     has_metadata :name => "descMetadata", :type => MyDatastream 
-      #     
+      #     has_metadata :name => "descMetadata", :type => MyDatastream
+      #
       #     delegate :field1, :to=>"descMetadata", :unique=>true
       #     delegate :field2, :to=>"descMetadata", :at=>[:term1, :term2]
       #   end
@@ -26,27 +26,54 @@ module ActiveFedora
         create_delegate_accessor(field, args)
         create_delegate_setter(field, args)
       end
-      
+
+
+      # Allows you to delegate multiple terminologies to the same datastream, instead
+      # having to call the method each time for each term.  The target datastream is the
+      # first argument, followed by an array of the terms that will point to that
+      # datastream.  Terms must be a single value, ie. :field and not [:term1, :term2].
+      # This is best accomplished by refining your OM terminology using :ref or :proxy
+      # methods to reduce nested terms down to one.
+      #
+      #   class Foo < ActiveFedora::Base
+      #     has_metadata :name => "descMetadata", :type => MyDatastream
+      #
+      #     delegate_to :descMetadata, [:field1, :field2]
+      #   end
+      #
+      #   foo = Foo.new
+      #   foo.field1 = "My Value"
+      #   foo.field1                 # => "My Value"
+      #   foo.field2                 # => NoMethodError: undefined method `field2' for #<Foo:0x1af30c>
+
+      def delegate_to(datastream,fields,args={})
+        fields.each do |f|
+          args.merge!({:to=>datastream})
+          create_delegate_accessor(f, args)
+          create_delegate_setter(f, args)
+        end
+      end
+
       private
       def create_delegate_accessor(field, args)
         define_method field do
           ds = self.send(args[:to])
           val = if ds.kind_of?(ActiveFedora::MetadataDatastream) || ds.kind_of?(ActiveFedora::RDFDatastream)
                   ds.send(:get_values, field)
-                else 
+                else
                   terminology = args[:at] || [field]
                   ds.send(:term_values, *terminology)
                 end
           args[:unique] ? val.first : val
         end
       end
-      
+
       def create_delegate_setter(field, args)
         define_method "#{field}=".to_sym do |v|
           ds = self.send(args[:to])
           if ds.kind_of?(ActiveFedora::MetadataDatastream) || ds.kind_of?(ActiveFedora::RDFDatastream)
             ds.send(:set_value, field, v)
-          else 
+          else
             terminology = args[:at] || [field]
             ds.send(:update_indexed_attributes, {terminology => v})
           end

--- a/spec/unit/base_delegate_to_spec.rb
+++ b/spec/unit/base_delegate_to_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+
+  describe "deletgating multiple terms to one datastream" do
+    class BarnyardDocument < ActiveFedora::NokogiriDatastream
+      set_terminology do |t|
+        t.root(:path=>"animals", :xmlns=>"urn:zoobar")
+        t.waterfowl do
+          t.ducks do
+            t.duck
+          end
+        end
+        t.donkey()
+        t.cow()
+        t.horse()
+        t.chicken()
+        t.pig()
+        t.duck(:ref=>[:waterfowl,:ducks,:duck])
+      end
+
+      def self.xml_template
+            Nokogiri::XML::Document.parse '<animals xmlns="urn:zoobar">
+              <waterfowl>
+                <ducks>
+                  <duck/>
+                </ducks>
+              </waterfowl>
+              <donkey></donkey>
+              <cow></cow>
+              <horse></horse>
+              <chicken></chicken>
+              <pig></pig>
+            </animals>'
+      end
+    end
+
+    class Barnyard < ActiveFedora::Base
+      has_metadata :type=>BarnyardDocument, :name=>"xmlish"
+      delegate_to :xmlish, [:cow, :chicken, :pig, :duck]
+      delegate_to :xmlish, [:donkey, :horse], :unique=>true
+      #delegate :donkey, :to=>'xmlish', :unique=>true
+    end
+    before :each do
+      @n = Barnyard.new()
+    end
+    it "should save a delegated property uniquely" do
+      @n.donkey="Bray"
+      @n.donkey.should == "Bray"
+      @n.xmlish.term_values(:donkey).first.should == 'Bray'
+      @n.horse="Winee"
+      @n.horse.should == "Winee"
+      @n.xmlish.term_values(:horse).first.should == 'Winee'
+    end
+    it "should return an array if not marked as unique" do
+      ### Metadata datastream does not appear to support multiple value setting
+      @n.cow=["one", "two"]
+      @n.cow.should == ["one", "two"]
+    end
+
+    it "should be able to delegate deeply into the terminology" do
+      @n.duck=["Quack", "Peep"]
+      @n.duck.should == ["Quack", "Peep"]
+    end
+
+  end
+end
+
+


### PR DESCRIPTION
This adds in the #delegate_to method for easier delegation of multiple terms to the same datastream.
