### PR TITLE
The object should be indexed before triggering the after_save

### DIFF
--- a/lib/active_fedora/callbacks.rb
+++ b/lib/active_fedora/callbacks.rb
@@ -232,7 +232,7 @@ module ActiveFedora
 
   private
 
-    def persist #:nodoc:
+    def persist(should_update_index) #:nodoc:
       run_callbacks(:save) { super }
     end
 

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -360,14 +360,17 @@ describe ActiveFedora::Base do
     describe '.save' do
       it "should create a new record" do
         @test_object.stub(:new_record? => true)
-        @test_object.should_receive(:create)
+        @test_object.should_receive(:assign_pid)
+        @test_object.should_receive(:serialize_datastreams)
+        @test_object.inner_object.should_receive(:save)
         @test_object.should_receive(:update_index)
         @test_object.save
       end
 
       it "should update an existing record" do
         @test_object.stub(:new_record? => false)
-        @test_object.should_receive(:update_record)
+        @test_object.should_receive(:serialize_datastreams)
+        @test_object.inner_object.should_receive(:save)
         @test_object.should_receive(:update_index)
         @test_object.save
       end


### PR DESCRIPTION
callbacks.
This enables us to use the relationships within the after_save
callback. They aren't usable until indexed in solr.
