### PR TITLE
Added :type to ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS.

### DIFF
--- a/lib/active_fedora/qualified_dublin_core_datastream.rb
+++ b/lib/active_fedora/qualified_dublin_core_datastream.rb
@@ -76,8 +76,9 @@ module ActiveFedora
                :tableOfContents,
                :temporal,
                :title,
+               :type,
                :valid
-              ] # removed :type, :format
+              ] # removed :format
     DCTERMS.freeze
 
     #Constructor. this class will call self.field for each DCTERM. In short, all DCTERMS fields will already exist

--- a/spec/unit/qualified_dublin_core_datastream_spec.rb
+++ b/spec/unit/qualified_dublin_core_datastream_spec.rb
@@ -45,7 +45,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
   end
 
   it "should create the right number of fields" do
-    ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS.size.should == 53
+    ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS.size.should == 54
   end
 
   it "should have unmodifiable constants" do


### PR DESCRIPTION
Presumably this field was excluded due to Object#type from Ruby 1.8.
Since AF currently requires >= Ruby 1.9.3, it appears safe to add this DC 1.1 element.

Note: https://github.com/projecthydra/active_fedora/pull/135 is still relevant for :format at least, and possibly for other purposes.
