### PR TITLE
Rdf nested attributes should accept hashes

### DIFF
--- a/lib/active_fedora/rdf/nested_attributes.rb
+++ b/lib/active_fedora/rdf/nested_attributes.rb
@@ -12,14 +12,35 @@ module ActiveFedora
 
       UNASSIGNABLE_KEYS = %w( id _destroy )
 
+      # @params [Symbol] association_name
+      # @params [Hash, Array] attributes_collection
+      # @example
+      #
+      #   assign_nested_attributes_for_collection_association(:people, {
+      #     '1' => { id: '1', name: 'Peter' },
+      #     '2' => { name: 'John' },
+      #     '3' => { id: '2', _destroy: true }
+      #   })
+      #
+      # Will update the name of the Person with ID 1, build a new associated
+      # person with the name 'John', and mark the associated Person with ID 2
+      # for destruction.
+      #
+      # Also accepts an Array of attribute hashes:
+      #
+      #   assign_nested_attributes_for_collection_association(:people, [
+      #     { id: '1', name: 'Peter' },
+      #     { name: 'John' },
+      #     { id: '2', _destroy: true }
+      #   ])
       def assign_nested_attributes_for_collection_association(association_name, attributes_collection)
         options = self.nested_attributes_options[association_name]
 
         # TODO
         #check_record_limit!(options[:limit], attributes_collection)
 
-        if attributes_collection.is_a?(Hash) || attributes_collection.is_a?(String)
-          attributes_collection = [attributes_collection]
+        if attributes_collection.is_a?(Hash)# || attributes_collection.is_a?(String)
+          attributes_collection = attributes_collection.values
         end
 
         association = self.send(association_name)

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -70,18 +70,20 @@ describe "Nesting attribute behavior of RDFDatastream" do
       let(:params) do 
         { myResource: 
           {
-            topic_attributes: [
+            topic_attributes: {
+              '0' =>
               {
                 elementList_attributes: [{
                   topicElement:"Cosmology"
                   }]
               },
+              '1' =>
               {
                 elementList_attributes: [{
                   topicElement:"Quantum Behavior"
                 }]
               }
-            ],
+            },
             personalName_attributes: [
               { 
                 elementList_attributes: [{


### PR DESCRIPTION
Bug fix for passing a hash of attributes like:

``` ruby
obj.creator_attributes = {
  '1' => { id: '1', name: 'Peter' },
  '2' => { name: 'John' },
  '3' => { id: '2', _destroy: true }
}
```
