### PR TITLE
Include ActiveModel::Dirty on Base, call field_will_change! on delegated methods, and track changes on save

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -342,6 +342,7 @@ module ActiveFedora
     include Associations
     include NestedAttributes
     include Reflection
+    include ActiveModel::Dirty
   end
 
 end

--- a/spec/integration/delegating_spec.rb
+++ b/spec/integration/delegating_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "delegating objects" do
+  before :all do
+    class TitledObject < ActiveFedora::Base
+      has_metadata :type=>ActiveFedora::SimpleDatastream, :name=>"foo" do |m|
+        m.field "title", :string
+      end
+      delegate :title, :to=>'foo', :unique=>true
+    end
+  end
+  after :all do
+    Object.send(:remove_const, :TitledObject)
+  end
+
+  describe "save" do
+    subject do
+      obj = TitledObject.create 
+      obj.title = "Hydra for Dummies"
+      obj.save
+      obj
+    end
+    it "should keep a list of changes after a successful save" do
+      subject.previous_changes.should_not be_empty
+      subject.previous_changes.keys.should include("title")
+    end
+    it "should clean out changes" do
+      subject.title_changed?.should be_false
+      subject.changes.should be_empty
+    end
+  end
+end

--- a/spec/unit/base_delegate_to_spec.rb
+++ b/spec/unit/base_delegate_to_spec.rb
@@ -63,6 +63,12 @@ describe ActiveFedora::Base do
       @n.duck.should == ["Quack", "Peep"]
     end
 
+    it "should be able to track change status" do
+      @n.chicken_changed?.should be_false
+      @n.chicken = ["Cheep"]
+      @n.chicken_changed?.should be_true
+    end 
+
   end
 end
 


### PR DESCRIPTION
This PR implements ActiveModel::Dirty for ActiveFedora::Base objects.  As discussed on the committer's call this might not be an ideal solution but might be best for now.  Ideally, delegate would delegate all of the AM::Dirty calls to the appropriate datastream which would track the changes so obj.attribute_changed? and obj.datastream.attribute_changed? would both exist and report the same value.  But given how OM works this might be hard to implement.
