### PR TITLE
Fix validations unit test to pass legitimately

### DIFF
--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -8,7 +8,7 @@ describe ActiveFedora::Base do
         m.field "swank", :text
       end
       delegate :fubar, :to=>'someData'
-      delegate :swank, :to=>'someData'
+      delegate :swank, :to=>'someData', unique: true
 
       validates_presence_of :fubar
       validates_length_of :swank, :minimum=>5
@@ -25,7 +25,7 @@ describe ActiveFedora::Base do
     end
     
     it "should be valid" do
-      @obj.should_not be_valid
+      @obj.should be_valid
     end
   end
   describe "an invalid object" do


### PR DESCRIPTION
Previously the unit test passed but the test was not correct.  The test was:

```
it "should be valid" do
  @object.should_not be_valid
end

```

This test did pass however because the delegation method on the 'swank' attribute did not have `unique: true` set.  

In this request I have set `unique: true` and changed the validation to ensure `@object` is valid.

The test passes and has been run with `rake active_fedora:ci`.
