### PR TITLE
Adding more verbose logging to specs

### DIFF
--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -30,6 +30,7 @@ require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:rspec) do |spec|
     spec.pattern = FileList['spec/**/*_spec.rb']
     spec.pattern += FileList['spec/*_spec.rb']
+    spec.rspec_opts = ['--backtrace']
   end
 
   RSpec::Core::RakeTask.new(:rcov) do |spec|


### PR DESCRIPTION
This could be very helpful for Travis builds
And I need to test if the RDF gem is the culprit of a modify frozen
string error. Or the ActiveFedora gem. Or if it is isolated to Curate.
