### PR TITLE
Updating explicit path for rspec matchers

### DIFF
--- a/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'ostruct'
 require 'webmock/rspec'
-require 'lib/active_fedora/rspec_matchers/belong_to_associated_active_fedora_object_matcher'
+require File.expand_path("../../../lib/active_fedora/rspec_matchers/belong_to_associated_active_fedora_object_matcher", File.dirname(__FILE__))
 
 describe RSpec::Matchers, "belong_to_associated_active_fedora_object_matcher" do
   subject { OpenStruct.new(:pid => pid )}
@@ -10,16 +10,14 @@ describe RSpec::Matchers, "belong_to_associated_active_fedora_object_matcher" do
   let(:object2) { Object.new }
   let(:association) { :association }
 
-  before(:each) do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-  end
-
   it 'should match when association is properly stored in fedora' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(association).and_return(object1)
     subject.should belong_to_associated_active_fedora_object(association).with_object(object1)
   end
 
   it 'should not match when association is different' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(association).and_return(object1)
     lambda {
       subject.should belong_to_associated_active_fedora_object(association).with_object(object2)

--- a/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'ostruct'
 require 'webmock/rspec'
-require 'active_fedora/rspec_matchers/have_many_associated_active_fedora_objects_matcher'
+require File.expand_path("../../../lib/active_fedora/rspec_matchers/have_many_associated_active_fedora_objects_matcher", File.dirname(__FILE__))
 
 describe RSpec::Matchers, "have_many_associated_active_fedora_objects_matcher" do
   subject { OpenStruct.new(:pid => pid )}
@@ -11,16 +11,14 @@ describe RSpec::Matchers, "have_many_associated_active_fedora_objects_matcher" d
   let(:object3) { Object.new }
   let(:association) { :association }
 
-  before(:each) do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-  end
-
   it 'should match when association is properly stored in fedora' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(association).and_return([object1,object2])
     subject.should have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
   end
 
   it 'should not match when association is different' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(association).and_return([object1,object3])
     lambda {
       subject.should have_many_associated_active_fedora_objects(association).with_objects([object1, object2])

--- a/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'ostruct'
 require 'webmock/rspec'
-require 'active_fedora/rspec_matchers/have_predicate_matcher'
+require File.expand_path("../../../lib/active_fedora/rspec_matchers/have_predicate_matcher", File.dirname(__FILE__))
 
 describe RSpec::Matchers, "have_predicate_matcher" do
   subject { OpenStruct.new(:pid => pid )}
@@ -11,16 +11,14 @@ describe RSpec::Matchers, "have_predicate_matcher" do
   let(:object3) { Object.new }
   let(:predicate) { :predicate }
 
-  before(:each) do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-  end
-
   it 'should match when relationship is "what we have in Fedora"' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(:relationships).with(predicate).and_return([object1,object2])
     subject.should have_predicate(predicate).with_objects([object1, object2])
   end
 
   it 'should not match when relationship is different' do
+    subject.class.should_receive(:find).with(pid).and_return(subject)
     subject.should_receive(:relationships).with(predicate).and_return([object1,object3])
     lambda {
       subject.should have_predicate(predicate).with_objects([object1, object2])

--- a/spec/unit/rspec_matchers/match_fedora_datastream_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/match_fedora_datastream_matcher_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'ostruct'
 require 'webmock/rspec'
-require 'active_fedora/rspec_matchers/match_fedora_datastream_matcher'
+require File.expand_path("../../../lib/active_fedora/rspec_matchers/match_fedora_datastream_matcher", File.dirname(__FILE__))
 
 describe RSpec::Matchers, "match_fedora_datastream" do
   let(:pid) { 123 }


### PR DESCRIPTION
Since these are not automatically included, making sure they work.
