### PR TITLE
Contains failing test for datastream content

### DIFF
--- a/lib/active_fedora/rdf_datastream.rb
+++ b/lib/active_fedora/rdf_datastream.rb
@@ -111,7 +111,7 @@ module ActiveFedora
     class TermProxy
 
       attr_reader :graph, :subject, :predicate
-      delegate :class, :to_s, :==, :kind_of?, :each, :map, :empty?, :as_json, :to => :values
+      delegate :class, :to_s, :==, :kind_of?, :each, :map, :empty?, :as_json, :is_a?, :to => :values
 
       def initialize(graph, subject, predicate)
         @graph = graph

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -183,5 +183,8 @@ describe ActiveFedora::NtriplesRDFDatastream do
       @subject.title.delete("title1", "title2", "title3")
       @subject.title.empty?.should be_true
     end
+    it "should suppost the is_a? method" do
+      @subject.title.is_a?(Array).should == true
+    end
   end
 end


### PR DESCRIPTION
rspec ./spec/unit/datastream_collections_spec.rb:84

 1) ActiveFedora::DatastreamCollections#add_named_datastream should  allow access to file content
     Failure/Error: @test_object2.thumbnail[0].content
     IOError:
       closed stream
     # ./spec/unit/datastream_collections_spec.rb:88:in `block (3 levels) in <top (required)>'
