### PR TITLE
Adding active_fedora:model generator

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -17,6 +17,12 @@ h2. Getting Started
 
 The "ActiveFedora Console Tour":https://github.com/projecthydra/active_fedora/wiki/Getting-Started:-Console-Tour  gives you a brief tour through ActiveFedora's features on the command line.
 
+h2. Generators
+
+You can generate a model inheriting from ActiveFedora::Base.
+
+<pre>rails generate active_fedora:model Book</pre>
+
 h2. Testing (this Gem)
 
 In order to run the RSpec tests, you need to have a copy of the ActiveFedora source code, and then run bundle install in the source directory.

--- a/lib/active_fedora/railtie.rb
+++ b/lib/active_fedora/railtie.rb
@@ -4,9 +4,11 @@ module ActiveFedora
       load "tasks/active_fedora.rake"
     end
     generators do
-      puts 'hello'
       require(
         'generators/active_fedora/config/config_generator'
+      )
+      require(
+        'generators/active_fedora/model/model_generator'
       )
     end
   end

--- a/lib/active_fedora/test_support.rb
+++ b/lib/active_fedora/test_support.rb
@@ -1,0 +1,38 @@
+module ActiveFedora
+  module TestSupport
+
+    # Assert that all of the :objects are persisted the :subject's RELS-EXT entry
+    # with the :predicate.
+    def assert_rels_ext(subject, predicate, objects = [])
+      assert_equal objects.count, subject.relationships(predicate).count
+      objects.each do |object|
+        internal_uri = object.respond_to?(:internal_uri) ?
+          object.internal_uri : object
+        assert subject.relationships(predicate).include?(internal_uri)
+      end
+    end
+
+    # Assert that the :subject's RELS-EXT for predicate :has_model collection
+    # includes the class_name
+    def assert_rels_ext_has_model(subject, class_name)
+      model_relationships = subject.relationships(:has_model)
+      assert_block("Expected afmodel:#{class_name} to be defined in #{model_relationships.inspect}") do
+        model_relationships.detect {|r| r =~ /\/afmodel:#{class_name}\Z/ }
+      end
+    end
+
+    # Assert that the :subject's :association_name equals the input :object
+    def assert_active_fedora_belongs_to(subject, association_name, object)
+      subject.send(association_name).must_equal object
+    end
+
+    # Assert that the :subject's :association_name contains all of the :objects
+    def assert_active_fedora_has_many(subject, association_name, objects)
+      association = subject.send(association_name)
+      assert_equal objects.count, association.count
+      objects.each do |object|
+        assert association.include?(object)
+      end
+    end
+  end
+end

--- a/lib/generators/active_fedora/model/USAGE
+++ b/lib/generators/active_fedora/model/USAGE
@@ -1,0 +1,9 @@
+Description:
+  Generate a class that inherits from ActiveFedora::Base
+
+Example:
+  rails generate active_fedora:model Journal
+
+  This will create:
+    app/models/journal.rb
+    spec/models/journal_spec.rb

--- a/lib/generators/active_fedora/model/model_generator.rb
+++ b/lib/generators/active_fedora/model/model_generator.rb
@@ -1,0 +1,21 @@
+require 'rails/generators'
+
+module ActiveFedora
+  class ModelGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('../templates', __FILE__)
+    check_class_collision
+
+    class_option :directory, :type => :string, :default => 'models', :desc => "Which directory to generate? (i.e. app/DIRECTORY)"
+
+    def install
+      template('model.rb.erb',File.join('app', directory, "#{file_name}.rb"))
+      template('model_spec.rb.erb',File.join('spec', directory, "#{file_name}_spec.rb"))
+    end
+
+    protected
+
+    def directory
+      options[:directory] || 'models'
+    end
+  end
+end

--- a/lib/generators/active_fedora/model/templates/model.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model.rb.erb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate active_fedora::model <%= class_name %>`
+require 'active_fedora/base'
+class <%= class_name %> < ActiveFedora::Base
+
+end

--- a/lib/generators/active_fedora/model/templates/model_spec.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model_spec.rb.erb
@@ -1,0 +1,21 @@
+# Generated via
+#  `rails generate active_fedora::model <%= class_name %>`
+require 'spec_helper'
+require 'active_fedora/test_support'
+
+describe <%= class_name %> do
+  include ActiveFedora::TestSupport
+  subject { <%= class_name %>.new }
+
+  it 'should persist to Fedora' do
+    subject.save!
+    expect {
+      subject.reload
+    }.to_not raise_error(ActiveFedora::ObjectNotFoundError)
+
+    assert_rels_ext_has_model(subject, JournalEntry)
+
+    subject.destroy
+  end
+
+end


### PR DESCRIPTION
This commit also includes the ActiveFedora::TestSupport assertions to
assist in testing your ActiveFedora models

HYDRA-520
