### PR TITLE
Added has_attributes to replace delegate_to

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -345,7 +345,6 @@ module ActiveFedora
   end
 
   Base.class_eval do
-    include Attributes
     include ActiveFedora::Persistence
     extend ActiveSupport::DescendantsTracker
     extend Model
@@ -354,6 +353,7 @@ module ActiveFedora
     include ActiveModel::Conversion
     include Validations
     include Callbacks
+    include Attributes
     include Datastreams
     extend ActiveModel::Naming
     include Delegating

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -145,7 +145,7 @@ module ActiveFedora
     def condition_to_clauses(key, value)
       unless value.nil?
         # if the key is a property name, turn it into a solr field
-        if self.delegates.key?(key)
+        if self.defined_attributes.key?(key)
           # TODO Check to see if `key' is a possible solr field for this class, if it isn't try :searchable instead
           key = ActiveFedora::SolrService.solr_name(key, :stored_searchable, type: :string)
         end

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "delegating attributes" do
+  before :all do
+    class TitledObject < ActiveFedora::Base
+      has_metadata 'foo', type: ActiveFedora::SimpleDatastream do |m|
+        m.field "title", :string
+      end
+      has_attributes :title, datastream: 'foo', multiple: false
+    end
+  end
+  after :all do
+    Object.send(:remove_const, :TitledObject)
+  end
+
+  describe "save" do
+    subject do
+      obj = TitledObject.create 
+      obj.title = "Hydra for Dummies"
+      obj.save
+      obj
+    end
+    it "should keep a list of changes after a successful save" do
+      subject.previous_changes.should_not be_empty
+      subject.previous_changes.keys.should include("title")
+    end
+    it "should clean out changes" do
+      subject.title_changed?.should be_false
+      subject.changes.should be_empty
+    end
+  end
+end
+


### PR DESCRIPTION
We don't want to conflate attributes stored in the repository with delegating
to methods. There are certain actions like change tracking or casting to
a singular value (multiple: false) that we only want to do on persisted
attributes.  The previous implementation could break in certain cases when
developers attempted to use ActiveSupport's delegate method.
