### PR TITLE
Remove loading of rake tasks because they are already loaded in the railtie

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -174,7 +174,6 @@ module ActiveFedora #:nodoc:
 end
 
 
-load File.join(File.dirname(__FILE__),"tasks/active_fedora.rake") if defined?(Rake)
 I18n.load_path << File.dirname(__FILE__) + '/active_fedora/locale/en.yml'
 
 require 'active_fedora/railtie' if defined?(Rails)


### PR DESCRIPTION
active_fedora.rake was being loaded both in lib/active_fedora.rb and lib/active_fedora/railtie.rb.  This led to double definitions of the rake tasks and double invocation when running them from a Rails app.
