### PR TITLE
Added Base#to_json and Base#attributes.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -62,8 +62,9 @@ module ActiveFedora #:nodoc:
     autoload :Relation
     autoload :RelationshipGraph
     autoload :RelsExtDatastream
-    autoload :ServiceDefinitions
     autoload :SemanticNode
+    autoload :ServiceDefinitions
+    autoload :Serialization
     autoload :Sharding
     autoload :SimpleDatastream
     autoload :SolrDigitalObject

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -20,6 +20,10 @@ module ActiveFedora
       end
     end
 
+    def attributes
+      self.class.defined_attributes.keys.each_with_object({"id" => id}) {|key, hash| hash[key] = self[key]}
+    end
+
     # Calling inspect may trigger a bunch of loads, but it's mainly for debugging, so no worries.
     def inspect
       values = self.class.defined_attributes.keys.map {|r| "#{r}:#{send(r).inspect}"}

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -42,6 +42,7 @@ module ActiveFedora
     include NestedAttributes
     include Reflection
     include ActiveModel::Dirty
+    include Serialization
     include Core
     include FedoraAttributes
   end

--- a/lib/active_fedora/datastreams.rb
+++ b/lib/active_fedora/datastreams.rb
@@ -89,8 +89,7 @@ module ActiveFedora
         datastream.instance_variable_set :@dsid, generate_dsid(prefix)
       end
       datastreams[datastream.dsid] = datastream
-      self.class.build_datastream_accessor(datastream.dsid) unless respond_to? datastream.dsid
-      return datastream.dsid
+      datastream.dsid
     end
 
     # @return [Array] all datastreams that return true for `metadata?` and are not Rels-ext
@@ -145,7 +144,9 @@ module ActiveFedora
       attrs[:checksumType] = opts[:checksumType] if opts[:checksumType]
       attrs[:versionable] = opts[:versionable] unless opts[:versionable].nil?
       ds = create_datastream(self.class.datastream_class_for_name(opts[:dsid]), opts[:dsid], attrs)
-      add_datastream(ds)
+      add_datastream(ds).tap do |dsid|
+        self.class.build_datastream_accessor(dsid) unless respond_to? dsid
+      end
     end
     
     

--- a/lib/active_fedora/serialization.rb
+++ b/lib/active_fedora/serialization.rb
@@ -1,0 +1,19 @@
+module ActiveFedora #:nodoc:
+  # = Active Fedora Serialization
+  module Serialization
+    extend ActiveSupport::Concern
+    include ActiveModel::Serializers::JSON
+
+    included do
+      self.include_root_in_json = false
+    end
+
+    def serializable_hash(options = nil)
+      options = options.try(:clone) || {}
+
+      options[:except] = Array(options[:except]).map { |n| n.to_s }
+
+      super(options)
+    end
+  end
+end

--- a/spec/integration/json_serialization_spec.rb
+++ b/spec/integration/json_serialization_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "Objects should be serialized to JSON" do
+  it "should have json results" do
+    ActiveFedora::Base.new.to_json.should == "{\"id\":null}"
+  end
+
+  describe "with a more interesting model" do
+    before do
+      class Foo < ActiveFedora::Base
+        has_metadata 'descMetadata', type: ActiveFedora::SimpleDatastream do |m|
+          m.field "foo", :text
+          m.field "bar", :text
+        end
+        has_attributes :foo, datastream: 'descMetadata', multiple: true
+        has_attributes :bar, datastream: 'descMetadata', multiple: false
+      end
+    end
+    after do
+      Object.send(:remove_const, :Foo)
+    end
+    subject { Foo.new(foo: "baz", bar: 'quix') }
+    before { subject.stub(pid: 'test:123') }
+    it "should have to_json" do
+      json = JSON.parse(subject.to_json)
+      expect(json['id']).to eq "test:123"
+      expect(json['foo']).to eq ["baz"]
+      expect(json['bar']).to eq "quix"
+    end
+  end
+end

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -132,6 +132,14 @@ describe ActiveFedora::Base do
       end
     end
 
+    describe "attributes" do
+      let(:vals) { {'cow'=>["moo"], 'pig' => ['oink'], 'horse' =>['neigh'], "fubar"=>[], 'duck'=>['quack'] } }
+      before { subject.attributes = vals }
+      it "should return a hash" do
+        expect(subject.attributes).to eq(vals.merge('id' => nil))
+      end
+    end
+
   end
 
   describe "with a superclass" do

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -227,21 +227,27 @@ describe ActiveFedora::Base do
 
 
     describe ".datastreams" do
-      before do
-        @test_history = FooHistory.new
+      let(:test_history) { FooHistory.new }
+      it "should create accessors for datastreams declared with has_metadata" do
+        test_history.withText.should == test_history.datastreams['withText']
       end
-      it "should create dynamic accessors" do
-        @test_history.withText.should == @test_history.datastreams['withText']
-      end
-      it "dynamic accessors should convert dashes to underscores" do
-        ds = double('datastream', :dsid=>'eac-cpf')
-        @test_history.add_datastream(ds)
-        @test_history.eac_cpf.should == ds
-      end
-      it "dynamic accessors should not convert datastreams named with underscore" do
-        ds = double('datastream', :dsid=>'foo_bar')
-        @test_history.add_datastream(ds)
-        @test_history.foo_bar.should == ds
+      describe "dynamic accessors" do
+        before do
+          test_history.add_datastream(ds)
+          test_history.class.build_datastream_accessor(ds.dsid)
+        end
+        describe "when the datastream is named with dash" do
+          let(:ds) {double('datastream', :dsid=>'eac-cpf')}
+          it "should convert dashes to underscores" do
+            test_history.eac_cpf.should == ds
+          end
+        end
+        describe "when the datastream is named with underscore" do
+          let (:ds) { double('datastream', :dsid=>'foo_bar') }
+          it "should preserve the underscore" do
+            test_history.foo_bar.should == ds
+          end
+        end
       end
     end
 

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -221,6 +221,10 @@ describe ActiveFedora::NtriplesRDFDatastream do
         @obj.rights = "Totally open, y'all"
         @obj.save
       end
+      after do
+        Object.send(:remove_const, :Foo)
+      end
+
 
       describe ".fields()" do
         it "should return the right fields" do


### PR DESCRIPTION
`ActiveFedora::Base#attributes` is required to support the #to_json
method, but it's useful in it's own right.

In order to accomplish this, we had to remove auto-generating datastream
accessor methods when `ActiveFedora::Base#add_datastream` is called.  If
you want an accessor for your datastream (and you aren't using `has_metadata`
or `has_file_datastream`) then you should call
`self.class.build_datastream_accessor(dsid)`
