### PR TITLE
Fixed fields for solrconfig permissions

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr_conf/conf/solrconfig.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr_conf/conf/solrconfig.xml
@@ -90,12 +90,17 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
       <str name="fl">
         id,
-        access_tim,
-        discover_access_group_tim,discover_access_person_tim,
-        read_access_group_tim,read_access_person_tim,
-        edit_access_group_tim,edit_access_person_tim,
+        access_ssim,
+        discover_access_group_ssim,discover_access_person_ssim,
+        read_access_group_ssim,read_access_person_ssim,
+        edit_access_group_ssim,edit_access_person_ssim,
         depositor_ti,
         embargo_release_date_dtsi
+        inheritable_access_ssim,
+        inheritable_discover_access_group_ssim,inheritable_discover_access_person_ssim,
+        inheritable_read_access_group_ssim,inheritable_read_access_person_ssim,
+        inheritable_edit_access_group_ssim,inheritable_edit_access_person_ssim,
+        inheritable_embargo_release_date_dtsi
       </str>
     </lst>
   </requestHandler>


### PR DESCRIPTION
The correct solrconfig.xml was in hydra-head, but not active fedora.
