### PR TITLE
Allow query parameter AF.reindex_everything

### DIFF
--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -87,9 +87,11 @@ module ActiveFedora
       end
 
       # Using the fedora search (not solr), get every object and reindex it.
-      def reindex_everything
+      # @param [String] a query string that conforms to the query param format
+      #   of the underlying search's API
+      def reindex_everything(query = nil)
         connections.each do |conn|
-          conn.search(nil) do |object|
+          conn.search(query) do |object|
             ActiveFedora::Base.find(object.pid, :cast=>true).update_index
           end
         end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -92,6 +92,18 @@ describe ActiveFedora::Base do
        ActiveFedora::Base.should_receive(:find).with('ZZZ', :cast=>true).and_return(mock_update)
        ActiveFedora::Base.reindex_everything
     end
+
+    it "should accept a query param for the search" do
+       query_string = "pid~*"
+       Rubydora::Repository.any_instance.should_receive(:search).with(query_string).
+            and_yield(double(pid:'XXX')).and_yield(double(pid:'YYY')).and_yield(double(pid:'ZZZ'))
+       mock_update = double(:mock_obj)
+       mock_update.should_receive(:update_index).exactly(3).times
+       ActiveFedora::Base.should_receive(:find).with('XXX', :cast=>true).and_return(mock_update)
+       ActiveFedora::Base.should_receive(:find).with('YYY', :cast=>true).and_return(mock_update)
+       ActiveFedora::Base.should_receive(:find).with('ZZZ', :cast=>true).and_return(mock_update)
+       ActiveFedora::Base.reindex_everything(query_string)
+    end
   end
 
   describe "With a test class" do


### PR DESCRIPTION
ActiveFedora::Base.reindex_everything certainly does that. It will
search out all objects from Fedora and attempt to load them into an
ActiveFedora::Base model. If you ran this from an application that has
only a subset of the models in Fedora you could be in for some really
weird surprises.

This patch allows you to pass a Fedora query string to the underlying
Rubydora search method.

In the case of our application, I only want to reindex items that are in
the namespace "und", so my method call looked like the following:

```
`ActiveFedora::Base.reindex_everything("pid~und:*")`
```

Closes #160
