### PR TITLE
Modify or remove tests that check for DC datastreams; deprecate Datastreams#dc in favor of Datastreams#datastreams["DC"]

### DIFF
--- a/lib/active_fedora/datastreams.rb
+++ b/lib/active_fedora/datastreams.rb
@@ -123,6 +123,7 @@ module ActiveFedora
     # Return the Dublin Core (DC) Datastream. You can also get at this via 
     # the +datastreams["DC"]+.
     def dc
+      Deprecation.warn(Datastreams, 'dc is deprecated. Consider using Base#datastreams["DC"] instead.', caller)
       return datastreams["DC"] 
     end
 

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -296,16 +296,6 @@ describe ActiveFedora::Base do
     end
   end
   
-  describe ".dc" do
-    it "should expose the DC datastream" do
-      dc = @test_object.dc
-      dc.should be_a_kind_of(ActiveFedora::Datastream)
-      rexml = REXML::Document.new(dc.content)
-      rexml.root.elements["dc:identifier"].get_text.should_not be_nil
-    end
-  end
-
-  
   describe '.rels_ext' do
     it "should retrieve RelsExtDatastream object via rels_ext method" do
       @test_object.rels_ext.should be_instance_of(ActiveFedora::RelsExtDatastream)

--- a/spec/integration/datastreams_spec.rb
+++ b/spec/integration/datastreams_spec.rb
@@ -107,7 +107,6 @@ describe ActiveFedora::Datastreams do
       @has_file.file_ds.versionable.should be_false
       test_obj = HasFile.find(@has_file.pid)
       test_obj.file_ds.versionable.should be_false
-      test_obj.dc.changed?.should be_false
       test_obj.rels_ext.changed?.should be_false
       test_obj.file_ds.changed?.should be_false
       test_obj.file_ds2.changed?.should be_false
@@ -116,7 +115,6 @@ describe ActiveFedora::Datastreams do
     
     it "should use ds_specs on migrated objects" do
       test_obj = HasFile.find(@base.pid)
-      test_obj.dc.changed?.should be_false
       test_obj.file_ds.versionable.should be_false
       test_obj.file_ds.new?.should be_true
       test_obj.file_ds.content = "blah blah blah"

--- a/spec/unit/datastreams_spec.rb
+++ b/spec/unit/datastreams_spec.rb
@@ -175,16 +175,6 @@ describe ActiveFedora::Datastreams do
     end
   end
 
-  describe "#dc" do
-    it "should be the DC datastream" do
-      subject.dc.should be_kind_of ActiveFedora::Datastream
-    end
-    it "should be an inline datastream" do
-      subject.dc.controlGroup.should == 'X'
-    end
-  end
-
-
   describe "#relsext" do
     it "should be the RELS-EXT datastream" do
       m = mock


### PR DESCRIPTION
For #85
