### PR TITLE
ActiveFedora::SolrService.reify_solr_result modified to pass Solr hit to...

### DIFF
--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -48,7 +48,7 @@ module ActiveFedora
     def self.reify_solr_result(hit, opts = {})
       klass = class_from_solr_document(hit)
       if opts[:load_from_solr]
-        klass.load_instance_from_solr(hit[SOLR_DOCUMENT_ID])
+        klass.load_instance_from_solr(hit[SOLR_DOCUMENT_ID], hit)
       else
         klass.find(hit[SOLR_DOCUMENT_ID], cast: true)
       end

--- a/spec/unit/solr_service_spec.rb
+++ b/spec/unit/solr_service_spec.rb
@@ -49,6 +49,17 @@ describe ActiveFedora::SolrService do
                            {"id"=>"my:_PID2_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["info:fedora/afmodel:AudioRecord"]},
                            {"id"=>"my:_PID3_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["info:fedora/afmodel:AudioRecord"]}]
     end
+    describe ".reify_solr_result" do
+      it "should use .find to instantiate objects" do
+        AudioRecord.should_receive(:find).with("my:_PID1_", cast: true)
+        ActiveFedora::SolrService.reify_solr_result(@sample_solr_hits.first)
+      end
+      it "should use .load_instance_from_solr when called with :load_from_solr option" do
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits.first)
+        ActiveFedora::SolrService.should_not receive(:query)
+        ActiveFedora::SolrService.reify_solr_result(@sample_solr_hits.first, load_from_solr: true)
+      end
+    end
     describe ".reify_solr_results" do
       it "should use AudioRecord.find to instantiate objects" do
         AudioRecord.should_receive(:find).with("my:_PID1_", cast: true)
@@ -57,9 +68,10 @@ describe ActiveFedora::SolrService do
         ActiveFedora::SolrService.reify_solr_results(@sample_solr_hits)
       end
       it "should use AudioRecord.load_instance_from_solr when called with :load_from_solr option" do
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_")
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_")
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_")
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
+        ActiveFedora::SolrService.should_not receive(:query)
         ActiveFedora::SolrService.reify_solr_results(@sample_solr_hits, load_from_solr: true)
       end
     end
@@ -71,9 +83,10 @@ describe ActiveFedora::SolrService do
         ActiveFedora::SolrService.lazy_reify_solr_results(@sample_solr_hits).each {|r| r}
       end
       it "should use AudioRecord.load_instance_from_solr when called with :load_from_solr option" do
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_")
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_")
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_")
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
+        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
+        ActiveFedora::SolrService.should_not receive(:query)
         ActiveFedora::SolrService.lazy_reify_solr_results(@sample_solr_hits, load_from_solr: true).each {|r| r}
       end
     end


### PR DESCRIPTION
... load_instance_from_solr when called with :load_from_solr, which eliminates extra Solr query.
