### PR TITLE
Add `args' param to ActiveFedora::SolrService.count

### DIFF
--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -96,8 +96,9 @@ module ActiveFedora
     # Get the count of records that match the query
     # @param [String] query a solr query 
     # @return [Integer] number of records matching
-    def self.count(query)
-        SolrService.query(query, :raw=>true, :rows=>0)['response']['numFound'].to_i
+    def self.count(query, args={})
+      args = args.merge(:raw=>true, :rows=>0)
+      SolrService.query(query, args)['response']['numFound'].to_i
     end
 
     def self.add(doc)

--- a/spec/unit/solr_service_spec.rb
+++ b/spec/unit/solr_service_spec.rb
@@ -91,6 +91,13 @@ describe ActiveFedora::SolrService do
       ActiveFedora::SolrService.stub(:instance =>stub("instance", :conn=>mock_conn))
       ActiveFedora::SolrService.count('querytext').should == 7 
     end
+    it "should accept query args" do
+      mock_conn = mock("Connection")
+      stub_result = {'response' => {'numFound'=>'7'}}
+      mock_conn.should_receive(:get).with('select', :params=>{:rows=>0, :q=>'querytext', :qt=>'standard', :fq=>'filter'}).and_return(stub_result)
+      ActiveFedora::SolrService.stub(:instance =>stub("instance", :conn=>mock_conn))
+      ActiveFedora::SolrService.count('querytext', :fq=>'filter', :rows=>10).should == 7 
+    end
   end
   describe ".add" do
     it "should call solr" do 


### PR DESCRIPTION
Backwards compatible change adding optional `args' param to ActiveFedora::SolrService.count, enabling the method to pass args through to ActiveFedora::SolrService.query.
