### PR TITLE
Added :path option to ActiveFedora::QualifiedDublinCoreDatastream#field ...

### DIFF
--- a/lib/active_fedora/qualified_dublin_core_datastream.rb
+++ b/lib/active_fedora/qualified_dublin_core_datastream.rb
@@ -122,7 +122,8 @@ module ActiveFedora
       self.class.class_fields << name.to_s
       # add term to terminology
       unless self.class.terminology.has_term?(name.to_sym)
-        term = OM::XML::Term.new(name.to_sym, {:xmlns=>"http://purl.org/dc/terms/", :namespace_prefix => "dcterms"}, self.class.terminology)
+        om_term_opts = {:xmlns=>"http://purl.org/dc/terms/", :namespace_prefix => "dcterms", :path => opts[:path]}
+        term = OM::XML::Term.new(name.to_sym, om_term_opts, self.class.terminology)
         self.class.terminology.add_term(term)
         term.generate_xpath_queries!
       end

--- a/spec/unit/qualified_dublin_core_datastream_spec.rb
+++ b/spec/unit/qualified_dublin_core_datastream_spec.rb
@@ -114,12 +114,21 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
     end
 
   end
+
   describe 'custom fields' do
     it 'should grab the term' do
       sample_xml = "<dc xmlns:dcterms='http://purl.org/dc/terms/' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'><dcterms:cust>custom</dcterms:cust></dc>"
       test_ds = ActiveFedora::QualifiedDublinCoreDatastream.from_xml(sample_xml )
       test_ds.field :cust
       test_ds.cust.should == ['custom']
+    end
+  end
+
+  describe "#field should accept :path option" do
+    it "should be able to map :dc_type to the path 'type'" do
+      test_ds = ActiveFedora::QualifiedDublinCoreDatastream.from_xml(@sample_xml)
+      test_ds.field :dc_type, :string, path: "type", multiple: true
+      test_ds.dc_type.should == ['sound']
     end
   end
 


### PR DESCRIPTION
...in order to support, for example,

mapping the term :dc_type to dcterms:type (:type is excluded from ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS).
Implementation simply adds :path (even if nil) to OM::XML::Term.new since initializer falls back to field name anyway.
