### PR TITLE
Deprecate Base.pids_from_uris

### DIFF
--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -25,6 +25,7 @@ module ActiveFedora
   #
   class Base
     include SemanticNode
+    extend Deprecation
 
     class_attribute :fedora_connection, :profile_solr_name
     self.fedora_connection = {}
@@ -295,15 +296,14 @@ module ActiveFedora
       self.init_with DigitalObject.find(self.class,self.pid)
     end
     
+    # @param [String,Array] uris a single uri (as a string) or a list of uris to convert to pids
+    # @returns [String] the pid component of the URI
     def self.pids_from_uris(uris) 
-      if uris.class == String
-        return uris.gsub("info:fedora/", "")
-      elsif uris.class == Array
-        arr = []
-        uris.each do |uri|
-          arr << uri.gsub("info:fedora/", "")
-        end
-        return arr
+      Deprecation.warn(Base, "pids_from_uris has been deprecated and will be removed in active-fedora 8.0.0", caller)
+      if uris.kind_of? String
+        pid_from_uri(uris)
+      else
+        Array(uris).map {|uri| pid_from_uri(uri)}
       end
     end
 

--- a/lib/active_fedora/semantic_node.rb
+++ b/lib/active_fedora/semantic_node.rb
@@ -132,7 +132,7 @@ module ActiveFedora
     def ids_for_outbound(predicate)
       (object_relations[predicate] || []).map do |o|
         o = o.to_s if o.kind_of? RDF::Literal
-        o.kind_of?(String) ? o.gsub("info:fedora/", "") : o.pid
+        o.kind_of?(String) ? self.class.pid_from_uri(o) : o.pid
       end
     end
 
@@ -177,6 +177,13 @@ module ActiveFedora
 
 
     module ClassMethods
+
+      # @param [String] uri a uri (as a string)
+      # @returns [String] the pid component of the URI
+      def pid_from_uri(uri)
+        uri.gsub("info:fedora/", "")
+      end
+
       # Return hash that persists relationship metadata defined by has_relationship calls.  If you implement a child class of ActiveFedora::Base it will inherit
       # the relationship descriptions defined there by merging in the class
       # instance variable values.  It will also do this for any level of 


### PR DESCRIPTION
Added pid_from_uri to SemanticNode::ClassMethods which pids_from_uris
will use and cleaned up semantic_node_spec.
