### PR TITLE
Move query methods onto the relation instead of the class.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -64,6 +64,7 @@ module ActiveFedora #:nodoc:
     autoload :Relation
 
     autoload_under 'relation' do
+      autoload :Calculations
       autoload :Delegation
       autoload :SpawnMethods
       autoload :QueryMethods

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -59,6 +59,11 @@ module ActiveFedora
         @loaded = false
       end
 
+      def find(*args)
+        puts "Scope is #{scope}"
+        scope.find(*args)
+      end
+
       def first(*args)
         first_or_last(:first, *args)
       end

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -1,159 +1,19 @@
 module ActiveFedora
   module Querying
-    delegate :find, :first, :exists?, :where, :limit, :order, :delete_all, :destroy_all, :count, :last, :to=>:all
+    delegate :find, :first, :exists?, :where, :limit, :order, :delete_all, 
+      :destroy_all, :count, :last, :find_with_conditions, :find_in_batches, :find_each, :to=>:all
 
     def self.extended(base)
       base.class_attribute  :solr_query_handler
       base.solr_query_handler = 'standard'
     end
 
-    # Yields each batch of solr records that was found by the find +options+ as
-    # an array. The size of each batch is set by the <tt>:batch_size</tt>
-    # option; the default is 1000.
-    #
-    # Returns a solr result matching the supplied conditions
-    # @param[Hash] conditions solr conditions to match
-    # @param[Hash] options 
-    # @option opts [Array] :sort a list of fields to sort by 
-    # @option opts [Array] :rows number of rows to return
-    #
-    # @example
-    #  Person.find_in_batches('age_t'=>'21', {:batch_size=>50}) do |group|
-    #  group.each { |person| puts person['name_t'] }
-    #  end
-    
-    def find_in_batches conditions, opts={}
-      opts[:q] = create_query(conditions)
-      opts[:qt] = solr_query_handler
-      #set default sort to created date ascending
-      unless opts[:sort].present?
-        opts[:sort]= default_sort_params
-      end
-
-      batch_size = opts.delete(:batch_size) || 1000
-
-      counter = 0
-      begin
-        counter += 1
-        response = ActiveFedora::SolrService.instance.conn.paginate counter, batch_size, "select", :params => opts
-        docs = response["response"]["docs"]
-        yield docs
-      end while docs.has_next? 
-    end
-
-    def calculate(calculation, conditions, opts={})
-      SolrService.query(create_query(conditions), :raw=>true, :rows=>0)['response']['numFound']
-    end
-
     def default_sort_params
       [ActiveFedora::SolrService.solr_name(:system_create, :stored_sortable, type: :date)+' asc'] 
     end
 
-    # Yields the found ActiveFedora::Base object to the passed block
-    #
-    # @param [Hash] conditions the conditions for the solr search to match
-    # @param [Hash] opts 
-    # @option opts [Boolean] :cast when true, examine the model and cast it to the first known cModel
-    def find_each( conditions={}, opts={})
-      cast = opts.delete(:cast)
-      find_in_batches(conditions, opts.merge({:fl=>SOLR_DOCUMENT_ID})) do |group|
-        group.each do |hit|
-          begin 
-            yield(find_one(hit[SOLR_DOCUMENT_ID], cast))
-          rescue ActiveFedora::ObjectNotFoundError
-            logger.error "When trying to find_each #{hit[SOLR_DOCUMENT_ID]}, encountered an ObjectNotFoundError. Solr may be out of sync with Fedora"
-          end
-        end
-      end
-    end
-
-
-    # Returns a solr result matching the supplied conditions
-    # @param[Hash,String] conditions can either be specified as a string, or 
-    # hash representing the query part of an solr statement. If a hash is 
-    # provided, this method will generate conditions based simple equality
-    # combined using the boolean AND operator.
-    # @param[Hash] options 
-    # @option opts [Array] :sort a list of fields to sort by 
-    # @option opts [Array] :rows number of rows to return
-    def find_with_conditions(conditions, opts={})
-      #set default sort to created date ascending
-      unless opts.include?(:sort)
-        opts[:sort]=default_sort_params
-      end
-      SolrService.query(create_query(conditions), opts) 
-    end
-
     def quote_for_solr(value)
       '"' + value.gsub(/(:)/, '\\:').gsub(/(\/)/, '\\/').gsub(/"/, '\\"') + '"'
-    end
-
-    # Retrieve the Fedora object with the given pid, explore the returned object, determine its model 
-    # using #{ActiveFedora::ContentModel.known_models_for} and cast to that class.
-    # Raises a ObjectNotFoundError if the object is not found.
-    # @param [String] pid of the object to load
-    # @param [Boolean] cast when true, cast the found object to the class of the first known model defined in it's RELS-EXT
-    #
-    # @example because the object hydra:dataset1 asserts it is a Dataset (hasModel info:fedora/afmodel:Dataset), return a Dataset object (not a Book).
-    #   Book.find_one("hydra:dataset1") 
-    def find_one(pid, cast=nil)
-      cast = true if self == ActiveFedora::Base && cast.nil?
-      inner = DigitalObject.find(self, pid)
-      af_base = self.allocate.init_with(inner)
-      cast ? af_base.adapt_to_cmodel : af_base
-    end
-    
-    private 
-
-    # Returns a solr query for the supplied conditions
-    # @param[Hash] conditions solr conditions to match
-    def create_query(conditions)
-      conditions.kind_of?(Hash) ? create_query_from_hash(conditions) : create_query_from_string(conditions)
-    end
-
-    def create_query_from_hash(conditions)
-      clauses = search_model_clause ?  [search_model_clause] : []
-      conditions.each_pair do |key,value|
-        clauses << condition_to_clauses(key, value)
-      end
-      return "*:*" if clauses.empty?
-      clauses.compact.join(" AND ")
-    end
-
-    def condition_to_clauses(key, value)
-      unless value.nil?
-        # if the key is a property name, turn it into a solr field
-        if self.defined_attributes.key?(key)
-          # TODO Check to see if `key' is a possible solr field for this class, if it isn't try :searchable instead
-          key = ActiveFedora::SolrService.solr_name(key, :stored_searchable, type: :string)
-        end
-
-        if value.empty?
-          "-#{key}:['' TO *]"
-        elsif value.is_a? Array
-          value.map { |val| "#{key}:#{quote_for_solr(val)}" }
-        else
-          key = SOLR_DOCUMENT_ID if (key === :id || key === :pid)
-          escaped_value = quote_for_solr(value)
-          key.to_s.eql?(SOLR_DOCUMENT_ID) ? "#{key}:#{escaped_value}" : "#{key}:#{escaped_value}"
-        end
-      end
-    end
-
-    def create_query_from_string(conditions)
-      model_clause = search_model_clause
-      if model_clause 
-        conditions ? "#{model_clause} AND (#{conditions})" : model_clause
-      else
-        conditions
-      end
-    end
-
-    # Return the solr clause that queries for this type of class
-    def search_model_clause
-      unless self == ActiveFedora::Base
-        return ActiveFedora::SolrService.construct_query_for_rel(:has_model => self.to_class_uri)
-      end
     end
   end
 end

--- a/lib/active_fedora/relation/calculations.rb
+++ b/lib/active_fedora/relation/calculations.rb
@@ -1,0 +1,19 @@
+module ActiveFedora
+  module Calculations
+
+    # Get a count of the number of objects from solr
+    # Takes :conditions as an argument
+    def count(*args)
+      return apply_finder_options(args.first).count  if args.any?
+      opts = {}
+      opts[:rows] = limit_value if limit_value
+      opts[:sort] = order_values if order_values
+      
+      calculate :count, where_values, opts
+    end
+
+    def calculate(calculation, conditions, opts={})
+      SolrService.query(create_query(conditions), :raw=>true, :rows=>0)['response']['numFound']
+    end
+  end
+end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -1,5 +1,65 @@
 module ActiveFedora
   module FinderMethods
+
+    # Returns the first records that was found.
+    #
+    # @example
+    #  Person.where(name_t: 'Jones').first
+    #    => #<Person @id="foo:123" @name='Jones' ... >
+    def first
+      if loaded?
+        @records.first
+      else
+        @first ||= limit(1).to_a[0]
+      end
+    end
+
+    # Returns the last record sorted by id.  ID was chosen because this mimics
+    # how ActiveRecord would achieve the same behavior.
+    #
+    # @example
+    #  Person.where(name_t: 'Jones').last
+    #    => #<Person @id="foo:123" @name='Jones' ... >
+    def last
+      if loaded?
+        @records.last
+      else
+        @last ||= order('id desc').limit(1).to_a[0]
+      end
+    end
+
+    # Returns an Array of objects of the Class that +find+ is being 
+    # called on
+    #
+    # @param[String,Hash] args either a pid or a hash of conditions
+    # @option args [Integer] :rows when :all is passed, the maximum number of rows to load from solr
+    # @option args [Boolean] :cast when true, examine the model and cast it to the first known cModel
+    def find(*args)
+      return to_a.find { |*block_args| yield(*block_args) } if block_given?
+      options = args.extract_options!
+      options = options.dup
+
+      cast = if @klass == ActiveFedora::Base && !options.has_key?(:cast)
+        true
+      else 
+        options.delete(:cast)
+      end
+      if options[:sort]
+        # Deprecate sort sometime?
+        sort = options.delete(:sort) 
+        options[:order] ||= sort if sort.present?
+      end
+
+      if options.present?
+        options = args.first unless args.empty?
+        options = {conditions: options}
+        apply_finder_options(options)
+      else
+        raise ArgumentError, "#{self}.find() expects a pid. You provided `#{args.inspect}'" unless args.is_a? Array
+        find_with_ids(args, cast)
+      end
+    end
+
     # Returns true if the pid exists in the repository
     # @param[String] pid
     # @return[boolean]
@@ -9,6 +69,167 @@ module ActiveFedora
       !!DigitalObject.find(self.klass, conditions)
     rescue ActiveFedora::ObjectNotFoundError
       false
+    end
+
+    # Returns a solr result matching the supplied conditions
+    # @param[Hash,String] conditions can either be specified as a string, or 
+    # hash representing the query part of an solr statement. If a hash is 
+    # provided, this method will generate conditions based simple equality
+    # combined using the boolean AND operator.
+    # @param[Hash] options 
+    # @option opts [Array] :sort a list of fields to sort by 
+    # @option opts [Array] :rows number of rows to return
+    def find_with_conditions(conditions, opts={})
+      #set default sort to created date ascending
+      unless opts.include?(:sort)
+        opts[:sort]=@klass.default_sort_params
+      end
+      SolrService.query(create_query(conditions), opts) 
+    end
+
+    # Yields the found ActiveFedora::Base object to the passed block
+    #
+    # @param [Hash] conditions the conditions for the solr search to match
+    # @param [Hash] opts 
+    # @option opts [Boolean] :cast when true, examine the model and cast it to the first known cModel
+    def find_each( conditions={}, opts={})
+      cast = opts.delete(:cast)
+      find_in_batches(conditions, opts.merge({:fl=>SOLR_DOCUMENT_ID})) do |group|
+        group.each do |hit|
+          begin 
+            yield(find_one(hit[SOLR_DOCUMENT_ID], cast))
+          rescue ActiveFedora::ObjectNotFoundError
+            logger.error "When trying to find_each #{hit[SOLR_DOCUMENT_ID]}, encountered an ObjectNotFoundError. Solr may be out of sync with Fedora"
+          end
+        end
+      end
+    end
+
+    # Yields each batch of solr records that was found by the find +options+ as
+    # an array. The size of each batch is set by the <tt>:batch_size</tt>
+    # option; the default is 1000.
+    #
+    # Returns a solr result matching the supplied conditions
+    # @param[Hash] conditions solr conditions to match
+    # @param[Hash] options 
+    # @option opts [Array] :sort a list of fields to sort by 
+    # @option opts [Array] :rows number of rows to return
+    #
+    # @example
+    #  Person.find_in_batches('age_t'=>'21', {:batch_size=>50}) do |group|
+    #  group.each { |person| puts person['name_t'] }
+    #  end
+    
+    def find_in_batches conditions, opts={}
+      opts[:q] = create_query(conditions)
+      opts[:qt] = @klass.solr_query_handler
+      #set default sort to created date ascending
+      unless opts[:sort].present?
+        opts[:sort]= @klass.default_sort_params
+      end
+
+      batch_size = opts.delete(:batch_size) || 1000
+
+      counter = 0
+      begin
+        counter += 1
+        response = ActiveFedora::SolrService.instance.conn.paginate counter, batch_size, "select", :params => opts
+        docs = response["response"]["docs"]
+        yield docs
+      end while docs.has_next? 
+    end
+
+    # Retrieve the Fedora object with the given pid, explore the returned object, determine its model 
+    # using #{ActiveFedora::ContentModel.known_models_for} and cast to that class.
+    # Raises a ObjectNotFoundError if the object is not found.
+    # @param [String] pid of the object to load
+    # @param [Boolean] cast when true, cast the found object to the class of the first known model defined in it's RELS-EXT
+    #
+    # @example because the object hydra:dataset1 asserts it is a Dataset (hasModel info:fedora/afmodel:Dataset), return a Dataset object (not a Book).
+    #   Book.find_one("hydra:dataset1") 
+    def find_one(pid, cast=nil)
+      cast = true if self == ActiveFedora::Base && cast.nil?
+      inner = DigitalObject.find(@klass, pid)
+      af_base = @klass.allocate.init_with(inner)
+      cast ? af_base.adapt_to_cmodel : af_base
+    end
+    
+    protected
+
+
+    def find_with_ids(ids, cast)
+      expects_array = ids.first.kind_of?(Array)
+      return ids.first if expects_array && ids.first.empty?
+
+      ids = ids.flatten.compact.uniq
+
+      case ids.size
+      when 0
+        raise ArgumentError, "Couldn't find #{@klass.name} without an ID"
+      when 1
+        result = find_one(ids.first, cast)
+        expects_array ? [ result ] : result
+      else
+        find_some(ids, cast)
+      end
+    end
+
+    def find_some(ids, cast)
+      ids.map{|id| find_one(id, cast)}
+    end
+
+
+    private 
+
+    # Returns a solr query for the supplied conditions
+    # @param[Hash] conditions solr conditions to match
+    def create_query(conditions)
+      conditions.kind_of?(Hash) ? create_query_from_hash(conditions) : create_query_from_string(conditions)
+    end
+
+    def create_query_from_hash(conditions)
+      clauses = search_model_clause ?  [search_model_clause] : []
+      conditions.each_pair do |key,value|
+        clauses << condition_to_clauses(key, value)
+      end
+      return "*:*" if clauses.empty?
+      clauses.compact.join(" AND ")
+    end
+
+    def condition_to_clauses(key, value)
+      unless value.nil?
+        # if the key is a property name, turn it into a solr field
+        if @klass.defined_attributes.key?(key)
+          # TODO Check to see if `key' is a possible solr field for this class, if it isn't try :searchable instead
+          key = ActiveFedora::SolrService.solr_name(key, :stored_searchable, type: :string)
+        end
+
+        if value.empty?
+          "-#{key}:['' TO *]"
+        elsif value.is_a? Array
+          value.map { |val| "#{key}:#{@klass.quote_for_solr(val)}" }
+        else
+          key = SOLR_DOCUMENT_ID if (key === :id || key === :pid)
+          escaped_value = @klass.quote_for_solr(value)
+          key.to_s.eql?(SOLR_DOCUMENT_ID) ? "#{key}:#{escaped_value}" : "#{key}:#{escaped_value}"
+        end
+      end
+    end
+
+    def create_query_from_string(conditions)
+      model_clause = search_model_clause
+      if model_clause 
+        conditions ? "#{model_clause} AND (#{conditions})" : model_clause
+      else
+        conditions
+      end
+    end
+
+    # Return the solr clause that queries for this type of class
+    def search_model_clause
+      unless @klass == ActiveFedora::Base
+        return ActiveFedora::SolrService.construct_query_for_rel(:has_model => @klass.to_class_uri)
+      end
     end
 
   end

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -9,50 +9,37 @@ describe ActiveFedora::Base do
       belongs_to :library, property: :has_member
     end
   end
+  let(:library) { Library.create! }
+  let!(:book1) { Book.create!(library: library) }
+  let!(:book2) { Book.create!(library: library) }
   after do
+    Book.delete_all
+    Library.delete_all
     Object.send(:remove_const, :Library)
     Object.send(:remove_const, :Book)
   end
   describe "load_from_solr" do
-    before do
-      @library = Library.create
-      3.times { @library.books << Book.create }
-    end
-    after do
-      @library.books.each { |b| b.delete }
-      @library.delete
-    end
     it "should set rows to count, if not specified" do
-      @library.books(response_format: :solr).size.should == 3
+      library.books(response_format: :solr).size.should == 2
     end
     it "should limit rows returned if option passed" do
-      @library.books(response_format: :solr, rows: 1).size.should == 1
+      library.books(response_format: :solr, rows: 1).size.should == 1
     end
   end
 
   describe "#delete_all" do
-    before do
-      @library = Library.create!
-      @book1 = Book.create!(library: @library)
-      @book2 = Book.create!(library: @library)
-    end
     it "should delete em" do
       expect {
-        @library.books.delete_all
-      }.to change { @library.books.count}.by(-2)
+        library.books.delete_all
+      }.to change { library.books.count }.by(-2)
     end
   end
 
   describe "#destroy_all" do
-    before do
-      @library = Library.create!
-      @book1 = Book.create!(library: @library)
-      @book2 = Book.create!(library: @library)
-    end
     it "should delete em" do
       expect {
-        @library.books.destroy_all
-      }.to change { @library.books.count}.by(-2)
+        library.books.destroy_all
+      }.to change { library.books.count }.by(-2)
     end
   end
 end


### PR DESCRIPTION
This will enable us to start chaining relations together like this:

``` ruby
Library.find('test:123').books.where(author:
'Salinger').find('test:231')
```

(this doesn't yet work, but this reorganization is prerequisite for that
functionality)
