### PR TITLE
Id properties should just write to RELS-EXT without causing a load

### DIFF
--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -134,6 +134,16 @@ module ActiveFedora
       alias_method :push, :<<
       alias_method :concat, :<<
 
+      # Remove all records from this association
+      #
+      # See delete for more info.
+      def delete_all
+        delete(load_target).tap do
+          reset
+          loaded!
+        end
+      end
+
       # Removes +records+ from this association calling +before_remove+ and
       # +after_remove+ callbacks.
       #
@@ -342,7 +352,7 @@ module ActiveFedora
 
           records.each { |record| callback(:before_remove, record) }
 
-          delete_records(existing_records) if existing_records.any?
+          delete_records(existing_records, method) if existing_records.any?
           records.each { |record| target.delete(record) }
 
           records.each { |record| callback(:after_remove, record) }

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -52,7 +52,7 @@ module ActiveFedora
           load_target.size
         end
 
-        def delete_records(records)
+        def delete_records(records, method)
           records.each do |r| 
             @owner.remove_relationship(@reflection.options[:property], r)
             

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -79,6 +79,7 @@ module ActiveFedora
     # Reloads the object from Fedora.
     def reload
       clear_association_cache
+      clear_relationships
       init_with(self.class.find(self.pid).inner_object)
     end
 
@@ -207,6 +208,10 @@ module ActiveFedora
 
     #return the internal fedora URI
     def internal_uri
+      self.class.internal_uri(pid)
+    end
+
+    def self.internal_uri(pid)
       "info:fedora/#{pid}" if pid
     end
 

--- a/lib/active_fedora/datastreams.rb
+++ b/lib/active_fedora/datastreams.rb
@@ -16,7 +16,7 @@ module ActiveFedora
       end
 
       before_save :add_disseminator_location_to_datastreams
-      before_save :serialize_datastreams
+      #before_save :serialize_datastreams
     end
 
     def ds_specs

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -41,7 +41,13 @@ module ActiveFedora
       #   Invoice.reflect_on_association(:line_items).macro  # returns :has_many
       #
       def reflect_on_association(association)
-        reflections[association].is_a?(AssociationReflection) ? reflections[association] : nil
+        val = reflections[association].is_a?(AssociationReflection) ? reflections[association] : nil
+        unless val
+          # When a has_many is paired with a has_and_belongs_to_many the assocation will have a plural name 
+          association = association.to_s.pluralize.to_sym
+          val = reflections[association].is_a?(AssociationReflection) ? reflections[association] : nil
+        end
+        val 
       end
 
       class MacroReflection
@@ -171,7 +177,7 @@ module ActiveFedora
           end
         end
 
-        VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_one, :belongs_to]
+        VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_and_belongs_to_many, :belongs_to]
         INVALID_AUTOMATIC_INVERSE_OPTIONS = [:conditions, :through, :polymorphic, :foreign_key]
         
 

--- a/lib/active_fedora/relationship_graph.rb
+++ b/lib/active_fedora/relationship_graph.rb
@@ -3,7 +3,6 @@ module ActiveFedora
 
     attr_accessor :relationships, :dirty
 
-
     def initialize 
       self.dirty = false
       self.relationships = Hash.new { |h, k| h[k] = [] }
@@ -91,6 +90,5 @@ module ActiveFedora
       RDF::Statement.new(subject, predicate, object)
     
     end
-
   end
 end

--- a/lib/active_fedora/semantic_node.rb
+++ b/lib/active_fedora/semantic_node.rb
@@ -4,10 +4,16 @@ module ActiveFedora
     included do
       class_attribute :class_relationships_desc
     end
-    attr_accessor :relationships_loaded, :load_from_solr, :subject
+    attr_accessor :relationships_loaded
+    attr_accessor :load_from_solr, :subject
 
     def assert_kind_of(n, o,t)
       raise "Assertion failure: #{n}: #{o} is not of type #{t}" unless o.kind_of?(t)
+    end
+
+    def clear_relationships
+      @relationships_loaded = false
+      @object_relations = nil
     end
 
     def object_relations
@@ -25,6 +31,7 @@ module ActiveFedora
     # Add a relationship to the Object.
     # @param [Symbol, String] predicate
     # @param [URI, ActiveFedora::Base] target Either a string URI or an object that is a kind of ActiveFedora::Base 
+    # TODO is target ever a AF::Base anymore?
     def add_relationship(predicate, target, literal=false)
       raise ArgumentError, "predicate must be a symbol. You provided `#{predicate.inspect}'" unless predicate.class.in?([Symbol, String])
       object_relations.add(predicate, target, literal)
@@ -116,7 +123,7 @@ module ActiveFedora
     end
 
     def load_relationships
-      self.relationships_loaded = true
+      @relationships_loaded = true
       content = rels_ext.content
       return unless content.present?
       RelsExtDatastream.from_xml content, rels_ext

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -111,6 +111,17 @@ describe "Deleting a dependent relationship" do
   let(:item) { Item.create }
   let(:component) { Component.create }
 
+  it "should remove relationships" do
+    component.item = item
+    component.save!
+    item.components.should == [component]
+    item.components.delete(component)
+    item.reload
+    component.reload
+    component.relationships(:is_part_of).should == []
+    item.components.should == []
+  end
+
   it "should remove the relationships that point at that object" do
     component.item = item
     component.save!


### PR DESCRIPTION
of the referenced object.

```
  Book.new.library_id = 'changeme:1234'
```

should not cause a load of the changeme:1234 object.
