### PR TITLE
Removed the pid placeholder `__DO_NOT_USE__`

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -71,11 +71,6 @@ module ActiveFedora
       @marked_for_destruction
     end
 
-    def reload(options = nil)
-      @marked_for_destruction = false
-      super
-    end
-
     # Constructor.  You may supply a custom +:pid+, or we call the Fedora Rest API for the
     # next available Fedora pid, and mark as new object.
     # Also, if +attrs+ does not contain +:pid+ but does contain +:namespace+ it will pass the
@@ -96,6 +91,7 @@ module ActiveFedora
 
     # Reloads the object from Fedora.
     def reload
+      raise ActiveFedora::ObjectNotFoundError, "Can't reload an object that hasn't been saved" unless persisted?
       clear_association_cache
       init_with(self.class.find(self.pid, cast: false).inner_object)
     end

--- a/lib/active_fedora/unsaved_digital_object.rb
+++ b/lib/active_fedora/unsaved_digital_object.rb
@@ -4,7 +4,7 @@ module ActiveFedora
     include DigitalObject::DatastreamBootstrap
     attr_accessor :original_class, :ownerId, :state, :datastreams, :label, :namespace
 
-    PLACEHOLDER = '__DO_NOT_USE__'
+    PLACEHOLDER = nil
     
     def initialize(original_class, namespace, pid=nil)
       @pid = pid

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -147,8 +147,8 @@ describe ActiveFedora::NtriplesRDFDatastream do
     end
 
     it "should write rdf with proper subjects" do
-      @subject.rdf.type = "Frog"
       @subject.inner_object.pid = 'test:99'
+      @subject.rdf.type = "Frog"
       @subject.save!
       @subject.reload
       @subject.rdf.graph.dump(:ntriples).should == "<http://oregondigital.org/ns/99> <http://purl.org/dc/terms/type> \"Frog\" .\n"

--- a/spec/unit/base_extra_spec.rb
+++ b/spec/unit/base_extra_spec.rb
@@ -60,7 +60,7 @@ describe ActiveFedora::Base do
     it "should delete object from repository and index" do
       @test_object.inner_object.stub(:delete)
       mock_conn = double("SolrConnection")
-      mock_conn.should_receive(:delete_by_id).with("__DO_NOT_USE__") 
+      mock_conn.should_receive(:delete_by_id).with(nil) 
       mock_conn.should_receive(:commit)
       mock_ss = double("SolrService")
       mock_ss.stub(:conn).and_return(mock_conn)

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -202,10 +202,9 @@ describe ActiveFedora::Base do
 
     ### Methods for ActiveModel::Conversions
     it "should have to_param once it's saved" do
-
       @test_object.to_param.should be_nil
-      @test_object.inner_object.stub(:new? => false)
-      @test_object.to_param.should == @test_object.pid
+      @test_object.inner_object.stub(:new? => false, :pid => 'foo:123')
+      @test_object.to_param.should == 'foo:123'
     end
 
     it "should have to_key once it's saved" do
@@ -448,12 +447,13 @@ describe ActiveFedora::Base do
       it "should add pid, system_create_date, system_modified_date and object_state from object attributes" do
         @test_object.should_receive(:create_date).and_return("2012-03-04T03:12:02Z")
         @test_object.should_receive(:modified_date).and_return("2012-03-07T03:12:02Z")
+        @test_object.stub(pid: 'changeme:123')
         @test_object.state = "D"
         solr_doc = @test_object.to_solr
         solr_doc[ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)].should eql("2012-03-04T03:12:02Z")
         solr_doc[ActiveFedora::SolrService.solr_name("system_modified", :stored_sortable, type: :date)].should eql("2012-03-07T03:12:02Z")
         solr_doc[ActiveFedora::SolrService.solr_name("object_state", :stored_sortable)].should eql("D")
-        solr_doc[:id].should eql("#{@test_object.pid}")
+        solr_doc[:id].should eql("changeme:123")
       end
 
       it "should omit base metadata and RELS-EXT if :model_only==true" do

--- a/spec/unit/datastream_spec.rb
+++ b/spec/unit/datastream_spec.rb
@@ -19,7 +19,7 @@ describe ActiveFedora::Datastream do
   end
   
   it "should be inspectable" do
-    @test_datastream.inspect.should match /#<ActiveFedora::Datastream @pid=\"__DO_NOT_USE__\" @dsid=\"abcd\" @controlGroup=\"M\" changed=\"true\" @mimeType=\"\" >/
+    @test_datastream.inspect.should match /#<ActiveFedora::Datastream @pid=\"\" @dsid=\"abcd\" @controlGroup=\"M\" changed=\"true\" @mimeType=\"\" >/
   end
 
   describe '#validate_content_present' do

--- a/spec/unit/semantic_node_spec.rb
+++ b/spec/unit/semantic_node_spec.rb
@@ -90,7 +90,7 @@ describe ActiveFedora::SemanticNode do
       it "should not be written into the graph until it is saved" do
         @n1 = ActiveFedora::Base.new
         @node.add_relationship(:has_part, @n1)
-        @node.relationships.statements.to_a.first.object.to_s.should == 'info:fedora/__DO_NOT_USE__' 
+        @node.relationships.statements.to_a.first.object.to_s.should == 'info:fedora/' 
         @n1.save
         @node.relationships.statements.to_a.first.object.to_s.should == @n1.internal_uri
       end

--- a/spec/unit/solr_config_options_spec.rb
+++ b/spec/unit/solr_config_options_spec.rb
@@ -27,8 +27,9 @@ describe ActiveFedora do
       SOLR_DOCUMENT_ID = "id"
     end
     it "should be used by ActiveFedora::Base.to_solr" do
+      @test_object.stub(pid: 'changeme:123')
       SOLR_DOCUMENT_ID = "MY_SAMPLE_ID"
-      @test_object.to_solr[SOLR_DOCUMENT_ID.to_sym].should_not be_nil
+      @test_object.to_solr[SOLR_DOCUMENT_ID.to_sym].should == 'changeme:123'
       @test_object.to_solr[:id].should be_nil
     end
 

--- a/spec/unit/unsaved_digital_object_spec.rb
+++ b/spec/unit/unsaved_digital_object_spec.rb
@@ -16,8 +16,8 @@ describe ActiveFedora::UnsavedDigitalObject do
       @obj.ownerId.should == 'D'
     end
 
-    it "should have a default pid" do
-      @obj.pid.should == "__DO_NOT_USE__"
+    it "should not have a default pid" do
+      @obj.pid.should be_nil
     end
     it "should be able to set the pid" do
       @obj.pid = "my:new_object"


### PR DESCRIPTION
This is a crusty old relic and interferes with drawing nested
attribute forms.
