### PR TITLE
Objects loaded via Solr should have datastream properties of same class

### DIFF
--- a/lib/active_fedora/datastream.rb
+++ b/lib/active_fedora/datastream.rb
@@ -59,7 +59,7 @@ module ActiveFedora
     
     def profile_from_hash(profile_hash)
       profile_hash.each_pair do |key,value|
-        profile[key] = value.to_s
+        profile[key] = value
       end
     end
     

--- a/spec/integration/model_spec.rb
+++ b/spec/integration/model_spec.rb
@@ -57,6 +57,10 @@ describe ActiveFedora::Model do
       it "should create an xml datastream" do
         subject.datastreams['properties'].should be_kind_of ActiveFedora::SimpleDatastream
       end
+
+      it "should know the datastreams properties" do
+        subject.properties.dsSize.should == 19
+      end
     end
   end
 end


### PR DESCRIPTION
as when the object is loaded from Fedora. dsSize was a string when
loaded from solr, which broke Rubydora::Datastream#stream
