### PR TITLE
Preventing duplicate rdf:rest rdf:nil triple

### DIFF
--- a/lib/active_fedora/rdf_list.rb
+++ b/lib/active_fedora/rdf_list.rb
@@ -9,8 +9,9 @@ module ActiveFedora
       @graph = graph
       @subject = subject
       first = graph.query([subject, RDF.first, nil]).first
+      last = graph.query([subject, RDF.rest, nil]).first
       graph.insert([subject, RDF.first, RDF.nil]) unless first
-      graph.insert([subject, RDF.rest, RDF.nil])
+      graph.insert([subject, RDF.rest, RDF.nil]) unless last
     end
     
     # Override assign_nested_attributes

--- a/spec/unit/rdf_list_nested_attributes_spec.rb
+++ b/spec/unit/rdf_list_nested_attributes_spec.rb
@@ -78,6 +78,9 @@ describe ActiveFedora::RdfList do
       topic.elementList.first[0].elementValue.should == ["Baseball"]
       topic.elementList.first[1].should be_kind_of(TopicElement)
       topic.elementList.first[1].elementValue.should == ["Football"]
+
+      # only one rdf:rest rdf:nil
+      topic.graph.query([nil, RDF.rest, RDF.nil]).size.should == 1 
     end
     it "should insert new nodes of varying types into RdfLists (rather than calling .build)" do
       # It's Not clear what the syntax should be when an RDF list contains multiple types of sub-nodes.  


### PR DESCRIPTION
Adding test for existing rdf:rest rdf:nil triple to prevent a duplicate triple that resulted in broken RDF lists when there were multiple items in the list.
