### PR TITLE
remove @owner.new_record? check from the association collection append o...

### DIFF
--- a/lib/active_fedora/associations/association_collection.rb
+++ b/lib/active_fedora/associations/association_collection.rb
@@ -74,7 +74,7 @@ module ActiveFedora
         flatten_deeper(records).each do |record|
           raise_on_type_mismatch(record)
           add_record_to_target_with_callbacks(record) do |r|
-            result &&= insert_record(record) unless @owner.new_record?
+            result &&= insert_record(record)
           end
         end
 

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -31,7 +31,10 @@ module ActiveFedora
 
           ### TODO save relationship
           @owner.add_relationship(@reflection.options[:property], record)
-          if (@reflection.options[:inverse_of])
+
+          if @owner.new_record? and @reflection.options[:inverse_of]
+            logger.warn("has_and_belongs_to_many #{@reflection.inspect} is cowardly refusing to insert the inverse relationship into #{record}, because #{@owner} is not persisted yet.")
+          elsif @reflection.options[:inverse_of]
             record.add_relationship(@reflection.options[:inverse_of], @owner)
             record.save
           end

--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -31,6 +31,10 @@ module ActiveFedora
       end
 
       def insert_record(record, force = false, validate = true)
+        if @owner.new_record?
+          logger.warn("has_many #{@reflection.inspect} is cowardly refusing to insert a relationship into #{record}, because #{@owner} is not persisted yet.")
+          return true 
+        end
         set_belongs_to_association_for(record)
         #force ? record.save! : record.save(:validate => validate)
         record.save


### PR DESCRIPTION
...perator; do that check in insert_record as needed instead.

This associations stuff is bad black magic, but i think this change is correct. You should be able to add all the outbound relationships you want to an object that doesn't exist yet. Inbound relationships are just as broken as they ever were, though.
