### PR TITLE
Adding "An ActiveModel" shared behavior

### DIFF
--- a/lib/active_fedora/test_support.rb
+++ b/lib/active_fedora/test_support.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../../../spec/support/an_active_model', __FILE__)
 module ActiveFedora
   module TestSupport
 

--- a/lib/generators/active_fedora/model/templates/model_spec.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model_spec.rb.erb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'active_fedora/test_support'
 
 describe <%= class_name %> do
+  it_behaves_like 'An ActiveModel'
   include ActiveFedora::TestSupport
   subject { <%= class_name %>.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'active-fedora'
 require 'rspec'
 require 'equivalent-xml/rspec_matchers'
 
-require 'support/mock_fedora'
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each {|f| require f }
 require 'samples/samples'
 
 

--- a/spec/support/an_active_model.rb
+++ b/spec/support/an_active_model.rb
@@ -1,0 +1,28 @@
+shared_examples_for "An ActiveModel" do
+  begin
+    require 'minitest/unit'
+    include Minitest::Assertions
+  rescue NameError
+    puts "Unable to load minitest, here's hoping these methods are adequate"
+
+    def assert(test, *args)
+      expect(test).to eq(true)
+    end
+
+    def assert_kind_of(klass, inspected_object)
+      expect(inspected_object).to be_kind_of(klass)
+    end
+  end
+  include ActiveModel::Lint::Tests
+
+  ActiveModel::Lint::Tests.public_instance_methods.map{|m| m.to_s}.grep(/^test/).each do |m|
+    example m.gsub('_',' ') do
+      send m
+    end
+  end
+
+  def model
+    subject
+  end
+
+end

--- a/spec/unit/base_active_model_spec.rb
+++ b/spec/unit/base_active_model_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe ActiveFedora::Base do
-
   describe "active model methods" do 
     class BarStream < ActiveFedora::OmDatastream 
       set_terminology do |t|

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 @@last_pid = 0  
 
 describe ActiveFedora::Base do
+  it_behaves_like "An ActiveModel"
+
   describe 'descendants' do
     it "should record the decendants" do
       ActiveFedora::Base.descendants.should include(ModsArticle, SpecialThing)


### PR DESCRIPTION
Providing a shared behavior for verifying that ActiveFedora::Base (and
its descendants) implement the ActiveModel interface as defined by
ActiveModel::Lint::Test.
