### PR TITLE
Remove outdated fixture loading line from README. 

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -61,12 +61,6 @@ You need to have a copy of hydra-jetty running.  To do this, download a working 
 java -jar start.jar
 </pre>
 
-Then open a new terminal, go to your ActiveFedora source directory, and import fedora's demo objects.
-
-<pre>
-  rake active_fedora:fixtures environment=test
-</pre>
-
 Now you're ready to run the tests.  In the directory where active_fedora is installed, run
 
 <pre>


### PR DESCRIPTION
I deleted a series of testing instructions that no longer work.
From what I understand, they were leftover from:
https://github.com/projecthydra/active_fedora/pull/102
