### PR TITLE
Fixing delegate registry lookup

### DIFF
--- a/lib/active_fedora/delegating.rb
+++ b/lib/active_fedora/delegating.rb
@@ -4,7 +4,7 @@ module ActiveFedora
 
     # Calling inspect may trigger a bunch of loads, but it's mainly for debugging, so no worries.
     def inspect
-      values = self.class.delegate_registry.map {|r| "#{r}:#{send(r).inspect}"}
+      values = self.class.delegates.keys.map {|r| "#{r}:#{send(r).inspect}"}
       "#<#{self.class} pid:\"#{pretty_pid}\", #{values.join(', ')}>"
     end
 
@@ -73,10 +73,6 @@ module ActiveFedora
         else
           super(*methods)
         end
-      end
-
-      def delegate_registry
-        self.delegates.keys
       end
 
       # Allows you to delegate multiple terminologies to the same datastream, instead

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -131,7 +131,7 @@ module ActiveFedora
     def condition_to_clauses(key, value)
       unless value.nil?
         # if the key is a property name, turn it into a solr field
-        if self.delegate_registry.include?(key.to_sym)
+        if self.delegates.key?(key)
           # TODO Check to see if `key' is a possible solr field for this class, if it isn't try :searchable instead
           key = ActiveFedora::SolrService.solr_name(key, :stored_searchable, type: :string)
         end


### PR DESCRIPTION
Given that the delegates hash is of indifferent access, when checking if
a delegate entry exists, we were first asking for delegates.keys. This
returned an array of strings. We were, however, passing a symbol.

By instead leveraging the hash key lookup, we don't have to worry about
receiving a symbol or a string.
