### PR TITLE
ActiveFedora::Predicates.set_predicates allows you to set predicates without wiping out existing configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tmp
 Gemfile.lock
 jetty
 bin
+.idea
+.ruby-version
+.ruby-gemset

--- a/lib/active_fedora/predicates.rb
+++ b/lib/active_fedora/predicates.rb
@@ -82,6 +82,27 @@ module ActiveFedora
       raise ActiveFedora::UnregisteredPredicateError, "Unregistered predicate: #{predicate.inspect}"
     end
 
+    # Add/Modify predicates without destroying the other predicate configs
+    #
+    # @example
+    #  ActiveFedora::Predicates.set_predicates({
+    #                                              "http://projecthydra.org/ns/relations#"=>{has_profile:"hasProfile"},
+    #                                              "info:fedora/fedora-system:def/relations-external#"=>{
+    #                                                  references:"references",
+    #                                                  has_derivation: "cameFrom"
+    #                                              },
+    #                                          })
+    def self.set_predicates(new_predicates)
+      predicate_config = ActiveFedora::Predicates.predicate_config
+      new_predicates.each_pair do |ns, predicate_confs|
+        predicate_config[:predicate_mapping][ns] ||= {}
+        predicate_confs.each_pair do |property, value|
+          predicate_config[:predicate_mapping][ns][property] = value
+        end
+      end
+      predicate_config
+    end
+
   end
 
 end

--- a/spec/unit/predicates_spec.rb
+++ b/spec/unit/predicates_spec.rb
@@ -83,7 +83,24 @@ describe ActiveFedora::Predicates do
     it 'should ensure that the configuration has the correct keys' do
       lambda { ActiveFedora::Predicates.predicate_config = { :foo => 'invalid!' } }.should raise_error TypeError
     end
-    
+
+    it "should allow adding predicates without wiping out existing predicates" do
+      ActiveFedora::Predicates.set_predicates({
+                                                  "http://projecthydra.org/ns/relations#"=>{has_profile:"hasProfile"},
+                                                  "info:fedora/fedora-system:def/relations-external#"=>{
+                                                      references:"references",
+                                                      has_derivation: "cameFrom"
+                                                  },
+                                              })
+      # New & Modified Predicates
+      ActiveFedora::Predicates.find_predicate(:has_profile).should == ["hasProfile", "http://projecthydra.org/ns/relations#"]
+      ActiveFedora::Predicates.find_predicate(:references).should == ["references", "info:fedora/fedora-system:def/relations-external#"]
+      ActiveFedora::Predicates.find_predicate(:has_derivation).should == ["cameFrom", "info:fedora/fedora-system:def/relations-external#"]
+      # Pre-Existing predicates should be unharmed
+      ActiveFedora::Predicates.find_predicate(:is_part_of).should == ["isPartOf", "info:fedora/fedora-system:def/relations-external#"]
+      ActiveFedora::Predicates.find_predicate(:is_governed_by).should == ["isGovernedBy", "http://projecthydra.org/ns/relations#"]
+    end
+
   end
   
 end


### PR DESCRIPTION
Allows you to do things like this, usually in initializers:

``` ruby
# Add :has_profile predicate for use in ActiveModel (RELS-EXT) relationships
ActiveFedora::Predicates.set_predicates("http://projecthydra.org/ns/relations#"=>{:has_profile => "hasProfile"})
```

or, more elaborate, setting some new predicates while overriding some existing predicates

``` ruby
ActiveFedora::Predicates.set_predicates({
                                          "http://projecthydra.org/ns/relations#"=>{
                                                  has_profile: "hasProfile"
                                              },
                                          "info:fedora/fedora-system:def/relations-external#"=>{
                                                  references: "references",
                                                  has_derivation: "cameFrom"
                                              },
                                           })
```
