### PR TITLE
Add a way to get the primary solr name for a field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Bundler will rely on active-fedora.gemspec for dependency information.
 

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -22,6 +22,7 @@ module ActiveFedora #:nodoc:
   class AssociationTypeMismatch < RuntimeError; end # :nodoc:
   class UnregisteredPredicateError < RuntimeError; end # :nodoc:
   class RecordNotSaved < RuntimeError; end # :nodoc:
+  class IllegalOperation < RuntimeError; end # :nodoc:
 
 
   eager_autoload do
@@ -35,6 +36,7 @@ module ActiveFedora #:nodoc:
     autoload :Config
     autoload :Core
     autoload :Datastream
+    autoload :DatastreamAttribute
     autoload :DatastreamHash
     autoload :Datastreams
     autoload :DigitalObject

--- a/lib/active_fedora/datastream_attribute.rb
+++ b/lib/active_fedora/datastream_attribute.rb
@@ -1,0 +1,61 @@
+module ActiveFedora
+  # Represents the mapping between a model attribute and a field in a datastream
+  class DatastreamAttribute
+    
+    attr_accessor :dsid, :field, :klass, :at, :reader, :writer, :multiple
+
+    def initialize(field, dsid, klass, args={})
+      self.field = field
+      self.dsid = dsid
+      self.klass = klass
+      self.multiple = args[:multiple].nil? ? false : args[:multiple]
+      self.at = args[:at]
+
+      initialize_reader!
+      initialize_writer!
+    end
+
+    # Gives the primary solr name for a column. If there is more than one indexer on the field definition, it gives the first 
+    def primary_solr_name
+      if klass.respond_to?(:primary_solr_name)
+        klass.primary_solr_name(dsid, field)
+      else
+        raise IllegalOperation, "the class '#{klass}' doesn't respond to 'primary_solr_name'"
+      end
+    end
+
+    private
+
+    def initialize_writer!
+      this = self
+      self.writer = lambda do |v|
+        ds = datastream_for_attribute(this.dsid)
+        mark_as_changed(this.field) if value_has_changed?(this.field, v)
+        if ds.kind_of?(ActiveFedora::RDFDatastream)
+          ds.send("#{this.field}=", v)
+        else
+          terminology = this.at || [this.field]
+          ds.send(:update_indexed_attributes, {terminology => v})
+        end
+      end
+    end
+
+    def initialize_reader!
+      this = self
+      self.reader = lambda do |*opts|
+        ds = datastream_for_attribute(this.dsid)
+        if ds.kind_of?(ActiveFedora::RDFDatastream)
+          ds.send(this.field)
+        else
+          terminology = this.at || [this.field]
+          if terminology.length == 1 && opts.present?
+            ds.send(terminology.first, *opts)
+          else
+            ds.send(:term_values, *terminology)
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/active_fedora/rdf_node.rb
+++ b/lib/active_fedora/rdf_node.rb
@@ -161,13 +161,9 @@ module ActiveFedora
     end
 
 
-    def config_for_term_or_uri(term)
-      case term
-      when RDF::URI
-        self.class.config.each { |k, v| return v if v.predicate == term}
-      else
-        self.class.config[term.to_sym]
-      end
+    # In Rails 4 you can do "delegate :config_for_term_or_uri, :class", but in rails 3 it breaks.
+    def config_for_term_or_uri(val)
+      self.class.config_for_term_or_uri(val)
     end
 
     # @param [Symbol, RDF::URI] term predicate  the predicate to insert into the graph
@@ -298,6 +294,15 @@ module ActiveFedora
           ActiveFedora::RdfNode.rdf_registry[uri] = self
         end
         @rdf_type
+      end
+
+      def config_for_term_or_uri(term)
+        case term
+        when RDF::URI
+          config.each { |k, v| return v if v.predicate == term}
+        else
+          config[term.to_sym]
+        end
       end
 
       def config_for_predicate(predicate)

--- a/spec/integration/field_to_solr_name_spec.rb
+++ b/spec/integration/field_to_solr_name_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "An object with RDF backed attributes" do
+
+  before do
+    class TestOne < ActiveFedora::Base
+      class MyMetadata < ActiveFedora::NtriplesRDFDatastream
+        map_predicates do |map|
+          map.title(in: RDF::DC) do |index|
+            index.as :stored_searchable
+          end
+        end
+      end
+      has_metadata 'descMetadata', type: MyMetadata
+      has_attributes :title, datastream: 'descMetadata'
+    end
+  end
+
+  after do 
+    Object.send(:remove_const, :TestOne)
+  end
+
+  it "should be able to grab the solr name" do
+    expect(TestOne.defined_attributes[:title].primary_solr_name).to eq 'desc_metadata__title_tesim'
+  end
+end

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -178,6 +178,12 @@ describe ActiveFedora::NtriplesRDFDatastream do
       @subject.should respond_to(:to_solr)
       @subject.to_solr.should be_kind_of(Hash)
     end
+
+    it "should have a solr_name method" do
+      expect(MyDatastream.primary_solr_name('descMetadata', :based_near)).to eq 'desc_metadata__based_near_sim'
+      expect(MyDatastream.primary_solr_name('props', :title)).to eq 'props__title_tesim'
+    end
+
     it "should optionally allow you to provide the Solr::Document to add fields to and return that document when done" do
       doc = Hash.new
       @subject.to_solr(doc).should == doc


### PR DESCRIPTION
This will enable simpler Blacklight configurations and will eventually
support looking up fields from solr instead of calling to fedora.
