### PR TITLE
add scoping. Remove metaprogramming.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -26,6 +26,7 @@ module ActiveFedora #:nodoc:
 
 
   eager_autoload do
+    autoload :AssociationRelation
     autoload :Associations
     autoload :Attributes
     autoload :Auditable
@@ -47,6 +48,7 @@ module ActiveFedora #:nodoc:
     autoload :NestedAttributes
     autoload :NomDatastream
     autoload :NtriplesRDFDatastream
+    autoload :NullRelation
     autoload :OmDatastream
     autoload :Property
     autoload :Persistence
@@ -60,8 +62,17 @@ module ActiveFedora #:nodoc:
     autoload :RdfxmlRDFDatastream
     autoload :Reflection
     autoload :Relation
+
+    autoload_under 'relation' do
+      autoload :Delegation
+      autoload :SpawnMethods
+      autoload :QueryMethods
+      autoload :FinderMethods
+    end
+
     autoload :RelationshipGraph
     autoload :RelsExtDatastream
+    autoload :Scoping
     autoload :SemanticNode
     autoload :ServiceDefinitions
     autoload :Serialization
@@ -77,7 +88,17 @@ module ActiveFedora #:nodoc:
     autoload :Validations
     autoload :SolrInstanceLoader
   end
-  
+
+  module Scoping
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :Default
+      autoload :Named
+    end
+  end
+
+
   
   include Loggable
   

--- a/lib/active_fedora/association_relation.rb
+++ b/lib/active_fedora/association_relation.rb
@@ -1,0 +1,18 @@
+module ActiveFedora
+  class AssociationRelation < Relation
+    def initialize(klass, association)
+      super(klass)
+      @association = association
+    end
+
+    def proxy_association
+      @association
+    end
+
+    private
+
+    def exec_queries
+      super.each { |r| @association.set_inverse_instance r }
+    end
+  end
+end

--- a/lib/active_fedora/associations.rb
+++ b/lib/active_fedora/associations.rb
@@ -6,6 +6,7 @@ module ActiveFedora
     extend ActiveSupport::Concern
 
     autoload :Association,           'active_fedora/associations/association'
+    autoload :AssociationScope,      'active_fedora/associations/association_scope'
     autoload :SingularAssociation,   'active_fedora/associations/singular_association'
     autoload :CollectionAssociation, 'active_fedora/associations/collection_association'
     autoload :CollectionProxy,       'active_fedora/associations/collection_proxy'

--- a/lib/active_fedora/associations/association.rb
+++ b/lib/active_fedora/associations/association.rb
@@ -61,9 +61,21 @@ module ActiveFedora
         loaded!
       end
 
-      # def scoped
-      #   target_scope.merge(@association_scope)
-      # end
+      def scope
+        target_scope.merge(association_scope)
+      end
+
+      # The scope for this association.
+      #
+      # Note that the association_scope is merged into the target_scope only when the
+      # scope method is called. This is because at that point the call may be surrounded
+      # by scope.scoping { ... } or with_scope { ... } etc, which affects the scope which
+      # actually gets built.
+      def association_scope
+        if klass
+          @association_scope ||= AssociationScope.new(self).scope
+        end
+      end
       
       # Set the inverse association, if possible
       def set_inverse_instance(record)
@@ -71,6 +83,13 @@ module ActiveFedora
           inverse = record.association(inverse_reflection_for(record).name)
           inverse.target = owner
         end
+      end
+
+      
+      # Can be overridden (i.e. in ThroughAssociation) to merge in other scopes (i.e. the
+      # through association's scope)
+      def target_scope
+        klass.all
       end
 
       # Loads the \target if needed and returns it.

--- a/lib/active_fedora/associations/association_scope.rb
+++ b/lib/active_fedora/associations/association_scope.rb
@@ -1,0 +1,33 @@
+module ActiveFedora
+  module Associations
+    class AssociationScope #:nodoc:
+
+      attr_reader :association
+      
+      delegate :klass, :owner, :reflection, :interpolate, :to => :association
+      delegate :chain, :scope_chain, :options, :source_options, :active_record, :to => :reflection
+
+      def initialize(association)
+        @association = association
+      end
+
+      
+      def scope
+        scope = klass.unscoped
+        add_constraints(scope)
+      end
+
+      private
+      def add_constraints(scope)
+        chain.each_with_index do |reflection, i|
+          is_first_chain = i == 0
+          klass = is_first_chain ? self.klass : reflection.klass
+          scope.where_values[options[:property]] = owner.id
+        end
+
+        scope
+      end
+
+    end
+  end
+end

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -92,6 +92,17 @@ module ActiveFedora
         concat(other_array.select { |v| !current.include?(v) })
       end
       
+      def include?(record)
+        if record.is_a?(reflection.klass)
+          if record.new_record?
+            target.include?(record)
+          else
+            loaded? ? target.include?(record) : scope.exists?(record)
+          end
+        else
+          false
+        end
+      end
 
       def to_ary
         load_target.dup
@@ -273,6 +284,15 @@ module ActiveFedora
         record
       end
 
+      def scope(opts = {})
+        scope = super()
+        scope.none! if opts.fetch(:nullify, true) && null_scope?
+        scope
+      end
+
+      def null_scope?
+        owner.new_record? && !foreign_key_present?
+      end
       protected
         def reset_target!
           @target = Array.new

--- a/lib/active_fedora/associations/collection_proxy.rb
+++ b/lib/active_fedora/associations/collection_proxy.rb
@@ -33,12 +33,7 @@ module ActiveFedora
     #
     # is computed directly through SQL and does not trigger by itself the
     # instantiation of the actual post records.
-    class CollectionProxy # :nodoc:
-      alias :proxy_extend :extend
-
-      #TODO remove using: https://github.com/rails/rails/commit/c86a32d7451c5d901620ac58630460915292f88b#diff-bee622c17de67f292adf310f75288e25
-      instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|object_id|to_a)$|^__|^respond_to|proxy_/ }
-
+    class CollectionProxy < Relation # :nodoc:
       delegate :group, :order, :limit, :joins, :where, :preload, :eager_load, :includes, :from,
                :lock, :readonly, :having, :to => :scoped
 
@@ -54,7 +49,8 @@ module ActiveFedora
 
       def initialize(association)
         @association = association
-        Array(association.options[:extend]).each { |ext| proxy_extend(ext) }
+        super association.klass
+        merge! association.scope
       end
 
       def respond_to?(*args)

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -29,6 +29,7 @@ module ActiveFedora
     include SemanticNode
     include Sharding
     include ActiveFedora::Persistence
+    include Scoping
     include Loggable
     include Indexing
     include ActiveModel::Conversion

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -1,5 +1,7 @@
 module ActiveFedora
   module Core
+    extend ActiveSupport::Concern
+    
     attr_reader :inner_object
 
     # Constructor.  You may supply a custom +:pid+, or we call the Fedora Rest API for the
@@ -139,5 +141,11 @@ module ActiveFedora
       self.init_with DigitalObject.find(self.class,self.pid)
     end
     
+    module ClassMethods
+      private
+      def relation
+        Relation.new(self)
+      end
+    end
   end
 end

--- a/lib/active_fedora/null_relation.rb
+++ b/lib/active_fedora/null_relation.rb
@@ -1,0 +1,7 @@
+module ActiveFedora
+  module NullRelation # :nodoc:
+    def exists?(_id = false)
+      false
+    end
+  end
+end

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -1,15 +1,10 @@
 module ActiveFedora
   module Querying
-    delegate :find, :first, :where, :limit, :order, :all, :delete_all, :destroy_all, :count, :last, :to=>:relation
+    delegate :find, :first, :exists?, :where, :limit, :order, :delete_all, :destroy_all, :count, :last, :to=>:all
 
     def self.extended(base)
       base.class_attribute  :solr_query_handler
       base.solr_query_handler = 'standard'
-    end
-    
-
-    def relation
-      Relation.new(self)
     end
 
     # Yields each batch of solr records that was found by the find +options+ as
@@ -72,16 +67,6 @@ module ActiveFedora
       end
     end
 
-
-    # Returns true if the pid exists in the repository
-    # @param[String] pid
-    # @return[boolean]
-    def exists?(pid)
-      return false if pid.nil? || pid.empty?
-      !!DigitalObject.find(self, pid)
-    rescue ActiveFedora::ObjectNotFoundError
-      false
-    end
 
     # Returns a solr result matching the supplied conditions
     # @param[Hash,String] conditions can either be specified as a string, or 

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -165,9 +165,11 @@ module ActiveFedora
           @foreign_key ||= options[:foreign_key] || derive_foreign_key
         end
 
-        # def primary_key_name
-        #   @primary_key_name ||= options[:foreign_key] || derive_primary_key_name
-        # end
+        # A chain of reflections from this one back to the owner. For more see the explanation in
+        # ThroughReflection.
+        def chain
+          [self]
+        end
 
         def inverse_of
           return unless inverse_name

--- a/lib/active_fedora/relation/delegation.rb
+++ b/lib/active_fedora/relation/delegation.rb
@@ -1,0 +1,12 @@
+module ActiveFedora
+  module Delegation # :nodoc:
+    extend ActiveSupport::Concern
+
+    # This module creates compiled delegation methods dynamically at runtime, which makes
+    # subsequent calls to that method faster by avoiding method_missing. The delegations
+    # may vary depending on the klass of a relation, so we create a subclass of Relation
+    # for each different klass, and the delegations are compiled into that subclass only.
+    
+    delegate :length, :collect, :map, :each, :all?, :include?, :to_ary, :to => :to_a
+  end
+end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -1,0 +1,15 @@
+module ActiveFedora
+  module FinderMethods
+    # Returns true if the pid exists in the repository
+    # @param[String] pid
+    # @return[boolean]
+    def exists?(conditions)
+      conditions = conditions.id if Base === conditions
+      return false if !conditions
+      !!DigitalObject.find(self.klass, conditions)
+    rescue ActiveFedora::ObjectNotFoundError
+      false
+    end
+
+  end
+end

--- a/lib/active_fedora/relation/merger.rb
+++ b/lib/active_fedora/relation/merger.rb
@@ -1,0 +1,21 @@
+module ActiveFedora
+  class Relation
+    class HashMerger # :nodoc:
+    end
+
+    class Merger # :nodoc:
+      attr_reader :relation, :values, :other
+
+      def initialize(relation, other)
+        @relation = relation
+        @values   = other.values
+        @other    = other
+      end
+
+      def merge
+        # TODO merge where and order
+        relation
+      end
+    end
+  end
+end

--- a/lib/active_fedora/relation/query_methods.rb
+++ b/lib/active_fedora/relation/query_methods.rb
@@ -1,0 +1,54 @@
+module ActiveFedora
+  module QueryMethods # :nodoc:
+
+    def extending_values
+      @values[:extending] || []
+    end
+
+    def extending_values=(values)
+      raise ImmutableRelation if @loaded
+      @values[:extending] = values
+    end
+
+    def where_values
+      @values[:where] || {}
+    end
+
+    def where_values=(values)
+      raise ImmutableRelation if @loaded
+      @values[:where] = values
+    end   
+
+    def order_values
+      @values[:order] || []
+    end
+
+    def order_values=(values)
+      raise ImmutableRelation if @loaded
+      @values[:order] = values
+    end   
+
+    def limit_value
+      @values[:limit]
+    end
+
+    def limit_value=(value)
+      raise ImmutableRelation if @loaded
+      @values[:limit] = value
+    end   
+
+    def none! # :nodoc:
+      extending!(NullRelation)
+    end
+
+    def extending!(*modules, &block) # :nodoc:
+      modules << Module.new(&block) if block
+      modules.flatten!
+
+      self.extending_values += modules
+      extend(*extending_values) if extending_values.any?
+
+      self
+    end
+  end
+end

--- a/lib/active_fedora/relation/spawn_methods.rb
+++ b/lib/active_fedora/relation/spawn_methods.rb
@@ -1,0 +1,46 @@
+require 'active_fedora/relation/merger'
+
+module ActiveFedora
+  module SpawnMethods
+
+    # This is overridden by Associations::CollectionProxy
+    def spawn #:nodoc:
+      clone
+    end
+
+    # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an <tt>ActiveRecord::Relation</tt>.
+    # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
+    #   Post.where(published: true).joins(:comments).merge( Comment.where(spam: false) )
+    #   # Performs a single join query with both where conditions.
+    #
+    #   recent_posts = Post.order('created_at DESC').first(5)
+    #   Post.where(published: true).merge(recent_posts)
+    #   # Returns the intersection of all published posts with the 5 most recently created posts.
+    #   # (This is just an example. You'd probably want to do this with a single query!)
+    #
+    # Procs will be evaluated by merge:
+    #
+    #   Post.where(published: true).merge(-> { joins(:comments) })
+    #   # => Post.where(published: true).joins(:comments)
+    #
+    # This is mainly intended for sharing common conditions between multiple associations.
+    def merge(other)
+      if other.is_a?(Array)
+        to_a & other
+      elsif other
+        spawn.merge!(other)
+      else
+        self
+      end
+    end
+
+    def merge!(other) # :nodoc:
+      if !other.is_a?(Relation) && other.respond_to?(:to_proc)
+        instance_exec(&other)
+      else
+        klass = other.is_a?(Hash) ? Relation::HashMerger : Relation::Merger
+        klass.new(self, other).merge
+      end
+    end
+  end
+end

--- a/lib/active_fedora/scoping.rb
+++ b/lib/active_fedora/scoping.rb
@@ -1,0 +1,20 @@
+module ActiveFedora
+  module Scoping
+    extend ActiveSupport::Concern
+    included do
+      include Default
+      include Named
+    end
+
+    
+    module ClassMethods
+      def current_scope #:nodoc:
+        Thread.current["#{self}_current_scope"]
+      end
+
+      def current_scope=(scope) #:nodoc:
+        Thread.current["#{self}_current_scope"] = scope
+      end
+    end
+  end
+end

--- a/lib/active_fedora/scoping/default.rb
+++ b/lib/active_fedora/scoping/default.rb
@@ -1,0 +1,38 @@
+module ActiveFedora
+  module Scoping
+    module Default
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Returns a scope for the model without the +default_scope+.
+        #
+        #   class Post < ActiveRecord::Base
+        #     def self.default_scope
+        #       where published: true
+        #     end
+        #   end
+        #
+        #   Post.all          # Fires "SELECT * FROM posts WHERE published = true"
+        #   Post.unscoped.all # Fires "SELECT * FROM posts"
+        #
+        # This method also accepts a block. All queries inside the block will
+        # not use the +default_scope+:
+        #
+        #   Post.unscoped {
+        #     Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
+        #   }
+        #
+        # It is recommended that you use the block form of unscoped because
+        # chaining unscoped with +scope+ does not work. Assuming that
+        # +published+ is a +scope+, the following two statements
+        # are equal: the +default_scope+ is applied on both.
+        #
+        #   Post.unscoped.published
+        #   Post.published
+        def unscoped
+          block_given? ? relation.scoping { yield } : relation
+        end
+      end
+    end
+  end
+end

--- a/lib/active_fedora/scoping/named.rb
+++ b/lib/active_fedora/scoping/named.rb
@@ -1,0 +1,32 @@
+module ActiveFedora
+  # = Active Fedora \Named \Scopes
+  module Scoping
+    module Named
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Returns an <tt>ActiveFedora::Relation</tt> scope object.
+        #
+        #   posts = Post.all
+        #   posts.size # Fires "select count(*) from  posts" and returns the count
+        #   posts.each {|p| puts p.name } # Fires "select * from posts" and loads post objects
+        #
+        #   fruits = Fruit.all
+        #   fruits = fruits.where(color: 'red') if options[:red_only]
+        #   fruits = fruits.limit(10) if limited?
+        #
+        # You can define a scope that applies to all finders using
+        # <tt>ActiveRecord::Base.default_scope</tt>.
+        def all
+          if current_scope
+            current_scope.clone
+          else
+            scope = relation
+            scope.default_scoped = true
+            scope
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -215,10 +215,6 @@ describe ActiveFedora::Base do
           @library.books << @book << Book.create 
           @library.save
 
-          # @book.library.pid.should == @library.pid
-          # @library.books.reload
-          # @library.books.should == [@book]
-
           @library2 = Library.find(@library.pid)
           @library2.books.size.should == 2
         end

--- a/spec/integration/model_spec.rb
+++ b/spec/integration/model_spec.rb
@@ -28,7 +28,7 @@ describe ActiveFedora::Model do
   
   describe "#all" do
     it "should return an array of instances of the calling Class" do
-      result = ModelIntegrationSpec::Basic.all
+      result = ModelIntegrationSpec::Basic.all.to_a
       result.should be_instance_of(Array)
       # this test is meaningless if the array length is zero
       result.length.should > 0

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -38,7 +38,7 @@ describe "scoped queries" do
     
     describe ".all" do
       it "should return an array of instances of the calling Class" do
-        result = ModelIntegrationSpec::Basic.all
+        result = ModelIntegrationSpec::Basic.all.to_a
         result.should be_instance_of(Array)
         # this test is meaningless if the array length is zero
         result.length.should > 0

--- a/spec/unit/has_and_belongs_to_many_collection_spec.rb
+++ b/spec/unit/has_and_belongs_to_many_collection_spec.rb
@@ -1,13 +1,27 @@
 require 'spec_helper'
 
 describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
+  before do 
+    class Book < ActiveFedora::Base
+    end
+    class Page < ActiveFedora::Base
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Book)
+    Object.send(:remove_const, :Page)
+  end
+
   it "should call add_relationship" do
-    subject = double("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a', :ids_for_outbound => [])
-    predicate = double(:klass => double.class, :options=>{:property=>'predicate'}, :class_name=> nil)
+    subject = Book.new(pid: 'subject:a')
+    subject.stub(:new_record? => false, save: true)
+    predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate'}, nil)
     ActiveFedora::SolrService.stub(:query).and_return([])
     ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
     ac.should_receive(:callback).twice
-    object = double("object", :new_record? => false, :pid => 'object:b', :save => nil)
+    object = Page.new(:pid => 'object:b')
+    object.stub(:new_record? => false, save: true)
   
     subject.should_receive(:add_relationship).with('predicate', object)
  
@@ -16,12 +30,14 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
   end
 
   it "should call add_relationship on subject and object when inverse_of given" do
-    subject = double("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a', :ids_for_outbound => [])
-    predicate = double(:klass => double.class, :options=>{:property=>'predicate', :inverse_of => 'inverse_predicate'}, :class_name=> nil)
+    subject = Book.new(pid: 'subject:a')
+    subject.stub(:new_record? => false, save: true)
+    predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate', :inverse_of => 'inverse_predicate'}, nil)
     ActiveFedora::SolrService.stub(:query).and_return([])
     ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
     ac.should_receive(:callback).twice
-    object = double("object", :new_record? => false, :pid => 'object:b', :save => nil)
+    object = Page.new(:pid => 'object:b')
+    object.stub(:new_record? => false, save: true)
   
     subject.should_receive(:add_relationship).with('predicate', object)
  
@@ -33,8 +49,9 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
 
   it "should call solr query multiple times" do
 
-    subject = double("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a', :ids_for_outbound => [])
-    predicate = double(:klass => double.class, :options=>{:property=>'predicate', solr_page_size:10}, :class_name=> nil)
+    subject = Book.new(pid: 'subject:a')
+    subject.stub(:new_record? => false, save: true)
+    predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate', :solr_page_size => 10}, nil)
     ids = []
     0.upto(15) {|i| ids << i.to_s}
     query1 = ids.slice(0,10).map {|i| "_query_:\"{!raw f=id}#{i}\""}.join(" OR ")

--- a/spec/unit/has_many_collection_spec.rb
+++ b/spec/unit/has_many_collection_spec.rb
@@ -1,13 +1,27 @@
 require 'spec_helper'
 
 describe ActiveFedora::Associations::HasManyAssociation do
+  before do 
+    class Book < ActiveFedora::Base
+    end
+    class Page < ActiveFedora::Base
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Book)
+    Object.send(:remove_const, :Page)
+  end
+
   it "should call add_relationship" do
-    subject = double("subject", :new_record? => false, :pid => 'subject:a', :internal_uri => 'info:fedora/subject:a')
-    predicate = double(:klass => double.class, :options=>{:property=>'predicate'}, :class_name=> nil)
+    subject = Book.new(pid: 'subject:a')
+    subject.stub(:new_record? => false, save: true)
+    predicate = Book.create_reflection(:has_many, 'pages', {:property=>'predicate'}, nil)
     ActiveFedora::SolrService.stub(:query).and_return([])
     ac = ActiveFedora::Associations::HasManyAssociation.new(subject, predicate)
     ac.should_receive(:callback).twice
-    object = double("object", :new_record? => false, :pid => 'object:b', :save => nil)
+    object = Page.new(:pid => 'object:b')
+    object.stub(:new_record? => false, save: true)
   
     object.should_receive(:add_relationship).with('predicate', subject)
  


### PR DESCRIPTION
This brings ActiveFedora into parity with a more recent version of
ActiveRecord
