### PR TITLE
Providing a YAMLAdaptor for Psych dependency

### DIFF
--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -1,5 +1,5 @@
 require 'erb'
-require 'psych'
+require 'active_fedora/yaml_adaptor'
 
 module ActiveFedora
   class FileConfigurator
@@ -110,7 +110,7 @@ module ActiveFedora
       end
 
       begin
-        fedora_yml = Psych.load(config_erb)
+        fedora_yml = YAMLAdaptor.load(config_erb)
       rescue StandardError => e
         raise("fedora.yml was found, but could not be parsed.\n")
       end
@@ -133,7 +133,7 @@ module ActiveFedora
       end
 
       begin
-        solr_yml = Psych.load(config_erb)
+        solr_yml = YAMLAdaptor.load(config_erb)
       rescue StandardError => e
         raise("solr.yml was found, but could not be parsed.\n")
       end
@@ -209,7 +209,7 @@ module ActiveFedora
 
     def predicate_config
       @predicate_config_path ||= build_predicate_config_path(File.dirname(self.path))
-      Psych.load(File.open(@predicate_config_path)) if File.exist?(@predicate_config_path)
+      YAMLAdaptor.load(File.open(@predicate_config_path)) if File.exist?(@predicate_config_path)
     end
 
     protected
@@ -227,7 +227,7 @@ module ActiveFedora
     end
 
     def valid_predicate_mapping?(testfile)
-      mapping = Psych.load(File.open(testfile))
+      mapping = YAMLAdaptor.load(File.open(testfile))
       return false unless mapping.has_key?(:default_namespace) && mapping[:default_namespace].is_a?(String)
       return false unless mapping.has_key?(:predicate_mapping) && mapping[:predicate_mapping].is_a?(Hash)
       true

--- a/lib/active_fedora/yaml_adaptor.rb
+++ b/lib/active_fedora/yaml_adaptor.rb
@@ -1,0 +1,12 @@
+begin
+  require 'psych'
+  YAMLAdaptor = Psych
+rescue LoadError
+  $stderr.puts "*"*80
+  $stderr.puts "WARNING: Unable to load Psych, falling back to YAML for parser."
+  $stderr.puts "    YAML will be removed in ActiveFedora 7.0.0."
+  $stderr.puts "    YAMLAdaptor will be removed in ActiveFedora 7.0.0, and replaced with Psych"
+  $stderr.puts "*"*80
+  require 'yaml'
+  YAMLAdaptor = YAML
+end

--- a/spec/config_helper.rb
+++ b/spec/config_helper.rb
@@ -2,7 +2,7 @@ def mock_yaml(hash, path)
   mock_file = mock(path.split("/")[-1])
   File.stub(:exist?).with(path).and_return(true)
   File.stub(:open).with(path).and_return(mock_file)
-  YAML.stub(:load).and_return(hash)
+  YAMLAdaptor.stub(:load).and_return(hash)
 end
 
 def default_predicate_mapping_file

--- a/spec/unit/code_configurator_spec.rb
+++ b/spec/unit/code_configurator_spec.rb
@@ -38,7 +38,7 @@ describe ActiveFedora::FileConfigurator do
   end
 
   it "should initialize from code" do
-    YAML.should_receive(:load).never
+    YAMLAdaptor.should_receive(:load).never
     File.should_receive(:exists?).never
     File.should_receive(:read).never
     File.should_receive(:open).never

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe ActiveFedora::Config do
   describe "with a single fedora instance" do
-    conf = Psych.load(File.read('spec/fixtures/rails_root/config/fedora.yml'))['test']
+    conf = YAMLAdaptor.load(File.read('spec/fixtures/rails_root/config/fedora.yml'))['test']
     subject { ActiveFedora::Config.new(conf) }
     its(:credentials) { should == {:url => 'http://testhost.com:8983/fedora', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'}}
     it { should_not be_sharded }
   end
   describe "with several fedora shards" do
-    conf = Psych.load(File.read('spec/fixtures/sharded_fedora.yml'))['test']
+    conf = YAMLAdaptor.load(File.read('spec/fixtures/sharded_fedora.yml'))['test']
     subject { ActiveFedora::Config.new(conf) }
     its(:credentials) { should == [{:url => 'http://127.0.0.1:8983/fedora1', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'},
                               {:url => 'http://127.0.0.1:8983/fedora2', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'},

--- a/spec/unit/file_configurator_spec.rb
+++ b/spec/unit/file_configurator_spec.rb
@@ -323,7 +323,7 @@ describe ActiveFedora::FileConfigurator do
       subject.instance_variable_set :@config_loaded, nil
     end
     it "should return the default mapping if it has not been initialized" do
-      subject.predicate_config().should == YAML.load(File.read(default_predicate_mapping_file))
+      subject.predicate_config().should == YAMLAdaptor.load(File.read(default_predicate_mapping_file))
     end
   end
 


### PR DESCRIPTION
While updating from ActiveFedora 5.x to 6.4.0.rc4 I encountered a gotcha
in that Psych was now a dependency. And with Psych comes a system
dependency of libyaml. The dependency was caught on my Jenkins server
(but not Travis).

By providing the adaptor I am hoping to provide a bridge from YAML to
Psych without an abrupt requirement. As indicated in the deprecation
notice, I would envision removing the YAML adaptor.
