### PR TITLE
HYDRA-883 RDFDatastreams should handle Literals as object values

### DIFF
--- a/lib/active_fedora/rdf_datastream.rb
+++ b/lib/active_fedora/rdf_datastream.rb
@@ -263,6 +263,7 @@ module ActiveFedora
       graph.delete(predicate)
       args = [args] unless args.respond_to? :each
       args.each do |arg|
+        arg = arg.to_s if arg.kind_of? RDF::Literal
         graph.add(predicate, arg, true) unless arg.empty?
       end
       graph.dirty = true

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -9,6 +9,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
           map.created(:in => RDF::DC)
           map.title(:in => RDF::DC)
           map.publisher(:in => RDF::DC)
+          map.creator(:in => RDF::DC)
           map.based_near(:in => RDF::FOAF)
           map.related_url(:to => "seeAlso", :in => RDF::RDFS)
         end
@@ -58,6 +59,10 @@ describe ActiveFedora::NtriplesRDFDatastream do
     it "should set fields" do
       @subject.publisher = "St. Martin's Press"
       @subject.publisher.should == ["St. Martin's Press"]
+    end
+    it "should set rdf literal fields" do
+      @subject.creator = RDF.Literal("Geoff Ryman")
+      @subject.creator.should == ["Geoff Ryman"]
     end
     it "should append fields" do
       @subject.publisher << "St. Martin's Press"


### PR DESCRIPTION
This is a one line fix + test coverage.

Just runs .to_s on any RDF::Literals passed in and carries on treating them as strings like it did before.
