### PR TITLE
new ActiveFedora::Auditable mixin - provides access to Fedora audit trail

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -26,6 +26,7 @@ module ActiveFedora #:nodoc:
   eager_autoload do
     autoload :Associations
     autoload :Attributes
+    autoload :Auditable
     autoload :Base
     autoload :ContentModel
     autoload :Callbacks

--- a/lib/active_fedora/auditable.rb
+++ b/lib/active_fedora/auditable.rb
@@ -1,0 +1,9 @@
+module ActiveFedora
+  module Auditable
+    
+    def audit_trail
+      inner_object.audit_trail
+    end
+
+  end
+end

--- a/spec/fixtures/auditable.foxml.xml
+++ b/spec/fixtures/auditable.foxml.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject VERSION="1.1" PID="changeme:242"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE=""/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="fedoraAdmin"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2013-02-25T16:43:05.802Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2013-02-25T16:43:06.379Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2013-02-25T16:43:05.802Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2013-02-25T16:43:06.219Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2013-02-25T16:43:06.315Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2013-02-25T16:43:06.379Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2013-02-25T16:43:05.802Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="341">
+<foxml:contentDigest TYPE="SHA-256" DIGEST="eb075bf6da5903e54464631dc998f66f95bffde9f4137132796457d31de5cd44"/>
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:identifier>changeme:242</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2013-02-25T16:43:06.219Z" MIMETYPE="application/rdf+xml" SIZE="284">
+<foxml:contentDigest TYPE="SHA-256" DIGEST="013d2229de7bd91c61256563eff1b475cd1e8f7e45a2f15de5a36f2d20ec2852"/>
+<foxml:xmlContent>
+<rdf:RDF xmlns:ns0="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/changeme:242">
+    <ns0:hasModel rdf:resource="info:fedora/afmodel:TestModel"></ns0:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="descMetadata.0" LABEL="" CREATED="2013-02-25T16:43:06.315Z" MIMETYPE="text/xml" SIZE="215">
+<foxml:contentDigest TYPE="SHA-256" DIGEST="3f588eca58dea77b31c9ed0b90e4560288a419856c4bb744fab9c7fe8749ad19"/>
+<foxml:xmlContent>
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dcterms:title>DulHydra Test Object</dcterms:title>
+  <dcterms:identifier>test00001</dcterms:identifier>
+</dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="" CREATED="2013-02-25T16:43:06.379Z" MIMETYPE="text/xml" SIZE="596">
+<foxml:contentDigest TYPE="SHA-256" DIGEST="472f8634b31bd425dadd9206531ab02a70c08c22e4250bb2b0d3dd0314cfb240"/>
+<foxml:xmlContent>
+<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1" version="0.1">
+  <copyright>
+    <human type="title"></human>
+    <human type="description"></human>
+    <machine type="uri"></machine>
+  </copyright>
+  <access type="discover">
+    <human></human>
+    <machine></machine>
+  </access>
+  <access type="read">
+    <human></human>
+    <machine>
+      <group>public</group>
+    </machine>
+  </access>
+  <access type="edit">
+    <human></human>
+    <machine></machine>
+  </access>
+  <embargo>
+    <human></human>
+    <machine></machine>
+  </embargo>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/unit/auditable_spec.rb
+++ b/spec/unit/auditable_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ActiveFedora::Auditable do
+
+  before(:all) do
+    class AuditableModel < ActiveFedora::Base
+      include ActiveFedora::Auditable
+    end
+    path = File.join(File.dirname(__FILE__), '..', 'fixtures', 'auditable.foxml.xml')
+    pid = ActiveFedora::FixtureLoader.import_to_fedora(path)
+    ActiveFedora::FixtureLoader.index(pid)
+    @test_object = AuditableModel.find(pid)
+  end
+  after(:all) do
+    @test_object.delete
+  end
+  it "should have the correct number of audit records" do
+    @test_object.audit_trail.records.length.should == 3
+  end
+  it "should return all the data from each audit record" do
+    record = @test_object.audit_trail.records.first
+    record.id.should == "AUDREC1"
+    record.process_type.should == "Fedora API-M"
+    record.action.should == "addDatastream"
+    record.component_id.should == "RELS-EXT"
+    record.responsibility.should == "fedoraAdmin"
+    record.date.should == "2013-02-25T16:43:06.219Z"
+    record.justification.should == ""
+  end
+  
+end


### PR DESCRIPTION
See: https://github.com/projecthydra/active_fedora/pull/47

unit tests for ActiveFedora::Auditable

Added FOXML fixture for AF::Auditable unit tests

Added Auditable to eager autoload modules

made fixture load work

Requiring Rubydora 1.6; ActiveFedora::Auditable updated
