### PR TITLE
Add hash options to CollectionAssociation#load_from_solr

### DIFF
--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+  before do
+    class Library < ActiveFedora::Base 
+      has_many :books, property: :has_member
+    end
+    class Book < ActiveFedora::Base; end
+  end
+  after do
+    Object.send(:remove_const, :Library)
+    Object.send(:remove_const, :Book)
+  end
+  describe "load_from_solr" do
+    before do
+      @library = Library.create
+      3.times { @library.books << Book.create }
+      @books = double(@library.books)
+    end
+    after do
+      @library.books.each { |b| b.delete }
+      @library.delete
+    end
+    it "should set rows to count, if not specified" do
+      @library.books(response_format: :solr).size.should == 3
+    end
+    it "should limit rows returned if option passed" do
+      @library.books(response_format: :solr, rows: 1).size.should == 1
+    end
+  end
+end


### PR DESCRIPTION
CollectionAssociation#load_from_solr accepts a hash of options to pass through to ActiveFedora::SolrService.query, and by default sets the :rows option to CollectionAssociation#count -- i.e., to return all results.
In order to stay "safe" CollectionAssociation#find_target explicitly passes :rows=>1000, which retains the current
behavior.  However, now when the assocation reader is called with :response_format=>:solr (and w/o :rows), all the results will be returned.  This permits the following:

``` ruby
ActiveFedora::SolrService.lazy_reify_solr_results(association(response_format: :solr))
```

so that code can lazily iterate over all the target objects.
