### PR TITLE
Ensuring that AF::Base.find("") raises exception

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency("mediashelf-loggable")
   s.add_dependency("rubydora", '~>1.6', '>= 1.6.5')
   s.add_dependency("rdf")
-  s.add_dependency("rdf-rdfxml", '~>1.0.0')
+  s.add_dependency("rdf-rdfxml", '1.0.1')
   s.add_dependency("deprecation")
   s.add_development_dependency("rdoc")
   s.add_development_dependency("yard")

--- a/lib/active_fedora/digital_object.rb
+++ b/lib/active_fedora/digital_object.rb
@@ -31,6 +31,7 @@ module ActiveFedora
     include DatastreamBootstrap
 
     def self.find(original_class, pid)
+      raise ActiveFedora::ObjectNotFoundError.new("Unable to find #{pid.inspect} in fedora. ") unless pid.present?
       conn = original_class.connection_for_pid(pid)
       obj = begin
         super(pid, conn)

--- a/spec/integration/bug_spec.rb
+++ b/spec/integration/bug_spec.rb
@@ -20,6 +20,12 @@ describe 'bugs' do
     Object.send(:remove_const, :FooHistory)
   end
 
+  it 'should raise ActiveFedora::ObjectNotFoundError when find("")' do
+    expect {
+      FooHistory.find('')
+    }.to raise_error(ActiveFedora::ObjectNotFoundError)
+  end
+
   it "should not clobber everything when setting a value" do
     @test_object.someData.fubar=['initial']
     @test_object.save!


### PR DESCRIPTION
Prior to this patch, a new object would be instantiated & returned when
ActiveFedora::Base.find("") was called.
