### PR TITLE
abstract nokogiri-related DS methods into a reusable mixin

### DIFF
--- a/lib/active_fedora/datastreams.rb
+++ b/lib/active_fedora/datastreams.rb
@@ -2,6 +2,8 @@ module ActiveFedora
   module Datastreams
     extend ActiveSupport::Concern
 
+    autoload :NokogiriDatastreams,           'active_fedora/datastreams/nokogiri_datastreams'
+
     included do
       class_attribute :ds_specs
       self.ds_specs = {'RELS-EXT'=> {:type=> ActiveFedora::RelsExtDatastream, :label=>"Fedora Object-to-Object Relationship Metadata", :block=>nil}}

--- a/lib/active_fedora/datastreams/nokogiri_datastreams.rb
+++ b/lib/active_fedora/datastreams/nokogiri_datastreams.rb
@@ -1,0 +1,146 @@
+module ActiveFedora
+  module Datastreams
+    module NokogiriDatastreams
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        # Create an instance of this class based on xml content
+        # @param [String, File, Nokogiri::XML::Node] xml the xml content to build from
+        # @param [ActiveFedora::OmDatastream] tmpl the Datastream object that you are building @default a new instance of this class
+        # Careful! If you call this from a constructor, be sure to provide something 'ie. self' as the @tmpl. Otherwise, you will get an infinite loop!
+        def from_xml(xml, tmpl=nil)
+          tmpl = self.new if tmpl.nil?  ## This path is used only for unit testing (e.g. MarpaDCDatastream.from_xml(fixture("data.xml")) )
+
+          if !xml.present?
+            tmpl.ng_xml = self.xml_template
+          elsif xml.kind_of? Nokogiri::XML::Node || xml.kind_of?(Nokogiri::XML::Document)
+            tmpl.ng_xml = xml
+          else
+            tmpl.ng_xml = Nokogiri::XML::Document.parse(xml)
+          end
+
+          tmpl.ng_xml_doesnt_change!
+
+          return tmpl
+        end
+        
+        def xml_template
+          Nokogiri::XML::Document.parse("<xml/>")
+        end
+
+        def decorate_ng_xml(xml)
+          xml
+        end
+      end
+
+
+      def ng_xml 
+        @ng_xml ||= begin
+          if new?
+            ## Load up the template
+            xml = self.class.xml_template
+          else
+            xml = Nokogiri::XML::Document.parse(datastream_content)
+          end
+          self.class.decorate_ng_xml xml
+        end
+      end
+      
+      def ng_xml=(new_xml)
+        # before we set ng_xml, we load the datastream so we know if the new value differs.
+        local_or_remote_content(true)
+
+        case new_xml 
+        when Nokogiri::XML::Document
+          self.content=new_xml.to_xml
+        when  Nokogiri::XML::Node 
+          ## Cast a fragment to a document
+          self.content=new_xml.to_s
+        when String 
+          self.content=new_xml
+        else
+          raise TypeError, "You passed a #{new_xml.class} into the ng_xml of the #{self.dsid} datastream. OmDatastream.ng_xml= only accepts Nokogiri::XML::Document, Nokogiri::XML::Element, Nokogiri::XML::Node, or raw XML (String) as inputs."
+        end
+      end
+      
+      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
+      def ng_xml_will_change!
+        changed_attributes['ng_xml'] = nil
+      end
+
+      def ng_xml_doesnt_change!
+        changed_attributes.delete('ng_xml')
+      end
+      
+      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
+      def ng_xml_changed?
+        changed_attributes.has_key? 'ng_xml'
+      end
+
+      def datastream_content
+        @datastream_content ||= Nokogiri::XML(super).to_xml  {|config| config.no_declaration}.strip
+      end
+      
+      def content=(new_content)
+        if inline?
+          # inline datastreams may be transformed by fedora 3, so we test for equivalence instead of equality
+          if !EquivalentXml.equivalent?(datastream_content, new_content)
+            ng_xml_will_change! 
+            @ng_xml = Nokogiri::XML::Document.parse(new_content)
+            super(@ng_xml.to_s)
+          end
+        else
+          if datastream_content != new_content
+            ng_xml_will_change! 
+            @ng_xml = Nokogiri::XML::Document.parse(new_content)
+            super(@ng_xml.to_s)
+          end
+        end
+        self.class.decorate_ng_xml @ng_xml
+      end
+
+      def content_changed?
+        return false if !xml_loaded
+        super
+      end
+
+      def to_xml(xml = nil)
+        xml = self.ng_xml if xml.nil?
+        ng_xml = self.ng_xml
+        if ng_xml.respond_to?(:root) && ng_xml.root.nil? && self.class.respond_to?(:root_property_ref) && !self.class.root_property_ref.nil?
+          ng_xml = self.class.generate(self.class.root_property_ref, "")
+          if xml.root.nil?
+            xml = ng_xml
+          end
+        end
+
+        unless xml == ng_xml || ng_xml.root.nil?
+          if xml.kind_of?(Nokogiri::XML::Document)
+              xml.root.add_child(ng_xml.root)
+          elsif xml.kind_of?(Nokogiri::XML::Node)
+              xml.add_child(ng_xml.root)
+          else
+              raise "You can only pass instances of Nokogiri::XML::Node into this method.  You passed in #{xml}"
+          end
+        end
+        
+        return xml.to_xml {|config| config.no_declaration}.strip
+      end
+
+      def local_or_remote_content(ensure_fetch = true)
+        @content = to_xml if ng_xml_changed? || autocreate?
+        super
+      end
+
+      def autocreate?
+        changed_attributes.has_key? :profile
+      end
+
+      def xml_loaded
+        instance_variable_defined? :@ng_xml
+      end
+    
+    end
+  end
+end

--- a/lib/active_fedora/nom_datastream.rb
+++ b/lib/active_fedora/nom_datastream.rb
@@ -2,6 +2,9 @@ require  "nom"
 
 module ActiveFedora
   class NomDatastream < Datastream
+
+      include Datastreams::NokogiriDatastreams
+
       def self.set_terminology(options = {}, &block)
         @terminology_options = options || {}
         @terminology = block
@@ -29,33 +32,14 @@ module ActiveFedora
       ds
     end
 
-    def ng_xml
-      @ng_xml ||= begin
-         xml = Nokogiri::XML content
-         xml.set_terminology self.class.terminology_options, &self.class.terminology
-         xml.nom!
-         xml
-      end
+    def self.decorate_ng_xml(xml)
+      xml.set_terminology terminology_options, &terminology
+      xml.nom!
+      xml
     end
     
-    def ng_xml= ng_xml
-      @ng_xml = ng_xml
-      @ng_xml.set_terminology self.class.terminology_options, &self.class.terminology
-      content_will_change!
-      @ng_xml
-    end
-
     def serialize!
        self.content = @ng_xml.to_s if @ng_xml
-    end
-
-    def content
-      @content || super
-    end
-
-    def content=(content)
-      super
-      @ng_xml = nil
     end
 
     def to_solr

--- a/lib/active_fedora/om_datastream.rb
+++ b/lib/active_fedora/om_datastream.rb
@@ -12,7 +12,8 @@ module ActiveFedora
 
     include OM::XML::Document
     include OM::XML::TerminologyBasedSolrizer # this adds support for calling .to_solr
-    
+    include Datastreams::NokogiriDatastreams
+
     alias_method(:om_term_values, :term_values) unless method_defined?(:om_term_values)
     alias_method(:om_update_values, :update_values) unless method_defined?(:om_update_values)
     
@@ -22,134 +23,10 @@ module ActiveFedora
       super.merge(:controlGroup => 'M', :mimeType => 'text/xml')
     end
 
-    # Create an instance of this class based on xml content
-    # @param [String, File, Nokogiri::XML::Node] xml the xml content to build from
-    # @param [ActiveFedora::OmDatastream] tmpl the Datastream object that you are building @default a new instance of this class
-    # Careful! If you call this from a constructor, be sure to provide something 'ie. self' as the @tmpl. Otherwise, you will get an infinite loop!
-    def self.from_xml(xml, tmpl=nil)
-      tmpl = self.new if tmpl.nil?  ## This path is used only for unit testing (e.g. MarpaDCDatastream.from_xml(fixture("data.xml")) )
-
-      if !xml.present?
-        tmpl.ng_xml = self.xml_template
-      elsif xml.kind_of? Nokogiri::XML::Node || xml.kind_of?(Nokogiri::XML::Document)
-        tmpl.ng_xml = xml
-      else
-        tmpl.ng_xml = Nokogiri::XML::Document.parse(xml)
-      end
-
-      tmpl.ng_xml_doesnt_change!
-
-      return tmpl
-    end
-    
-    def self.xml_template
-      Nokogiri::XML::Document.parse("<xml/>")
-    end
-
-    def ng_xml 
-      @ng_xml ||= begin
-      if new?
-        ## Load up the template
-        self.class.xml_template
-      else
-        Nokogiri::XML::Document.parse(datastream_content)
-      end
-      end
-    end
-    
-    def ng_xml=(new_xml)
-      # before we set ng_xml, we load the datastream so we know if the new value differs.
-      local_or_remote_content(true)
-
-      case new_xml 
-      when Nokogiri::XML::Document
-        self.content=new_xml.to_xml
-      when  Nokogiri::XML::Node 
-        ## Cast a fragment to a document
-        self.content=new_xml.to_s
-      when String 
-        self.content=new_xml
-      else
-        raise TypeError, "You passed a #{new_xml.class} into the ng_xml of the #{self.dsid} datastream. OmDatastream.ng_xml= only accepts Nokogiri::XML::Document, Nokogiri::XML::Element, Nokogiri::XML::Node, or raw XML (String) as inputs."
-      end
-    end
-    
-    # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
-    def ng_xml_will_change!
-      changed_attributes['ng_xml'] = nil
-    end
-
-    def ng_xml_doesnt_change!
-      changed_attributes.delete('ng_xml')
-    end
-    
-    # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
-    def ng_xml_changed?
-      changed_attributes.has_key? 'ng_xml'
-    end
-
     # Indicates that this datastream has metadata content. 
     # @return true 
     def metadata?
       true
-    end
-
-    def local_or_remote_content(ensure_fetch = true)
-      @content = to_xml if ng_xml_changed? || autocreate?
-      super
-    end
-
-    def autocreate?
-      changed_attributes.has_key? :profile
-    end
-
-    def datastream_content
-      @datastream_content ||= Nokogiri::XML(super).to_xml  {|config| config.no_declaration}.strip
-    end
-    
-    def content=(new_content)
-      if inline?
-        # inline datastreams may be transformed by fedora 3, so we test for equivalence instead of equality
-        if !EquivalentXml.equivalent?(datastream_content, new_content)
-          ng_xml_will_change! 
-          @ng_xml = Nokogiri::XML::Document.parse(new_content)
-          super(@ng_xml.to_s)
-        end
-      else
-        if datastream_content != new_content
-          ng_xml_will_change! 
-          @ng_xml = Nokogiri::XML::Document.parse(new_content)
-          super(@ng_xml.to_s)
-        end
-      end
-    end
-
-    def content_changed?
-      return false if !xml_loaded
-      super
-    end
-
-    def to_xml(xml = nil)
-      xml = self.ng_xml if xml.nil?
-      ng_xml = self.ng_xml
-      if ng_xml.respond_to?(:root) && ng_xml.root.nil? && self.class.respond_to?(:root_property_ref) && !self.class.root_property_ref.nil?
-        ng_xml = self.class.generate(self.class.root_property_ref, "")
-        if xml.root.nil?
-          xml = ng_xml
-        end
-      end
-
-      unless xml == ng_xml || ng_xml.root.nil?
-        if xml.kind_of?(Nokogiri::XML::Document)
-            xml.root.add_child(ng_xml.root)
-        elsif xml.kind_of?(Nokogiri::XML::Node)
-            xml.add_child(ng_xml.root)
-        else
-            raise "You can only pass instances of Nokogiri::XML::Node into this method.  You passed in #{xml}"
-        end
-      end
-      
-      return xml.to_xml {|config| config.no_declaration}.strip
     end
     
     # ** Experimental **
@@ -422,9 +299,5 @@ module ActiveFedora
       end
     end
 
-    def xml_loaded
-      instance_variable_defined? :@ng_xml
-    end
-    
   end
 end


### PR DESCRIPTION
This is a proposed change to:
1) Make it easier to have non-Om, Nokogiri-backed datastreams
2) Ensure that OmDatastream and NomDatastream depart intentionally in their Nokogiri handling
