### PR TITLE
An empty query value that is a string should not return all documents.

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -138,6 +138,8 @@ module ActiveFedora
         end
         if value.is_a? Array
           value.map { |val| "#{key}:#{quote_for_solr(val)}" }
+        elsif value.is_a? String and value.empty?
+          "-#{key}:['' TO *]"
         else
           key = SOLR_DOCUMENT_ID if (key === :id || key === :pid)
           escaped_value = quote_for_solr(value)

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -82,6 +82,10 @@ describe ActiveFedora::Base do
         SpecModel::Basic.find({:foo=>'bar', :baz=>['quix','quack']}).should == ["Fake Object1", "Fake Object2"]
       end
 
+      it "should correctly query for empty strings" do
+        SpecModel::Basic.find( :active_fedora_model_ssi => '').count.should == 0
+      end
+
       it "should add options" do
         SpecModel::Basic.should_receive(:find_one).with("changeme:30", nil).and_return("Fake Object1")
         SpecModel::Basic.should_receive(:find_one).with("changeme:22", nil).and_return("Fake Object2")


### PR DESCRIPTION
## Example

Collection name is required.  There are zero objects in the database with an empty collection name.
#### Before

``` ruby
pry(main)> Admin::Collection.where('name_tesim' => "").count
=> 12
```
#### After

``` ruby
pry(main)> Admin::Collection.where('name_tesim' => "").count
=> 0
```
- Should I write tests for this?  Where should they go?
- Where should I put my change in HISTORY?  The latest release?
