### PR TITLE
Adding a failing test to make sure the has and belongs to many can have more than 10 results

### DIFF
--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -186,6 +186,17 @@ describe ActiveFedora::Base do
           @book.topics.should == []
           @topic1.books.should == []
         end
+        it "Should allow for more than 10 items" do
+
+          (0..11).each do
+            @book.topics << Topic.create
+          end
+          @book.save
+          @book.topics.count.should == 12
+          book2 = Book.find(@book.pid)
+          book2.topics.count.should == 12
+        end
+
         after do
           @topic1.delete
           @topic2.delete


### PR DESCRIPTION
When you reload a item that has more than 10 associated items through has_and_belongs_to_many you only get 10 results back.  I'm guessing it is related to the default solr rows:10, but I'm not sure.
@jcoyne can you take a look at this?  It is blocking @DanCoughlin  
