### PR TITLE
Force RDF data to be UTF-8

### DIFF
--- a/lib/active_fedora/rdf_datastream.rb
+++ b/lib/active_fedora/rdf_datastream.rb
@@ -73,7 +73,7 @@ module ActiveFedora
       return repository if new? and data.nil?
 
       data ||= datastream_content
-
+      data.force_encoding('utf-8')
       RDF::Reader.for(serialization_format).new(data) do |reader|
         reader.each_statement do |statement|
           repository << statement

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 describe ActiveFedora::RDFDatastream do
@@ -51,6 +52,17 @@ describe ActiveFedora::RDFDatastream do
 
     it "should have a list of fields" do
       MyDatastream.fields.should == [:title, :description]
+    end
+  end
+
+  describe "deserialize" do
+    it "should be able to handle non-utf-8 characters" do
+      # see https://github.com/ruby-rdf/rdf/issues/142
+      ds = ActiveFedora::NtriplesRDFDatastream.new
+      data = "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT')
+      
+      result = ds.deserialize(data)
+      result.dump(:ntriples).should == "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n’ \" .\n"
     end
   end
 end


### PR DESCRIPTION
The RDF reader chokes on certain character combinations if the raw data
is not encoded UTF-8.  See https://github.com/ruby-rdf/rdf/issues/142
Fedora does not store character encoding, so by default they come back as
ASCII-8BIT.
