### PR TITLE
Add jetty.yml to solr generator to overwrite the Blacklight jetty.yml.

### DIFF
--- a/lib/generators/active_fedora/config/solr/solr_generator.rb
+++ b/lib/generators/active_fedora/config/solr/solr_generator.rb
@@ -5,6 +5,7 @@ module ActiveFedora
     source_root File.expand_path('../templates', __FILE__)
 
     def generate
+      copy_file('jetty.yml', 'config/jetty.yml')
       copy_file('solr.yml', 'config/solr.yml')
       directory('solr_conf', 'solr_conf')
     end

--- a/lib/generators/active_fedora/config/solr/templates/jetty.yml
+++ b/lib/generators/active_fedora/config/solr/templates/jetty.yml
@@ -1,0 +1,5 @@
+default:
+  jetty_port: 8983
+  java_opts:
+    - "-XX:MaxPermSize=128m" 
+    - "-Xmx256m"


### PR DESCRIPTION
I figured this belonged in ActiveFedora since HydraHead already will copy over jetty.yml in the absence of an active_fedora:config task.
