### PR TITLE
Add ActiveFedora::Relation#last.  Resolves #184

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Querying
-    delegate :find, :first, :where, :limit, :order, :all, :delete_all, :destroy_all, :count, :to=>:relation
+    delegate :find, :first, :where, :limit, :order, :all, :delete_all, :destroy_all, :count, :last, :to=>:relation
 
     def self.extended(base)
       base.class_attribute  :solr_query_handler

--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -33,6 +33,20 @@ module ActiveFedora
       end
     end
 
+    # Returns the last record sorted by id.  ID was chosen because this mimics
+    # how ActiveRecord would achieve the same behavior.
+    #
+    # @example
+    #  Person.where(name_t: 'Jones').last
+    #    => #<Person @id="foo:123" @name='Jones' ... >
+    def last
+      if loaded?
+        @records.last
+      else
+        @last ||= order('id desc').limit(1).to_a[0]
+      end
+    end
+
     # Limits the number of returned records to the value specified
     #
     # @option [Integer] value the number of records to return

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -188,6 +188,48 @@ describe ActiveFedora::Base do
       ActiveFedora::Base.count(:conditions=>'foo:bar').should == 7 
     end
   end
+
+  describe '#last' do
+    describe 'with multiple objects' do
+      before(:all) do
+        (@a, @b, @c) = 3.times {SpecModel::Basic.create!}
+      end
+      it 'should return one object' do
+        SpecModel::Basic.class == SpecModel::Basic
+      end
+      it 'should return the last object sorted by pid' do
+        SpecModel::Basic.last == @c
+        SpecModel::Basic.last != @a 
+      end
+    end
+    describe 'with one object' do 
+      it 'should equal the first object when there is only one' do
+        a = SpecModel::Basic.create!
+        SpecModel::Basic.first == SpecModel::Basic.last
+      end
+    end
+  end
+
+  describe '#first' do
+    describe 'with multiple objects' do
+      before(:all) do
+        (@a, @b, @c) = 3.times {SpecModel::Basic.create!}
+      end
+      it 'should return one object' do
+        SpecModel::Basic.class == SpecModel::Basic
+      end
+      it 'should return the last object sorted by pid' do
+        SpecModel::Basic.first == @a
+        SpecModel::Basic.first != @c 
+      end
+    end
+    describe 'with one object' do 
+      it 'should equal the first object when there is only one' do
+        a = SpecModel::Basic.create!
+        SpecModel::Basic.first == SpecModel::Basic.last
+      end
+    end
+  end
   
   describe '#find_with_conditions' do
     it "should make a query to solr and return the results" do


### PR DESCRIPTION
Provides convenience method to determine the last ActiveFedora object based on PID.
