### PR TITLE
Extracting .best_model_for from AF::Base

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -270,17 +270,7 @@ module ActiveFedora
     # cases above exists in the :has_model, then instantiate as that extended
     # model type instead.
     def adapt_to_cmodel
-      best_model_match = self.class unless self.instance_of? ActiveFedora::Base
-
-      ActiveFedora::ContentModel.known_models_for( self ).each do |model_value|
-        # If this is of type ActiveFedora::Base, then set to the first found :has_model.
-        best_model_match ||= model_value
-
-        # If there is an inheritance structure, use the most specific case.
-        if best_model_match > model_value
-          best_model_match = model_value
-        end
-      end
+      best_model_match = ActiveFedora::ContentModel.best_model_for(self)
 
       self.instance_of?(best_model_match) ? self : self.adapt_to(best_model_match)
     end

--- a/lib/active_fedora/content_model.rb
+++ b/lib/active_fedora/content_model.rb
@@ -21,6 +21,22 @@ module ActiveFedora
       obj.relationships(:has_model)
     end
     
+    def self.best_model_for(obj)
+      best_model_match = obj.class unless obj.instance_of? ActiveFedora::Base
+
+      known_models_for(obj).each do |model_value|
+        # If this is of type ActiveFedora::Base, then set to the first found :has_model.
+        best_model_match ||= model_value
+
+        # If there is an inheritance structure, use the most specific case.
+        if best_model_match > model_value
+          best_model_match = model_value
+        end
+      end
+
+      best_model_match
+    end
+
     # returns an array of the model classes that are defined in the current 
     # application that the given object asserts (ie. if the object asserts 
     # a StreamingVideo model but the application doesn't define a 

--- a/spec/unit/content_model_spec.rb
+++ b/spec/unit/content_model_spec.rb
@@ -50,6 +50,25 @@ describe ActiveFedora::ContentModel do
     @test_cmodel.should respond_to(:pid_suffix=)
   end
   
+  describe '.best_model_for' do
+    it 'should be the input model if no relationships' do
+      mock_object = BaseModel.new
+      mock_object.should_receive(:relationships).with(:has_model).and_return([])
+      expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq BaseModel
+    end
+
+    it 'should be based on inheritance hierarchy' do
+      mock_object = ActiveFedora::Base.new
+      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
+      expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq SampleModel
+    end
+
+    it 'should find the deepest descendant of the on inheritance hierarchy' do
+      mock_object = BaseModel.new
+      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
+      expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq SampleModel
+    end
+  end
   
   describe "models_asserted_by" do
     it "should return an array of all of the content models asserted by the given object" do


### PR DESCRIPTION
I have a use case in which I want the object's best model but don't
want it cast to that model. By extracting this behavior, I have access
to that behavior.
