### PR TITLE
Added association delete callbacks

### DIFF
--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -48,10 +48,16 @@ module ActiveFedora
             
             if (@reflection.options[:inverse_of])
               r.remove_relationship(@reflection.options[:inverse_of], @owner)
+              # It looks like inverse_of points at a predicate, not at a relationship name,
+              # which is what we should have done. Now we need a way to look up the
+              # reflection by predicate
+              name = r.class.reflection_name_for_predicate(@reflection.options[:inverse_of])
+              r.send(name).reset
               r.save
             end
           end
         end
+
     end
   end
 end

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -252,7 +252,6 @@ module ActiveFedora
       elsif @inner_object.respond_to? :createdDate
         Array(@inner_object.createdDate).first
       else
-        puts @inner_object.inspect
         @inner_object.profile['objCreateDate']
       end
     end

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -8,8 +8,13 @@ module ActiveFedora
     end
 
 
-
     module ClassMethods
+      def reflection_name_for_predicate(predicate)
+        reflections.each do |k, v|
+          return k if v.options[:property] == predicate
+        end
+      end
+
       def create_reflection(macro, name, options, active_fedora)
         case macro
           when :has_many, :belongs_to, :has_and_belongs_to_many

--- a/spec/unit/has_and_belongs_to_many_collection_spec.rb
+++ b/spec/unit/has_and_belongs_to_many_collection_spec.rb
@@ -29,31 +29,4 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
 
   end
   
-  it "should call remove_relationship" do
-    subject = stub("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a')
-    predicate = stub(:klass => mock.class, :options=>{:property=>'predicate'}, :class_name=> nil)
-    ActiveFedora::SolrService.stub(:query).and_return([])
-    ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
-    object = stub("object", :new_record? => false, :pid => 'object:b', :save => nil)
-  
-    subject.should_receive(:remove_relationship).with('predicate', object)
- 
-    ac.delete(object)
-
-  end
-
-  it "should call remove_relationship on subject and object when inverse_of given" do
-    subject = stub("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a')
-    predicate = stub(:klass => mock.class, :options=>{:property=>'predicate', :inverse_of => 'inverse_predicate'}, :class_name=> nil)
-    ActiveFedora::SolrService.stub(:query).and_return([])
-    ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
-    object = stub("object", :new_record? => false, :pid => 'object:b', :save => nil)
-  
-    subject.should_receive(:remove_relationship).with('predicate', object)
-    object.should_receive(:remove_relationship).with('inverse_predicate', subject)
- 
-    ac.delete(object)
-
-  end
-
 end

--- a/spec/unit/has_many_collection_spec.rb
+++ b/spec/unit/has_many_collection_spec.rb
@@ -14,32 +14,4 @@ describe ActiveFedora::Associations::HasManyAssociation do
 
   end
   
-  it "should call remove_relationship" do
-    subject = stub("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a')
-    predicate = stub(:klass => mock.class, :options=>{:property=>'predicate'}, :class_name=> nil)
-    ActiveFedora::SolrService.stub(:query).and_return([])
-    ac = ActiveFedora::Associations::HasManyAssociation.new(subject, predicate)
-    object = stub("object", :new_record? => false, :pid => 'object:b', :save => nil)
-  
-    object.should_receive(:remove_relationship).with('predicate', subject)
- 
-    ac.delete(object)
-
-  end
-
-  it "should be able to replace the collection" do
-    @owner = stub(:new_record? => false, :to_ary => nil, :internal_uri => 'info:fedora/changeme:99')
-    @reflection = stub(:klass => mock.class, :options=>{:property=>'predicate'}, :class_name=> nil)
-    ac = ActiveFedora::Associations::HasManyAssociation.new(@owner, @reflection)
-    @target = [stub(:to_ary => nil, :new_record? => false, :remove_relationship=>true), stub(:to_ary => nil, :new_record? => false, :remove_relationship=>true), stub(:to_ary => nil, :new_record? => false, :remove_relationship=>true)]
-    ac.target = @target 
-
-    @expected1 = stub(:new_record? => false, :add_relationship=>true, :save=>true, :to_ary => nil)
-    @expected2 = stub(:new_record? => false, :add_relationship=>true, :save=>true, :to_ary => nil)
-    ac.replace([@expected1, @expected2])
-    ac.target.should == [@expected1, @expected2]
-
-  end
-
-
 end


### PR DESCRIPTION
You can now define callbacks on a has_many or
has_and_belongs_to_many association that will be called
when an object is removed from the collection.
