### PR TITLE
Consolidating duplicate code

### DIFF
--- a/lib/active_fedora/qualified_dublin_core_datastream.rb
+++ b/lib/active_fedora/qualified_dublin_core_datastream.rb
@@ -36,18 +36,6 @@ module ActiveFedora
       end
     end
 
-    def update_indexed_attributes(params={}, opts={})
-      # if the params are just keys, not an array, make then into an array.
-      new_params = {}
-      params.each do |key, val|
-        if key.is_a? Array
-          new_params[key] = val
-        else
-          new_params[[key.to_sym]] = val
-        end
-      end
-      super(new_params, opts)
-    end
     def om_term_options(datatype)
       {:xmlns=>"http://purl.org/dc/terms/", :namespace_prefix => "dcterms"}
     end

--- a/lib/active_fedora/simple_datastream.rb
+++ b/lib/active_fedora/simple_datastream.rb
@@ -22,20 +22,6 @@ module ActiveFedora
     end
     protected :om_term_options
 
-    def update_indexed_attributes(params={}, opts={})
-      # if the params are just keys, not an array, make then into an array.
-      new_params = {}
-      params.each do |key, val|
-        if key.is_a? Array
-          new_params[key] = val
-        else
-          new_params[[key.to_sym]] = val
-        end
-      end
-      super(new_params, opts)
-    end
-    
-
     def self.xml_template
        Nokogiri::XML::Document.parse("<fields/>")
     end

--- a/spec/unit/nokogiri_datastream_spec.rb
+++ b/spec/unit/nokogiri_datastream_spec.rb
@@ -86,8 +86,7 @@ describe ActiveFedora::NokogiriDatastream do
     end
     it "should do nothing if field key is a string (must be an array or symbol).  Will not accept xpath queries!" do
       xml_before = @mods_ds.to_xml
-      logger.should_receive(:warn).with "WARNING: descMetadata ignoring {\"fubar\" => \"the role\"} because \"fubar\" is a String (only valid OM Term Pointers will be used).  Make sure your html has the correct field_selector tags in it."
-      @mods_ds.update_indexed_attributes( { "fubar"=>"the role" } ).should == {}
+      @mods_ds.update_indexed_attributes( { ":person"=>"the role" } ).should == {}
       @mods_ds.to_xml.should == xml_before
     end
     it "should do nothing if there is no accessor corresponding to the given field key" do


### PR DESCRIPTION
SimpleDatastream and QualifiedDublinCoreDatastream had several duplicate
lines of code. And in some cases the behavior of SimpleDatastream appeared
to have patches that weren't applied to QualifiedDublinCoreDatastream.

There are some changes which alter the functionality of the base
NokogiriDatastream; But I've moved the shared behavior of both the 
SimpleDatastream and the QualifiedDublinCoreDatastream classes into their
parent NokogiriDatastream.

HYDRA-898
