### PR TITLE
habtm#delete saves between the before and after hook.

### DIFF
--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -56,6 +56,7 @@ module ActiveFedora
               r.save
             end
           end
+          @owner.save!
         end
 
     end


### PR DESCRIPTION
When a has_and_belongs_to_many#delete method is called, the
relationships should be saved before the after_remove hook is called.
This enables the far side of the association to have the new
relationships in the after_remove hook.
