### PR TITLE
Don't raise a key error if a field can't be found in the solr document

### DIFF
--- a/lib/active_fedora/solr_digital_object.rb
+++ b/lib/active_fedora/solr_digital_object.rb
@@ -43,17 +43,16 @@ module ActiveFedora
       self
     end
 
-    def fetch(field)
+    def fetch(field, default=[])
       attribute = original_class.defined_attributes[field]
       field_name = attribute.primary_solr_name
-      if field_name
-       val = solr_doc.fetch field_name
-       case attribute.type
-       when :date
-         val.is_a?(Array) ? val.map{|v| Date.parse v} : Date.parse(val)
-       else
-         val
-       end
+      raise KeyError, "Tried to fetch `#{field}' from solr, but it isn't indexed." unless field_name
+      val = solr_doc.fetch field_name, default
+      case attribute.type
+      when :date
+        val.is_a?(Array) ? val.map{|v| Date.parse v} : Date.parse(val)
+      else
+        val
       end
     end
     

--- a/spec/integration/load_from_solr_spec.rb
+++ b/spec/integration/load_from_solr_spec.rb
@@ -43,6 +43,6 @@ describe "Loading from solr" do
     expect(obj.title).to eq "PLAN 9 FROM OUTER SPACE"
     expect(obj.date_uploaded).to eq [Date.parse('1959-01-01')]
     expect(obj.identifier).to eq 12345
-    expect(obj.part).to be_nil # since it wasn't indexed 
+    expect{obj.part}.to raise_error KeyError, "Tried to fetch `part' from solr, but it isn't indexed."
   end
 end


### PR DESCRIPTION
but raise a KeyError if the index doesn't exist.
