### PR TITLE
Deprecate .find's cast default option

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -98,6 +98,10 @@ module ActiveFedora
       '"' + value.gsub(/(:)/, '\\:').gsub(/(\/)/, '\\/').gsub(/"/, '\\"') + '"'
     end
 
+
+    extend Deprecation
+    self.deprecation_horizon = 'active-fedora 7.0.0'
+
     # Retrieve the Fedora object with the given pid, explore the returned object, determine its model 
     # using #{ActiveFedora::ContentModel.known_models_for} and cast to that class.
     # Raises a ObjectNotFoundError if the object is not found.
@@ -106,7 +110,11 @@ module ActiveFedora
     #
     # @example because the object hydra:dataset1 asserts it is a Dataset (hasModel info:fedora/afmodel:Dataset), return a Dataset object (not a Book).
     #   Book.find_one("hydra:dataset1") 
-    def find_one(pid, cast=false)
+    def find_one(pid, cast=nil)
+      if cast.nil?
+        cast = false
+        Deprecation.warn(Querying, "find_one's cast parameter will default to true", caller)
+      end
       inner = DigitalObject.find(self, pid)
       af_base = self.allocate.init_with(inner)
       cast ? af_base.adapt_to_cmodel : af_base

--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -90,7 +90,10 @@ module ActiveFedora
       relation.order_values += args.flatten
       relation
     end
-    
+
+    extend Deprecation
+    self.deprecation_horizon = 'active-fedora 7.0.0'
+
     # Returns an Array of objects of the Class that +find+ is being 
     # called on
     #
@@ -102,6 +105,9 @@ module ActiveFedora
       options = args.extract_options!
 
       # TODO is there any reason not to cast?
+      if !options.has_key?(:cast)
+        Deprecation.warn(Relation, "find's cast option will default to true", caller)
+      end
       cast = options.delete(:cast)
       if options[:sort]
         # Deprecate sort sometime?

--- a/spec/integration/model_spec.rb
+++ b/spec/integration/model_spec.rb
@@ -44,6 +44,9 @@ describe ActiveFedora::Model do
     end
     describe "#find with a valid pid without cast" do
       subject { ActiveFedora::Base.find(@test_instance.pid) }
+      before(:each) do
+        Deprecation.should_receive(:warn).at_least(1).times
+      end
       it { should be_instance_of ActiveFedora::Base}
     end
   end

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -15,6 +15,15 @@ describe ActiveFedora::Base do
     Object.send(:remove_const, :SpecModel)
   end
   
+  describe '#find_one' do
+    it 'should notify of deprecation if no cast parameter is passed' do
+      Deprecation.should_receive(:warn).at_least(1).times
+      expect {
+        ActiveFedora::Base.find_one('_PID_')
+      }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    end
+  end
+
   describe '#find' do
     describe "without :cast" do
       describe ":all" do


### PR DESCRIPTION
By default ActiveFedora::Base.find assumes cast to be false. This pull
request deprecates that behavior

Related #223
