### PR TITLE
We should be able to delete rdf nested attributes.

### DIFF
--- a/lib/active_fedora/rdf/nested_attributes.rb
+++ b/lib/active_fedora/rdf/nested_attributes.rb
@@ -25,19 +25,60 @@ module ActiveFedora
         association = self.send(association_name)
 
         attributes_collection.each do |attributes|
-          if attributes.instance_of? Hash
+          attributes = attributes.with_indifferent_access
+          
+          if attributes['id'].blank?
             attributes = attributes.with_indifferent_access
             association.build(attributes.except(*UNASSIGNABLE_KEYS))
+          elsif existing_record = association.detect { |record| record.rdf_subject.to_s == attributes['id'].to_s }
+            if !call_reject_if(association_name, attributes)
+              assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
+            end
           else
-            association.build(attributes)            
+            raise_nested_attributes_record_not_found(association_name, record.rdf_subject.to_s)
           end
         end
       end
 
+      # Updates a record with the +attributes+ or marks it for destruction if
+      # +allow_destroy+ is +true+ and has_destroy_flag? returns +true+.
+      def assign_to_or_mark_for_destruction(record, attributes, allow_destroy)
+        record.attributes = attributes.except(*UNASSIGNABLE_KEYS)
+        record.mark_for_destruction if has_destroy_flag?(attributes) && allow_destroy
+      end
+
+      def raise_nested_attributes_record_not_found(association_name, record_id)
+        raise RecordNotFound, "Couldn't find #{association_name} with ID=#{record_id} for #{self.class.name} with ID=#{id}"
+      end
+
+      def call_reject_if(association_name, attributes)
+        return false if has_destroy_flag?(attributes)
+        case callback = self.nested_attributes_options[association_name][:reject_if]
+        when Symbol
+          method(callback).arity == 0 ? send(callback) : send(callback, attributes)
+        when Proc
+          callback.call(attributes)
+        end
+      end
+
+      # Determines if a hash contains a truthy _destroy key.
+      def has_destroy_flag?(hash)
+        ["1", "true"].include?(hash['_destroy'].to_s)
+      end
+      
+
       module ClassMethods
-        def accepts_nested_attributes_for *relationships
-          relationships.each do |association_name|
-            nested_attributes_options[association_name] = {}
+        def accepts_nested_attributes_for *attr_names
+          options = { :allow_destroy => false, :update_only => false }
+          options.update(attr_names.extract_options!)
+          options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
+          options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
+
+          attr_names.each do |association_name|
+            nested_attributes_options = self.nested_attributes_options.dup
+            nested_attributes_options[association_name] = options
+            self.nested_attributes_options = nested_attributes_options
+
             generate_association_writer(association_name)
           end
         end
@@ -56,16 +97,17 @@ module ActiveFedora
         # the helper methods defined below. Makes it seem like the nested
         # associations are just regular associations.
         def generate_association_writer(association_name)
-            class_eval <<-eoruby, __FILE__, __LINE__ + 1
-              if method_defined?(:#{association_name}_attributes=)
-                remove_method(:#{association_name}_attributes=)
-              end
-              def #{association_name}_attributes=(attributes)
-                unless attributes.nil?
-                  assign_nested_attributes_for_collection_association(:#{association_name}, attributes)
-                end
-              end
-            eoruby
+          class_eval <<-eoruby, __FILE__, __LINE__ + 1
+            if method_defined?(:#{association_name}_attributes=)
+              remove_method(:#{association_name}_attributes=)
+            end
+            def #{association_name}_attributes=(attributes)
+              assign_nested_attributes_for_collection_association(:#{association_name}, attributes)
+              ## in lieu of autosave_association_callbacks just save all of em.
+              send(:#{association_name}).each {|obj| obj.marked_for_destruction? ? obj.destroy : nil}
+              send(:#{association_name}).reset!
+            end
+          eoruby
         end
       end
     end

--- a/lib/active_fedora/rdf_datastream.rb
+++ b/lib/active_fedora/rdf_datastream.rb
@@ -42,6 +42,7 @@ module ActiveFedora
     end
 
     def content=(content)
+      reset_child_cache!
       @graph = deserialize(content)
     end
 
@@ -98,6 +99,7 @@ module ActiveFedora
     # Note: This method is implemented on SemanticNode instead of RelsExtDatastream because SemanticNode contains the relationships array
     def serialize
       update_subjects_to_use_a_real_pid!
+
       RDF::Writer.for(serialization_format).dump(graph)
     end
 
@@ -109,6 +111,7 @@ module ActiveFedora
 
       bad_subject = rdf_subject
       reset_rdf_subject!
+      reset_child_cache!
       new_subject = rdf_subject
 
       new_repository = RDF::Repository.new
@@ -125,7 +128,7 @@ module ActiveFedora
 
     # returns a Hash, e.g.: {field => {:values => [], :type => :something, :behaviors => []}, ...}
     def fields
-      field_map = {}
+      field_map = {}.with_indifferent_access
 
       rdf_subject = self.rdf_subject
       query = RDF::Query.new do

--- a/lib/active_fedora/rdf_list.rb
+++ b/lib/active_fedora/rdf_list.rb
@@ -9,6 +9,10 @@ module ActiveFedora
       graph.insert([subject, RDF.rest, RDF.nil])
     end
 
+    def rdf_subject
+      subject
+    end
+
     def first
       self[0] 
     end

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -35,6 +35,23 @@ describe "Nested Rdf Objects" do
       ds.parts.first.label.should == ["Alternator"]
     end
 
+    it "should be able to replace attributes" do
+      v = ds.parts.build(label: 'Alternator')
+      ds.parts.first.label.should == ['Alternator']
+      ds.parts.first.label = ['Distributor']
+      ds.parts.first.label.should == ['Distributor']
+    end
+
+    it "should be able to replace objects" do
+      ds.parts.build(label: 'Alternator')
+      ds.parts.build(label: 'Distributor')
+      ds.parts.size.should == 2
+      comp = SpecDatastream::Component.new(ds.graph)
+      comp.label = "Injector port"
+      ds.parts = [comp]
+      ds.parts.size.should == 1
+    end
+
     it "should be able to nest many complex objects" do
       comp1 = SpecDatastream::Component.new ds.graph
       comp1.label = ["Alternator"]

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -1,118 +1,157 @@
 require 'spec_helper'
 
-describe ActiveFedora::RDFDatastream do
-    before do 
-      class DummyMADS < RDF::Vocabulary("http://www.loc.gov/mads/rdf/v1#")
-        # componentList and Types of components
-        property :componentList
-        property :Topic
-        property :Temporal
-        property :PersonalName
-        property :CorporateName
-        property :ComplexSubject
-        
-        
-        # elementList and elementList values
-        property :elementList
-        property :elementValue
-        property :TopicElement
-        property :TemporalElement
-        property :NameElement
-        property :FullNameElement
-        property :DateNameElement
+describe "Nesting attribute behavior of RDFDatastream" do
+  describe ".attributes=" do
+    describe "complex properties" do
+      before do 
+        class DummyMADS < RDF::Vocabulary("http://www.loc.gov/mads/rdf/v1#")
+          # componentList and Types of components
+          property :componentList
+          property :Topic
+          property :Temporal
+          property :PersonalName
+          property :CorporateName
+          property :ComplexSubject
+          
+          
+          # elementList and elementList values
+          property :elementList
+          property :elementValue
+          property :TopicElement
+          property :TemporalElement
+          property :NameElement
+          property :FullNameElement
+          property :DateNameElement
+        end
+
+        class ComplexRDFDatastream < ActiveFedora::NtriplesRDFDatastream
+          map_predicates do |map|
+            map.topic(in: DummyMADS, to: "Topic", class_name:"Topic")
+            map.personalName(in: DummyMADS, to: "PersonalName", class_name:"PersonalName")
+            map.title(in: RDF::DC)
+          end
+
+          accepts_nested_attributes_for :topic, :personalName
+
+          class Topic
+            include ActiveFedora::RdfObject
+            map_predicates do |map|
+              map.elementList(in: DummyMADS, class_name:"ComplexRDFDatastream::ElementList")
+            end
+            accepts_nested_attributes_for :elementList
+          end
+          class PersonalName
+            include ActiveFedora::RdfObject
+            map_predicates do |map|
+              map.elementList(in: DummyMADS, to: "elementList", class_name:"ComplexRDFDatastream::ElementList")
+              map.extraProperty(in: DummyMADS, to: "elementValue", class_name:"ComplexRDFDatastream::Topic")
+            end
+            accepts_nested_attributes_for :elementList, :extraProperty
+          end
+          class ElementList
+            include ActiveFedora::RdfObject
+            rdf_type DummyMADS.elementList
+            map_predicates do |map|
+              map.topicElement(in: DummyMADS, to: "TopicElement")
+              map.temporalElement(in: DummyMADS, to: "TemporalElement")
+              map.fullNameElement(in: DummyMADS, to: "FullNameElement")
+              map.dateNameElement(in: DummyMADS, to: "DateNameElement")
+              map.nameElement(in: DummyMADS, to: "NameElement")
+              map.elementValue(in: DummyMADS)
+            end
+          end
+        end
       end
-
-      class ComplexRDFDatastream < ActiveFedora::NtriplesRDFDatastream
-        map_predicates do |map|
-          map.topic(in: DummyMADS, to: "Topic", class_name:"Topic")
-          map.personalName(in: DummyMADS, to: "PersonalName", class_name:"PersonalName")
-          map.title(in: RDF::DC)
-        end
-
-        accepts_nested_attributes_for :topic, :personalName
-
-        class Topic
-          include ActiveFedora::RdfObject
-          map_predicates do |map|
-            map.elementList(in: DummyMADS, class_name:"ComplexRDFDatastream::ElementList")
-          end
-          accepts_nested_attributes_for :elementList
-        end
-        class PersonalName
-          include ActiveFedora::RdfObject
-          map_predicates do |map|
-            map.elementList(in: DummyMADS, to: "elementList", class_name:"ComplexRDFDatastream::ElementList")
-            map.extraProperty(in: DummyMADS, to: "elementValue", class_name:"ComplexRDFDatastream::Topic")
-          end
-          accepts_nested_attributes_for :elementList, :extraProperty
-        end
-        class ElementList
-          include ActiveFedora::RdfObject
-          rdf_type DummyMADS.elementList
-          map_predicates do |map|
-            map.topicElement(in: DummyMADS, to: "TopicElement")
-            map.temporalElement(in: DummyMADS, to: "TemporalElement")
-            map.fullNameElement(in: DummyMADS, to: "FullNameElement")
-            map.dateNameElement(in: DummyMADS, to: "DateNameElement")
-            map.nameElement(in: DummyMADS, to: "NameElement")
-            map.elementValue(in: DummyMADS)
-          end
-        end
+      after do
+        Object.send(:remove_const, :ComplexRDFDatastream)
+        Object.send(:remove_const, :DummyMADS)
       end
-    end
-    after do
-      Object.send(:remove_const, :ComplexRDFDatastream)
-      Object.send(:remove_const, :DummyMADS)
-    end
-    subject { ComplexRDFDatastream.new(stub('inner object', :pid=>'foo', :new? =>true), 'descMetadata') }
-    
-    describe ".attributes=" do
-      describe "complex properties" do
-        let(:params) do 
-          { myResource: 
-            {
-              topic_attributes: [
-                {
-                  elementList_attributes: {
-                    topicElement:"Cosmology"
-                    }
-                },
-                {
-                  elementList_attributes: {
-                    topicElement:"Quantum Behavior"
-                  }
-                }
-              ],
-              personalName_attributes: [
-                { 
-                  elementList_attributes: {
-                    fullNameElement: "Jefferson, Thomas",
-                    dateNameElement: "1743-1826"                  
-                  }
-                } 
-                #, "Hemings, Sally"
-              ],
-            }
+      subject { ComplexRDFDatastream.new(stub('inner object', :pid=>'foo', :new? =>true), 'descMetadata') }
+      let(:params) do 
+        { myResource: 
+          {
+            topic_attributes: [
+              {
+                elementList_attributes: [{
+                  topicElement:"Cosmology"
+                  }]
+              },
+              {
+                elementList_attributes: [{
+                  topicElement:"Quantum Behavior"
+                }]
+              }
+            ],
+            personalName_attributes: [
+              { 
+                elementList_attributes: [{
+                  fullNameElement: "Jefferson, Thomas",
+                  dateNameElement: "1743-1826"                  
+                }]
+              } 
+              #, "Hemings, Sally"
+            ],
           }
-        end
-        it "should support mass-assignment" do
-            # Replace the graph's contents with the Hash
-            subject.attributes = params[:myResource]
+        }
+      end
+      it "should create nested objects" do
+          # Replace the graph's contents with the Hash
+          subject.attributes = params[:myResource]
 
-            # Here's how this would happen if we didn't have attributes=
-            # personal_name = subject.personalName.build 
-            # elem_list = personal_name.elementList.build
-            # elem_list.fullNameElement = "Jefferson, Thomas"
-            # elem_list.dateNameElement = "1743-1826"
-            # topic = subject.topic.build
-            # elem_list = topic.elementList.build
-            # elem_list.fullNameElement = 'Cosmology'
+          # Here's how this would happen if we didn't have attributes=
+          # personal_name = subject.personalName.build 
+          # elem_list = personal_name.elementList.build
+          # elem_list.fullNameElement = "Jefferson, Thomas"
+          # elem_list.dateNameElement = "1743-1826"
+          # topic = subject.topic.build
+          # elem_list = topic.elementList.build
+          # elem_list.fullNameElement = 'Cosmology'
 
-            subject.topic.first.elementList.first.topicElement.should == ["Cosmology"]
-            subject.topic[1].elementList.first.topicElement.should == ["Quantum Behavior"]
-            subject.personalName.first.elementList.first.fullNameElement.should == ["Jefferson, Thomas"]
-            subject.personalName.first.elementList.first.dateNameElement.should == ["1743-1826"]
-        end
-      end    
+          subject.topic.first.elementList.first.topicElement.should == ["Cosmology"]
+          subject.topic[1].elementList.first.topicElement.should == ["Quantum Behavior"]
+          subject.personalName.first.elementList.first.fullNameElement.should == ["Jefferson, Thomas"]
+          subject.personalName.first.elementList.first.dateNameElement.should == ["1743-1826"]
+      end
     end
+
+    describe "with an existing object" do
+      before(:each) do 
+        class SpecDatastream < ActiveFedora::NtriplesRDFDatastream
+          map_predicates do |map|
+            map.parts(:in=> RDF::DC, :to=>'hasPart', :class_name=>'Component')
+          end
+          accepts_nested_attributes_for :parts, allow_destroy: true
+
+          class Component
+            include ActiveFedora::RdfObject
+            map_predicates do |map|
+              map.label(:in=> RDF::DC, :to=>'title')
+            end
+          end
+        end
+
+      end
+      
+      after(:each) do
+        Object.send(:remove_const, :SpecDatastream)
+      end
+      subject { SpecDatastream.new(stub('inner object', :pid=>'foo', :new? =>true), 'descMetadata') }
+      before do
+        subject.attributes = { parts_attributes: [
+                                  {label: 'Alternator'},
+                                  {label: 'Distributor'},
+                                  {label: 'Transmission'},
+                                  {label: 'Fuel Filter'}]}
+      end
+      let (:replace_object_id) { subject.parts[1].rdf_subject.to_s }
+      let (:remove_object_id) { subject.parts[3].rdf_subject.to_s }
+
+      it "should update nested objects" do
+        subject.parts_attributes= [{id: replace_object_id, label: "Universal Joint"}, {label:"Oil Pump"}, {id: remove_object_id, _destroy: '1', label: "bar1 uno"}]
+
+        subject.parts.map{|p| p.label.first}.should == ['Alternator', 'Universal Joint', 'Transmission', 'Oil Pump']
+
+      end
+    end    
+  end
 end

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -223,7 +223,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
 
       describe ".fields()" do
         it "should return the right fields" do
-          @obj.send(:fields).keys.should == [:created, :title, :publisher, :based_near, :related_url]
+          @obj.send(:fields).keys.should == ["created", "title", "publisher", "based_near", "related_url"]
         end
         it "should return the right values" do
           fields = @obj.send(:fields)


### PR DESCRIPTION
Because we "mark" the objects for deletion, this change required
that we do not reload the objects from the graph on every read.  Instead
it maintains a cache for the objects returned from the RDF query.
