### PR TITLE
The example test should look for Base.exists?()

### DIFF
--- a/lib/generators/active_fedora/model/templates/model_spec.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model_spec.rb.erb
@@ -7,13 +7,12 @@ describe <%= class_name %> do
   include ActiveFedora::TestSupport
   subject { <%= class_name %>.new }
 
-  it 'should persist to Fedora' do
-    subject.save!
-    expect {
-      subject.reload
-    }.to_not raise_error(ActiveFedora::ObjectNotFoundError)
-
-    subject.destroy
+  describe "when persisted to fedora" do
+    before { subject.save! }
+    after { subject.destroy }
+    it 'should exist' do
+      <%= class_name %>.exists?(subject.pid).should be_true
+    end
   end
 
   it 'should have a descMetadata datastream' do


### PR DESCRIPTION
... rather than checking to see that an ObjectNotFound error is raised.

The previous test triggers this deprecation warning:

```
DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is
deprecated. Use `expect { }.not_to raise_error()` instead. Called from
/Users/.../gems/rspec-expectations-2.14.0/lib/rspec/matchers/built_in/raise_error.rb:53:in
`does_not_match?'.
```
