### PR TITLE
Fix ActiveFedora under Ruby 2.1.

### DIFF
--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -141,13 +141,7 @@ module ActiveFedora
       if conditions
         where(conditions).destroy_all
       else
-        to_a.each {|object| 
-          begin
-            object.destroy
-          rescue ActiveFedora::ObjectNotFoundError
-            logger.error "When trying to destroy #{object.pid}, encountered an ObjectNotFoundError. Solr may be out of sync with Fedora"
-          end
-        }.tap { reset }.size
+        to_a.each {|object| object.destroy }.tap { reset }.size
       end
     end
 

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -99,7 +99,7 @@ module ActiveFedora
           begin 
             yield(find_one(hit[SOLR_DOCUMENT_ID], cast))
           rescue ActiveFedora::ObjectNotFoundError
-            logger.error "When trying to find_each #{hit[SOLR_DOCUMENT_ID]}, encountered an ObjectNotFoundError. Solr may be out of sync with Fedora"
+            logger.error "Although #{hit[SOLR_DOCUMENT_ID]} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch."
           end
         end
       end

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -98,7 +98,7 @@ describe "scoped queries" do
         test_instance3.delete
       end
       it "should log an error" do
-        ActiveFedora::Relation.logger.should_receive(:error).with("When trying to find_each #{pid}, encountered an ObjectNotFoundError. Solr may be out of sync with Fedora")
+        ActiveFedora::Relation.logger.should_receive(:error).with("Although #{pid} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
         ModelIntegrationSpec::Basic.all.should == [test_instance1, test_instance3]
       end
     end


### PR DESCRIPTION
It was primarily broken because we were using `and_call_original` from
rspec-mocks

see: https://bugs.ruby-lang.org/issues/9315
