### PR TITLE
has_attributes should raise an exception if the datastream property

### DIFF
--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -84,10 +84,10 @@ module ActiveFedora
         @defined_attributes = val
       end
 
-      # TODO check that the datastream attribute is set
       def has_attributes(*fields)
         options = fields.pop
         datastream = options.delete(:datastream)
+        raise ArgumentError, "You must provide a datastream to has_attributes" unless datastream
         define_attribute_methods fields
         fields.each do |f|
           create_attribute_reader(f, datastream, options)

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -193,6 +193,22 @@ describe ActiveFedora::Base do
       end
     end
   end 
+
+  describe "without a datastream" do
+    before :all do
+      class BarHistory4 < ActiveFedora::Base
+      end
+    end
+
+    after :all do
+      Object.send(:remove_const, :BarHistory4)
+    end
+
+    subject { BarHistory4}
+    it "should raise an error" do
+      expect {subject.has_attributes :title, :description, multiple: true}.to raise_error
+    end
+  end
 end
 
 


### PR DESCRIPTION
isn't specified.

Fixes #265
