### PR TITLE
New inherited cmodel pull request (read-only portion).

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,4 +22,5 @@ Contributors to this project:
 *  Richard Johnson
 *  Thomas Johnson
 *  mpc3c
+*  Steven Anderson
 

--- a/lib/active_fedora/associations/association_collection.rb
+++ b/lib/active_fedora/associations/association_collection.rb
@@ -150,8 +150,15 @@ module ActiveFedora
       def find_target
         return [] if @finder_query.empty?
         solr_result = SolrService.query(@finder_query, :rows=>1000)
+
+        # Set the default classname to base inheritance on.
+        opts = {}
+        if(@reflection.class_name != nil)
+          opts[:class] = @reflection.class_name.constantize.to_class_uri
+        end
+
 #TODO, don't reify, just store the solr results and lazily reify.
-        return ActiveFedora::SolrService.reify_solr_results(solr_result)
+        return ActiveFedora::SolrService.reify_solr_results(solr_result, opts)
       end
 
       def load_from_solr

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -15,6 +15,9 @@ describe ActiveFedora::Base do
         has_and_belongs_to_many :collections, :property=>:is_member_of_collection
       end
 
+      class SpecialInheritedBook < Book
+      end
+
       class Person < ActiveFedora::Base
       end
 
@@ -35,6 +38,7 @@ describe ActiveFedora::Base do
       Object.send(:remove_const, :Person)
       Object.send(:remove_const, :Collection)
       Object.send(:remove_const, :Topic)
+      Object.send(:remove_const, :SpecialInheritedBook)
     end
 
     describe "an unsaved instance" do
@@ -178,6 +182,7 @@ describe ActiveFedora::Base do
           @topic1 = Topic.create
           @topic2 = Topic.create
           @book = Book.create
+          @special_book = SpecialInheritedBook.create
         end
         it "habtm should set and remove relationships bidirectionally" do
           @book.topics << @topic1
@@ -201,9 +206,23 @@ describe ActiveFedora::Base do
           book2.topics.count.should == 12
         end
 
+        it "Should find inherited objects along with base objects" do
+          @book.topics << @topic1
+          @special_book.topics << @topic1
+          @topic1.books.should == [@book, @special_book]
+          @topic1.reload.books.should == [@book, @special_book]
+        end
+
+        it "Should cast found books to the correct cmodel" do
+          @topic1.books[0].class == Book
+          @topic1.books[1].class == SpecialInheritedBook
+        end
+
         after do
           @topic1.delete
           @topic2.delete
+          @book.delete
+          @special_book.delete
         end
       end
     end
@@ -279,6 +298,28 @@ describe ActiveFedora::Base do
           end
           after do
             @library2.delete
+          end
+        end
+
+        describe "when dealing with inherited objects" do
+          before do
+            @library2 = Library.create
+            @special_book = SpecialInheritedBook.create
+
+            @book.library = @library2
+            @book.save
+            @special_book.library = @library2
+            @special_book.save
+          end
+
+          it "should cast to the most specific class for the association" do
+            @library2.books[0].class == Book
+            @library2.books[1].class == SpecialInheritedBook
+          end
+
+          after do
+            @library2.delete
+            @special_book.delete
           end
         end
 
@@ -723,6 +764,86 @@ describe ActiveFedora::Base do
           book2.save
           book2.reload.contents.should == [text2]
           text2.reload.books.should == [book2]
+        end
+      end
+    end
+  end
+
+  describe "casting inheritance additional test cases" do
+    describe "for habtm" do
+      before :all do
+        class SimpleObject < ActiveFedora::Base
+          belongs_to :simple_collection, property: :is_part_of, class_name: 'SimpleCollection'
+          belongs_to :complex_collection, property: :is_part_of, class_name: 'ComplexCollection'
+        end
+
+        class ComplexObject < SimpleObject
+        end
+
+        class SimpleCollection < ActiveFedora::Base
+          has_many :objects, property: :is_part_of, class_name: 'SimpleObject'
+          has_many :complex_objects, property: :is_part_of, class_name: 'ComplexObject'
+        end
+
+        class ComplexCollection < SimpleCollection
+        end
+
+      end
+      after :all do
+        Object.send(:remove_const, :SimpleObject)
+        Object.send(:remove_const, :ComplexObject)
+        Object.send(:remove_const, :SimpleCollection)
+        Object.send(:remove_const, :ComplexCollection)
+      end
+
+      describe "saving between the before and after hooks" do
+        before do
+          @simple_object = SimpleObject.create
+          @complex_object = ComplexObject.create
+          @simple_collection = SimpleCollection.create
+          @complex_collection = ComplexCollection.create
+
+          @complex_object.simple_collection = @complex_collection
+          @complex_object.save!
+          @simple_object.simple_collection = @simple_collection
+          @simple_object.save!
+          @simple_collection.objects = [@simple_object, @complex_object]
+          @simple_collection.save!
+          @complex_collection.objects = [@simple_object, @complex_object]
+          @complex_collection.save!
+        end
+
+
+        #it "non-casted methods should work and return the specific class" do
+        it "casted association methods should work and return the most complex class" do
+          @complex_object.simple_collection.class == SimpleCollection
+          @complex_object.complex_collection.class == ComplexCollection
+
+          @simple_object.simple_collection.class == SimpleCollection
+          @simple_object.complex_collection == nil
+
+          @complex_collection.objects[0].class == ComplexObject
+          @complex_collection.objects[1].class == ComplexObject
+
+          @simple_collection.objects[0].class == ComplexObject
+          @simple_collection.objects[1].class == ComplexObject
+
+        end
+
+        it "specified ending relationships should ignore classes not specified" do
+          @complex_collection.complex_objects.length == 1
+          @complex_collection.complex_objects[0].class == ComplexObject
+          @complex_collection.complex_objects[1] = nil
+
+          @simple_collection.complex_objects.length == 1
+          @simple_collection.complex_objects[0].class == ComplexObject
+          @simple_collection.complex_objects[1] = nil
+
+        end
+
+        after do
+          @simple_object.delete
+          @complex_object.delete
         end
       end
     end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -28,7 +28,7 @@ describe ActiveFedora::Base do
       end
       describe "assign_pid" do
         it "should use fedora to generate pids" do
-          # TODO: This juggling of Fedora credentials & establishing connections should be handled by an establish_fedora_connection method, 
+          # TODO: This juggling of Fedora credentials & establishing connections should be handled by an establish_fedora_connection method,
           # possibly wrap it all into a fedora_connection method - MZ 06-05-2012
           stubfedora = double("Fedora")
           stubfedora.should_receive(:connection).and_return(double("Connection", :mint =>"sample:newpid"))
@@ -131,15 +131,20 @@ describe ActiveFedora::Base do
       class FooAdaptation < ActiveFedora::Base
         has_metadata :type=>ActiveFedora::OmDatastream, :name=>'someData'
       end
+
+      class FooInherited < FooHistory
+
+      end
     end
 
     after :all do
       Object.send(:remove_const, :FooHistory)
       Object.send(:remove_const, :FooAdaptation)
+      Object.send(:remove_const, :FooInherited)
     end
-    
+
     def increment_pid
-      @@last_pid += 1    
+      @@last_pid += 1
     end
 
     before(:each) do
@@ -161,11 +166,11 @@ describe ActiveFedora::Base do
 
 
     describe '#new' do
-      it "should create an inner object" do  
+      it "should create an inner object" do
         # for doing AFObject.new(params[:foo]) when nothing is in params[:foo]
         Rubydora::DigitalObject.any_instance.should_receive(:save).never
-        result = ActiveFedora::Base.new(nil)  
-        result.inner_object.should be_kind_of(ActiveFedora::UnsavedDigitalObject)    
+        result = ActiveFedora::Base.new(nil)
+        result.inner_object.should be_kind_of(ActiveFedora::UnsavedDigitalObject)
       end
 
       it "should not save or get an pid on init" do
@@ -203,7 +208,7 @@ describe ActiveFedora::Base do
       @test_object.to_param.should == @test_object.pid
     end
 
-    it "should have to_key once it's saved" do 
+    it "should have to_key once it's saved" do
       @test_object.to_key.should be_nil
       @test_object.inner_object.stub(:new? => false)
       @test_object.to_key.should == [@test_object.pid]
@@ -219,8 +224,8 @@ describe ActiveFedora::Base do
       FooHistory.model_name.should == 'FooHistory'
       FooHistory.model_name.human.should == 'Foo history'
     end
-    ### End ActiveModel::Naming 
-    
+    ### End ActiveModel::Naming
+
 
     describe ".datastreams" do
       before do
@@ -272,7 +277,7 @@ describe ActiveFedora::Base do
     describe '#add_relationship' do
       it 'should call #add_relationship on the rels_ext datastream' do
         @test_object.add_relationship("predicate", "info:fedora/object")
-        pred = ActiveFedora::Predicates.vocabularies["info:fedora/fedora-system:def/relations-external#"]["predicate"] 
+        pred = ActiveFedora::Predicates.vocabularies["info:fedora/fedora-system:def/relations-external#"]["predicate"]
         @test_object.relationships.should have_statement(RDF::Statement.new(RDF::URI.new(@test_object.internal_uri), pred, RDF::URI.new("info:fedora/object")))
       end
 
@@ -283,7 +288,7 @@ describe ActiveFedora::Base do
         @test_object.add_relationship(:is_member_of, "info:fedora/demo:5")
         @test_object.add_relationship(:is_member_of, "info:fedora/demo:10")
       end
-      
+
       it 'should add a relationship to an object only if it does not exist already' do
         next_pid = increment_pid.to_s
         ActiveFedora::Base.stub(:assign_pid).and_return(next_pid)
@@ -302,11 +307,11 @@ describe ActiveFedora::Base do
         @test_object.ids_for_outbound(:conforms_to).should == ["AnInterface"]
       end
     end
-    
+
     it 'should provide #remove_relationship' do
       @test_object.should respond_to(:remove_relationship)
     end
-    
+
     describe '#remove_relationship' do
       it 'should remove a relationship from the relationships hash' do
         @test_object3 = ActiveFedora::Base.new()
@@ -333,7 +338,7 @@ describe ActiveFedora::Base do
     describe '#relationships' do
       it 'should return a graph' do
         @test_object.relationships.kind_of?(RDF::Graph).should be_true
-        @test_object.relationships.size.should == 0 
+        @test_object.relationships.size.should == 0
       end
     end
 
@@ -343,7 +348,7 @@ describe ActiveFedora::Base do
         stub_add_ds(@this_pid, ['RELS-EXT'])
         @test_object.assert_content_model
         @test_object.relationships(:has_model).should == ["info:fedora/afmodel:ActiveFedora_Base"]
-        
+
       end
     end
 
@@ -352,14 +357,14 @@ describe ActiveFedora::Base do
         @test_object.stub(:new_record? => true)
         @test_object.should_receive(:create)
         @test_object.should_receive(:update_index)
-        @test_object.save     
+        @test_object.save
       end
 
       it "should update an existing record" do
         @test_object.stub(:new_record? => false)
         @test_object.should_receive(:update_record)
         @test_object.should_receive(:update_index)
-        @test_object.save     
+        @test_object.save
       end
     end
 
@@ -370,7 +375,7 @@ describe ActiveFedora::Base do
         FooHistory.should_receive(:new).and_return(obj)
         @hist = FooHistory.create(:fubar=>'ta', :swank=>'da')
       end
-      
+
     end
 
     describe ".adapt_to" do
@@ -408,17 +413,32 @@ describe ActiveFedora::Base do
       end
     end
 
-    describe ".adapt_to_cmodel" do
-      subject { FooHistory.new } 
-      it "should cast when a cmodel is found" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with( subject).and_return([FooAdaptation])
-        subject.adapt_to_cmodel.should be_kind_of FooAdaptation
+    describe ".adapt_to_cmodel with implemented (non-ActiveFedora::Base) cmodel" do
+      subject { FooHistory.new }
+
+      it "should not cast to a random first cmodel if it has a specific cmodel already" do
+        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation])
+        subject.adapt_to_cmodel.should be_kind_of FooHistory
+      end
+      it "should cast to an inherited model over a random one" do
+        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation, FooInherited])
+        subject.adapt_to_cmodel.should be_kind_of FooInherited
       end
       it "should not cast when a cmodel is same as the class" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with( subject).and_return([FooHistory])
+        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooHistory])
         subject.adapt_to_cmodel.should === subject
       end
     end
+
+    describe ".adapt_to_cmodel with ActiveFedora::Base" do
+      subject { ActiveFedora::Base.new }
+
+      it "should cast to the first cmodel if ActiveFedora::Base (or no specified cmodel)" do
+        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation, FooHistory])
+        subject.adapt_to_cmodel.should be_kind_of FooAdaptation
+      end
+    end
+
 
     describe ".to_solr" do
       it "should provide .to_solr" do
@@ -444,7 +464,7 @@ describe ActiveFedora::Base do
         solr_doc["id"].should be_nil
         solr_doc[ActiveFedora::SolrService.solr_name("has_part", :symbol)].should be_nil
       end
-      
+
       it "should add self.class as the :active_fedora_model" do
         stub_get(@this_pid)
         stub_get_content(@this_pid, ['RELS-EXT', 'someData', 'withText2', 'withText'])
@@ -460,7 +480,7 @@ describe ActiveFedora::Base do
         ngds.should_receive(:solrize_profile)
         mock1.should_receive(:solrize_profile)
         mock2.should_receive(:solrize_profile)
-        
+
         @test_object.should_receive(:datastreams).twice.and_return({:ds1 => mock1, :ds2 => mock2, :ngds => ngds})
         @test_object.should_receive(:solrize_relationships)
         @test_object.to_solr
@@ -468,7 +488,7 @@ describe ActiveFedora::Base do
       it "should call .to_solr on all RDFDatastreams, passing the resulting document to solr" do
         mock = double("ds1", :to_solr => {})
         mock.should_receive(:solrize_profile)
-        
+
         @test_object.should_receive(:datastreams).twice.and_return({:ds1 => mock})
         @test_object.should_receive(:solrize_relationships)
         @test_object.to_solr
@@ -481,16 +501,16 @@ describe ActiveFedora::Base do
         @test_object.should_receive(:solrize_relationships)
         @test_object.to_solr
       end
-      
+
     end
 
     describe ".label" do
-      it "should return the label of the inner object" do 
+      it "should return the label of the inner object" do
         @test_object.inner_object.should_receive(:label).and_return("foo label")
         @test_object.label.should == "foo label"
       end
     end
-    
+
     describe ".label=" do
       it "should set the label of the inner object" do
         @test_object.label.should_not == "foo label"
@@ -498,8 +518,8 @@ describe ActiveFedora::Base do
         @test_object.label.should == "foo label"
       end
     end
-    
-    
+
+
     describe "get_values_from_datastream" do
       it "should look up the named datastream and call get_values with the given pointer/field_name" do
         mock_ds = double("Datastream", :get_values=>["value1", "value2"])
@@ -507,13 +527,13 @@ describe ActiveFedora::Base do
         @test_object.get_values_from_datastream("ds1", "--my xpath--").should == ["value1", "value2"]
       end
     end
-    
+
     describe "update_datastream_attributes" do
       it "should look up any datastreams specified as keys in the given hash and call update_attributes on the datastream" do
         mock_desc_metadata = double("descMetadata")
         mock_properties = double("properties")
         mock_ds_hash = {'descMetadata'=>mock_desc_metadata, 'properties'=>mock_properties}
-        
+
         ds_values_hash = {
           "descMetadata"=>{ [{:person=>0}, :role]=>{"0"=>"role1", "1"=>"role2", "2"=>"role3"} },
           "properties"=>{ "notes"=>"foo" }
@@ -535,12 +555,12 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
         m.to_xml.should == untouched_xml
       end
     end
-    
+
     describe "update_attributes" do
       it "should set the attributes and save" do
         m = FooHistory.new
         att= {"fubar"=> '1234', "baz" =>'stuff'}
-        
+
         m.should_receive(:fubar=).with('1234')
         m.should_receive(:baz=).with('stuff')
         m.should_receive(:save)
@@ -552,14 +572,14 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
       it "should set the attributes and save" do
         m = FooHistory.new
         att= {"fubar"=> '1234', "baz" =>'stuff'}
-        
+
         m.should_receive(:fubar=).with('1234')
         m.should_receive(:baz=).with('stuff')
         m.should_receive(:save)
         m.update(att)
       end
     end
-    
+
     describe "update_indexed_attributes" do
       before do
         Deprecation.should_receive(:warn).at_least(1).times
@@ -567,13 +587,13 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
       it "should call .update_indexed_attributes on all metadata datastreams & nokogiri datastreams" do
         m = FooHistory.new
         att= {"fubar"=>{"-1"=>"mork", "0"=>"york", "1"=>"mangle"}}
-        
+
         m.datastreams['someData'].should_receive(:update_indexed_attributes)
         m.datastreams["withText"].should_receive(:update_indexed_attributes)
         m.datastreams['withText2'].should_receive(:update_indexed_attributes)
         m.update_indexed_attributes(att)
       end
-      it "should take a :datastreams argument" do 
+      it "should take a :datastreams argument" do
         att= {"fubar"=>{"-1"=>"mork", "0"=>"york", "1"=>"mangle"}}
         stub_get(@this_pid)
         stub_get_content(@this_pid, ['RELS-EXT', 'someData', 'withText2', 'withText'])
@@ -583,7 +603,7 @@ pending "This is broken, and deprecated.  I don't want to fix it - jcoyne"
         m.datastreams['someData'].fubar.should == []
         m.datastreams["withText"].fubar.should == ['mork', 'york', 'mangle']
         m.datastreams['withText2'].fubar.should == []
-        
+
         att= {"fubar"=>{"-1"=>"tork", "0"=>"work", "1"=>"bork"}}
         m.update_indexed_attributes(att, :datastreams=>["someData", "withText2"])
         m.should_not be_nil


### PR DESCRIPTION
In Active Fedora, it assumes quite often that a given object will have
only a single valid content model. With models in the community
starting to extend from other models (ie. Sufia or internal models at
BPL), this update makes such cases more sane. Note that this
functionality is only for reading of objects.

For the below bulleted examples, I will assume the following two
models:

```
class GenericFile << ActiveFedora::Base

class ExtendedGenericFile << GenericFile
```
- belongs_to and has_many should automatically cast objects based on
  the base class_name. For example, if one has:
  
  ``````
  ```
  has_many files, class_name: "GenericFile"
  ```
  ``````
  
  In this case, "GenericFile" objects will still be returned as such.
  But "ExtendedGenericFile" objects will be instantiated as that
  class. Note that only the first cmodel order on the
  "ExtendedGenericFile" object is not important as it will attempt
  to use the most specific class available.
- adapt_to_cmodel no longer blindly uses the first cmodel. If an object
  of a class other than ActiveFedora::Base is called with it, it will
  attempt to find a more specific model based on that base model. If
  no more specific model is found, it will return itself.
  
  Otherwise, if the object is loaded of type ActiveFedora::Base,
  it will use the first model, and cast as that unless it finds
  a more specific model registered in the system (based on that
  first model it finds).
- As these are read-only support, relationships are not written
  upon creation. So, to best use these, if one instantiates an
  extended cmodel, one should create the cmodel inheritance in
  their own code at some point. To do this, some psuedo-code
  one needs to do during object creation is:
  
  ``````
  ```
  object_superclass = self.class.superclass
  until object_superclass == ActiveFedora::Base
  || object_Superclass == Object do
    add_relationship(:has_model, object_superclass.to_class_uri)
    object_superclass = object_superclass.superclass
  end
  ```
  ``````
  
  It is ideal to place this in overriding "assert_content_model"
  that is only called on initial object creation.
  
  NOTE: This is not needed to use these changes in most cases.
  It only affects locating extended objects in relationships
  defined as their superclass. For example, using the objects
  above, :has_many of type "GenericFile" won't find
  "ExtendedGenericFile" objects without actually persisting this
  inheritence. This is not an issue if one isn't attempting to
  use extended cmodels (ie. rather than extending GenericFile
  one simply keeps the same name and overwrites it in their system,
  as is done in WGBH's DAM system).
