### PR TITLE
Delegate all the array methods for RdfNode::TermProxy

### DIFF
--- a/lib/active_fedora/rdf_node/term_proxy.rb
+++ b/lib/active_fedora/rdf_node/term_proxy.rb
@@ -4,9 +4,7 @@ module ActiveFedora
 
       attr_reader :graph, :subject, :predicate, :options
 
-      delegate :class, :to_s, :==, :kind_of?, :each, :each_with_index, :map,
-               :empty?, :as_json, :is_a?, :to_ary, :to_a, :inspect, :first,
-               :last, :include?, :count, :size, :join, :[], :to => :values
+      delegate *(Array.public_instance_methods - [:__send__, :__id__, :class, :object_id] + [:as_json]), :to => :values
 
       # @param graph RDF::Graph
       # @param subject RDF::URI


### PR DESCRIPTION
This enables calling any array method such as #inject without having to
list all of them in our code.
