### PR TITLE
Updating "active_fedora:model" rails generator

### DIFF
--- a/lib/generators/active_fedora/model/model_generator.rb
+++ b/lib/generators/active_fedora/model/model_generator.rb
@@ -6,6 +6,8 @@ module ActiveFedora
     check_class_collision
 
     class_option :directory, :type => :string, :default => 'models', :desc => "Which directory to generate? (i.e. app/DIRECTORY)"
+    class_option :has_file_datastream, :type => :string, :default => nil, :desc => "Name a file datastream to create"
+    class_option :descMetadata, :type => :string, :default => nil, :desc => "Add a descMetadata metadata datastream"
 
     def install
       template('model.rb.erb',File.join('app', directory, "#{file_name}.rb"))

--- a/lib/generators/active_fedora/model/templates/model.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model.rb.erb
@@ -2,5 +2,30 @@
 #  `rails generate active_fedora::model <%= class_name %>`
 require 'active_fedora/base'
 class <%= class_name %> < ActiveFedora::Base
+  <% if options['descMetadata'] %>
+  has_metadata name: "descMetadata", type: <% options['descMetadata'] %>
+  <% else %>
+  # Uncomment the following lines to add a #descMetadata method that is a
+  #   datastream. You will need to specify the :type:, which may involve
+  #   creating a new Datastream object.
+  #
+  # has_metadata name: "descMetadata", type: <%= class_name %>MetadataDatastream
+  <%- end -%>
+  <% if options['has_file_datastream'] %>
+  has_file_datastream "<%= options['has_file_datastream'] %>"
+  <% else %>
+  # Uncomment the following lines to add an #attachment method that is a
+  #   file_datastream:
+  #
+  # has_file_datastream "attachment"
+  <% end %>
+  # "If you need to add additional attributes to the SOLR document, define the
+  # #to_solr method and make sure to use super"
+  #
+  # def to_solr(solr_document={}, options={})
+  #   super(solr_document, options)
+  #   solr_document["my_attribute_s"] = my_attribute
+  #   return solr_document
+  # end
 
 end

--- a/lib/generators/active_fedora/model/templates/model_spec.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model_spec.rb.erb
@@ -13,8 +13,6 @@ describe <%= class_name %> do
       subject.reload
     }.to_not raise_error(ActiveFedora::ObjectNotFoundError)
 
-    assert_rels_ext_has_model(subject, JournalEntry)
-
     subject.destroy
   end
 


### PR DESCRIPTION
The `rails generate active_fedora:model CLASS_NAME` command now accepts
additional arguements for customizing the generated active fedora
object.

@WIP - It may be nice to wire this in as a model so we could use
scaffold and resource generators from Rails. Much like rspec allows you
to hook into the models for generation and FactoryGirl allows you to
override the generation of fixtures.
