### PR TITLE
Support for AF content models to extend others.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,4 +22,5 @@ Contributors to this project:
 *  Richard Johnson
 *  Thomas Johnson
 *  mpc3c
+*  Steven Anderson
 

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+6.5.0 (2013-07-30)
+
+Initial support for extended (inherited) Active Fedora models. [Steven Anderson]
+
 6.4.0 (2013-07-01)
 
 Removing experimental designation, tidying-up the code [Adam Wead]

--- a/README.textile
+++ b/README.textile
@@ -61,16 +61,10 @@ You need to have a copy of hydra-jetty running.  To do this, download a working 
 java -jar start.jar
 </pre>
 
-Then open a new terminal, go to your ActiveFedora source directory, and import fedora's demo objects.
-
-<pre>
-  rake active_fedora:fixtures environment=test
-</pre>
-
 Now you're ready to run the tests.  In the directory where active_fedora is installed, run
 
 <pre>
-  rake spec
+  rake active_fedora:rspec environment=test
 </pre>
 
 h2. Predicate Mappings

--- a/lib/active_fedora/associations/association_collection.rb
+++ b/lib/active_fedora/associations/association_collection.rb
@@ -150,8 +150,15 @@ module ActiveFedora
       def find_target
         return [] if @finder_query.empty?
         solr_result = SolrService.query(@finder_query, :rows=>1000)
+
+        # Limit to the specified class unless :cast=>true
+        opts = {}
+        if(!@reflection.cast && @reflection.class_name != nil)
+          opts[:class] = @reflection.class_name.constantize.to_class_uri
+        end
+
 #TODO, don't reify, just store the solr results and lazily reify.
-        return ActiveFedora::SolrService.reify_solr_results(solr_result)
+        return ActiveFedora::SolrService.reify_solr_results(solr_result, opts)
       end
 
       def load_from_solr

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -288,8 +288,20 @@ module ActiveFedora
 
     # Examine the :has_model assertions in the RELS-EXT.  Adapt this class to the first first known model
     def adapt_to_cmodel
-      the_model = ActiveFedora::ContentModel.known_models_for( self ).first
-      self.class != the_model ? self.adapt_to(the_model) : self
+      best_model_match = self.class unless self.class == ActiveFedora::Base
+
+      ActiveFedora::ContentModel.known_models_for( self ).each {|model_value|
+
+        # Use only the first match for initial consideration.
+        best_model_match ||= model_value
+
+        # If there is an inheritance structure, use the most specific case.
+        if best_model_match > model_value
+          best_model_match = model_value
+        end
+      }
+
+      self.class != best_model_match ? self.adapt_to(best_model_match) : self
     end
     
     # ** EXPERIMENTAL **

--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -25,6 +25,13 @@ module ActiveFedora
     # It's normally called once in the lifecycle, by #create#
     def assert_content_model
       add_relationship(:has_model, self.class.to_class_uri)
+
+      # Keep adding superclass objects if this is an inherited model
+      object_superclass = self.class.superclass
+      until object_superclass == ActiveFedora::Base || object_superclass == Object do
+        add_relationship(:has_model, object_superclass.to_class_uri)
+        object_superclass = object_superclass.superclass
+      end
     end
 
     # Pushes the object and all of its new or dirty datastreams into Fedora

--- a/lib/active_fedora/rdf_xml_writer.rb
+++ b/lib/active_fedora/rdf_xml_writer.rb
@@ -21,6 +21,30 @@ module ActiveFedora
       parent_node.add_child(node) if node
     end
 
+    # Overriding function from RDF::RDFXML::Writer
+    #
+    # Notable changes:
+    #
+    # Remove sorting on the property value within specific rels-ext relationships.
+    # Instead, leave it as the order the system entered it in.
+    #
+    def order_properties(properties)
+      # Make sorted list of properties
+      prop_list = []
+
+      predicate_order.each do |prop|
+        next unless properties[prop]
+        prop_list << prop.to_s
+      end
+
+      properties.keys.sort.each do |prop|
+        next if prop_list.include?(prop.to_s)
+        prop_list << prop.to_s
+      end
+
+      prop_list
+    end
+
     private
 
     def force_about(subject, parent_node)

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -91,6 +91,14 @@ module ActiveFedora
           @class_name ||= options[:class_name] || derive_class_name
         end
 
+        # Returns is the association is set to be casted
+        #
+        # <tt>:cast => true</tt> returns <tt>'true'</tt>
+        # <tt>Missing :cast variable returns false.</tt>
+        def cast
+          @cast ||= options[:cast]
+        end
+
         # Returns whether or not this association reflection is for a collection
         # association. Returns +true+ if the +macro+ is either +has_many+ or
         # +has_and_belongs_to_many+, +false+ otherwise.

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -50,12 +50,34 @@ module ActiveFedora
       method = opts[:load_from_solr] ? :load_instance_from_solr : :find
       classname.send(method, hit[SOLR_DOCUMENT_ID])
     end
-  
-    def self.class_from_solr_document(hit)
-        model_value = nil
-        hit[solr_name("has_model", :symbol)].each {|value| model_value ||= Model.from_class_uri(value)}
-        logger.warn "Could not find a model for #{hit["id"]}, defaulting to ActiveFedora::Base" unless model_value
-        model_value || ActiveFedora::Base
+
+    def self.class_from_solr_document(hit,opts = {})
+      best_model_match = nil
+
+      # If limited to a specific class
+      if opts[:class]
+        best_model_match ||= Model.from_class_uri(opts[:class])
+      # Else use the first model (unless there is an extended version of the first model in the tree)
+      else
+        hit[solr_name("has_model", :symbol)].each {|value|
+
+          model_value = Model.from_class_uri(value)
+
+          if(model_value)
+            # Use only the first match for initial consideration.
+            best_model_match ||= model_value
+
+            # If there is an inheritance structure, use the most specific case.
+            if best_model_match > model_value
+              best_model_match = model_value
+            end
+          end
+        }
+
+      end
+
+      logger.warn "Could not find a model for #{hit["id"]}, defaulting to ActiveFedora::Base" unless best_model_match
+      best_model_match || ActiveFedora::Base
     end
     
     # Construct a solr query for a list of pids

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -5,6 +5,7 @@ describe ActiveFedora::Base do
     before do
       class Library < ActiveFedora::Base 
         has_many :books, :property=>:has_constituent
+        has_many :books_casted, :property=>:has_constituent, :class_name=>'Book', :cast=>true
       end
 
       class Book < ActiveFedora::Base 
@@ -13,6 +14,9 @@ describe ActiveFedora::Base do
         belongs_to :publisher, :property=>:has_member
         has_and_belongs_to_many :topics, :property=>:has_topic, :inverse_of=>:is_topic_of
         has_and_belongs_to_many :collections, :property=>:is_member_of_collection
+      end
+
+      class SpecialInheritedBook < Book
       end
 
       class Person < ActiveFedora::Base
@@ -24,8 +28,9 @@ describe ActiveFedora::Base do
       class Collection < ActiveFedora::Base
       end
 
-      class Topic < ActiveFedora::Base 
+      class Topic < ActiveFedora::Base
         has_and_belongs_to_many :books, :property=>:is_topic_of
+        has_and_belongs_to_many :books_casted, :property=>:is_topic_of, :class_name=>'Book', :cast=>true
       end
     end
 
@@ -35,6 +40,7 @@ describe ActiveFedora::Base do
       Object.send(:remove_const, :Person)
       Object.send(:remove_const, :Collection)
       Object.send(:remove_const, :Topic)
+      Object.send(:remove_const, :SpecialInheritedBook)
     end
 
     describe "an unsaved instance" do
@@ -178,6 +184,7 @@ describe ActiveFedora::Base do
           @topic1 = Topic.create
           @topic2 = Topic.create
           @book = Book.create
+          @special_book = SpecialInheritedBook.create
         end
         it "habtm should set and remove relationships bidirectionally" do
           @book.topics << @topic1
@@ -201,9 +208,25 @@ describe ActiveFedora::Base do
           book2.topics.count.should == 12
         end
 
+        it "Should find inherited objects along with base objects" do
+          @book.topics << @topic1
+          @special_book.topics << @topic1
+          @topic1.books.should == [@book, @special_book]
+          @topic1.reload.books.should == [@book, @special_book]
+        end
+
+        it "Should cast found books to the correct cmodel" do
+          @topic1.books[0].class == Book
+          @topic1.books[1].class == Book
+          @topic1.books_casted[0].class == Book
+          @topic1.books_casted[1].class == SpecialInheritedBook
+        end
+
         after do
           @topic1.delete
           @topic2.delete
+          @book.delete
+          @special_book.delete
         end
       end
     end
@@ -279,6 +302,33 @@ describe ActiveFedora::Base do
           end
           after do
             @library2.delete
+          end
+        end
+
+        describe "when dealing with inherited objects" do
+          before do
+            @library2 = Library.create
+            @special_book = SpecialInheritedBook.create
+
+            @book.library = @library2
+            @book.save
+            @special_book.library = @library2
+            @special_book.save
+          end
+
+          it "should retrieve both as Book for non-casted association" do
+            @library2.books[0].class == Book
+            @library2.books[1].class == Book
+          end
+
+          it "should cast correctly for casted association" do
+            @library2.books_casted[0].class == Book
+            @library2.books_casted[1].class == SpecialInheritedBook
+          end
+
+          after do
+            @library2.delete
+            @special_book.delete
           end
         end
 
@@ -723,6 +773,92 @@ describe ActiveFedora::Base do
           book2.save
           book2.reload.contents.should == [text2]
           text2.reload.books.should == [book2]
+        end
+      end
+    end
+  end
+
+
+  describe "casting inheritance additional test cases" do
+    describe "for habtm" do
+      before :all do
+        class SimpleObject < ActiveFedora::Base
+          belongs_to :simple_collection, property: :is_part_of, class_name: 'SimpleCollection'
+          belongs_to :simple_collection_casted, property: :is_part_of, class_name: 'SimpleCollection', :cast=>true
+          belongs_to :complex_collection, property: :is_part_of, class_name: 'ComplexCollection'
+        end
+
+        class ComplexObject < SimpleObject
+        end
+
+        class SimpleCollection < ActiveFedora::Base
+          has_many :objects, property: :is_part_of, class_name: 'SimpleObject'
+          has_many :objects_casted, property: :is_part_of, class_name: 'SimpleObject', :cast=>true
+          has_many :complex_objects, property: :is_part_of, class_name: 'ComplexObject'
+        end
+
+        class ComplexCollection < SimpleCollection
+        end
+
+      end
+      after :all do
+        Object.send(:remove_const, :SimpleObject)
+        Object.send(:remove_const, :ComplexObject)
+        Object.send(:remove_const, :SimpleCollection)
+        Object.send(:remove_const, :ComplexCollection)
+      end
+
+      describe "saving between the before and after hooks" do
+        before do
+          @simple_object = SimpleObject.create
+          @complex_object = ComplexObject.create
+          @simple_collection = SimpleCollection.create
+          @complex_collection = ComplexCollection.create
+
+          @complex_object.simple_collection = @complex_collection
+          @complex_object.save!
+          @simple_object.simple_collection = @simple_collection
+          @simple_object.save!
+          @simple_collection.objects = [@simple_object, @complex_object]
+          @simple_collection.save!
+          @complex_collection.objects = [@simple_object, @complex_object]
+          @complex_collection.save!
+        end
+
+
+        it "non-casted methods should work and return the specific class" do
+          @complex_object.simple_collection.class == SimpleCollection
+          @complex_object.complex_collection.class == ComplexCollection
+
+          @simple_object.simple_collection.class == SimpleCollection
+          @simple_object.complex_collection == nil
+
+          @complex_collection.objects[0].class == SimpleObject
+          @complex_collection.objects[1].class == SimpleObject
+          @complex_collection.complex_objects.length == 1
+          @complex_collection.complex_objects[0].class == ComplexObject
+
+          @simple_collection.objects[0].class == SimpleObject
+          @simple_collection.objects[1].class == SimpleObject
+          @simple_collection.complex_objects.length == 1
+          @simple_collection.complex_objects[0].class == ComplexObject
+        end
+
+        it "casted association methods should work and return the most complex class" do
+          @complex_object.simple_collection_casted.class == ComplexCollection
+
+          @simple_object.simple_collection_casted.class == ComplexCollection
+
+          @complex_collection.objects_casted[0].class == ComplexObject
+          @complex_collection.objects_casted[1].class == ComplexObject
+
+          @simple_collection.objects_casted[0].class == ComplexObject
+          @simple_collection.objects_casted[1].class == ComplexObject
+        end
+
+        after do
+          @simple_object.delete
+          @complex_object.delete
         end
       end
     end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -131,11 +131,16 @@ describe ActiveFedora::Base do
       class FooAdaptation < ActiveFedora::Base
         has_metadata :type=>ActiveFedora::OmDatastream, :name=>'someData'
       end
+
+      class FooInherited < FooHistory
+        has_metadata :type=>ActiveFedora::OmDatastream, :name=>'someData'
+      end
     end
 
     after :all do
       Object.send(:remove_const, :FooHistory)
       Object.send(:remove_const, :FooAdaptation)
+      Object.send(:remove_const, :FooInherited)
     end
     
     def increment_pid
@@ -409,10 +414,15 @@ describe ActiveFedora::Base do
     end
 
     describe ".adapt_to_cmodel" do
-      subject { FooHistory.new } 
-      it "should cast when a cmodel is found" do
+      subject { FooHistory.new }
+
+      it "should not cast to a random first cmodel" do
         ActiveFedora::ContentModel.should_receive(:known_models_for).with( subject).and_return([FooAdaptation])
-        subject.adapt_to_cmodel.should be_kind_of FooAdaptation
+        subject.adapt_to_cmodel.should be_kind_of FooHistory
+      end
+      it "should cast to an inherited model over a random one" do
+        ActiveFedora::ContentModel.should_receive(:known_models_for).with( subject).and_return([FooAdaptation, FooInherited])
+        subject.adapt_to_cmodel.should be_kind_of FooInherited
       end
       it "should not cast when a cmodel is same as the class" do
         ActiveFedora::ContentModel.should_receive(:known_models_for).with( subject).and_return([FooHistory])

--- a/spec/unit/has_many_collection_spec.rb
+++ b/spec/unit/has_many_collection_spec.rb
@@ -3,11 +3,10 @@ require 'spec_helper'
 describe ActiveFedora::Associations::HasManyAssociation do
   it "should call add_relationship" do
     subject = double("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a')
-    predicate = double(:klass => double.class, :options=>{:property=>'predicate'}, :class_name=> nil)
+    predicate = double(:klass => double.class, :options=>{:property=>'predicate'}, :class_name=> nil, :cast=>false)
     ActiveFedora::SolrService.stub(:query).and_return([])
     ac = ActiveFedora::Associations::HasManyAssociation.new(subject, predicate)
     object = double("object", :new_record? => false, :pid => 'object:b', :save => nil)
-  
     object.should_receive(:add_relationship).with('predicate', subject)
  
     ac << object


### PR DESCRIPTION
(Additional note not in the commit message below: up until now we had been using a custom forked version of active_model. This is my attempt to generalize what we had been doing rather than continue to be on a separate fork. If these are deemed infeasible and no better suggestion for this type of support exists, can continue with a forked version for my institute). 

In Active Fedora, it assumes quite often that a given object will have
only a single valid content model. With models in the community
starting to extend from other models (ie. Sufia or internal models at
BPL), this update makes such cases more sane. It is not the ideal
coding solution with a few illogical inconsistencies left - but it
is one that should work without breaking any legacy code.

For the below bulleted examples, I will assume the following two
models:

```
class GenericFile << ActiveFedora::Base

class ExtendedGenericFile << GenericFile
```
- Rels-Ext relationships no longer automatically alphabetically reorder
  upon saving. Previously, saving an object with:
  
  ```
  add_relationship(:has_model, "GenericFile")
  add_relationship(:has_model, "ExtendedGenericFile")
  ```
  
  would cause "ExtendedGenericFile" to appear first in the rels_ext
  list. This is an issue as the first CModel is what most of the rails
  code uses when loading objects. Most people would expect for the
  models to be saved in the order they added them and this has been
  fixed.
- Extended hierachy is added to the content models automatically. So
  if you do:
  
  ```
  ExtendedGenericFile.create
  ```
  
  It will add the content models to the rails_ext for itself and also
  for "GenericFile". This will allow code that supports only
  "GenericFile" to still function and work with those functions
  that level of model supports. In short, it allows relationships
  that rely on "GenericFile" to still find "ExtendedGenericFile".
- belongs_to and has_many should no longer automatically cast objects.
  For example, if one has:
  
  ```
  has_many files, class_name: "GenericFile"
  ```
  
  A call to the "files" property will return all the objects as a type
  of "GenericFile".
- A ":cast" argument was added to relationships to allow for automatic
  casting. For example, using the previous example,
  
  ```
  has_many files, class_name: "GenericFile", :cast=>true
  ```
  
  In this case, "GenericFile" objects will still be returned as such.
  But "ExtendedGenericFile" objects will be instantiated as that
  class. Note that only the first cmodel order on the
  "ExtendedGenericFile" object is not important as it will attempt
  to use the most specific class available.
- adapt_to_cmodel no longer blindly uses the first cmodel. If an object
  of a class other than ActiveFedora::Base is called with it, it will
  attempt to find a more specific model based on that base model.
  Otherwise, it will use the first model, and cast as that unless it
  finds a more specific model registered in the system (based on that
  first model).
  
  This is easily reverted to using the first cmodel blindly. But
  seems like that is more unpredictable behavior.

As mentioned, not an ideal solution as still some "black magic"
decision making in there... but I believe it is overall more
consistent in how it functions. One thing that could perhaps help
greately at some point is a "best content model" field (perhaps
using the existing active_fedora_model_ssi?).
