### PR TITLE
In activerecord 4.0 the update() method accepts arguments.

### DIFF
--- a/lib/active_fedora/callbacks.rb
+++ b/lib/active_fedora/callbacks.rb
@@ -242,7 +242,7 @@ module ActiveFedora
       run_callbacks(:create) { super }
     end
 
-    def update(*) #:nodoc:
+    def update_record(*) #:nodoc:
       run_callbacks(:update) { super }
     end
   end

--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -11,7 +11,7 @@ module ActiveFedora
         result = create
         update_index if create_needs_index?
       else
-        result = update
+        result = update_record
         update_index if update_needs_index?
       end
       return result
@@ -27,11 +27,14 @@ module ActiveFedora
       add_relationship(:has_model, self.class.to_class_uri)
     end
 
-    def update_attributes(properties)
-      self.attributes=properties
+    # Pushes the object and all of its new or dirty datastreams into Fedora
+    def update(attributes)
+      self.attributes=attributes
       save
     end
 
+    alias update_attributes update
+    
     # Refreshes the object's info from Fedora
     # Note: Currently just registers any new datastreams that have appeared in fedora
     def refresh
@@ -138,16 +141,15 @@ module ActiveFedora
       persist
     end
 
+    def update_record
+      persist
+    end
+
     # replace the unsaved digital object with a saved digital object
     def assign_pid
       @inner_object = @inner_object.save 
     end
     
-    # Pushes the object and all of its new or dirty datastreams into Fedora
-    def update
-      persist
-    end
-
     def persist
       result = @inner_object.save
 

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -339,7 +339,7 @@ describe ActiveFedora::Base do
 
       it "should update an existing record" do
         @test_object.stub(:new_record? => false)
-        @test_object.should_receive(:update)
+        @test_object.should_receive(:update_record)
         @test_object.should_receive(:update_index)
         @test_object.save     
       end
@@ -519,7 +519,6 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
     end
     
     describe "update_attributes" do
-
       it "should set the attributes and save" do
         m = FooHistory.new
         att= {"fubar"=> '1234', "baz" =>'stuff'}
@@ -528,6 +527,18 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
         m.should_receive(:baz=).with('stuff')
         m.should_receive(:save)
         m.update_attributes(att)
+      end
+    end
+
+    describe "update" do
+      it "should set the attributes and save" do
+        m = FooHistory.new
+        att= {"fubar"=> '1234', "baz" =>'stuff'}
+        
+        m.should_receive(:fubar=).with('1234')
+        m.should_receive(:baz=).with('stuff')
+        m.should_receive(:save)
+        m.update(att)
       end
     end
     


### PR DESCRIPTION
Make ActiveFedora conform to that interface.
