### PR TITLE
When initializing a datastream, autogenerate a dsid if none is supplied

### DIFF
--- a/lib/active_fedora/datastream_collections.rb
+++ b/lib/active_fedora/datastream_collections.rb
@@ -215,8 +215,8 @@ module ActiveFedora
         assert_kind_of 'datastream',  ds, ActiveFedora::Datastream
         #make sure dsid is nil so that it uses the prefix for mapping purposes
         #check dsid works for the prefix if it is set
-        if !ds.dsid.nil? && opts.has_key?(:prefix)
-          raise "dsid supplied does not conform to pattern #{opts[:prefix]}[number]" unless ds.dsid =~ /#{opts[:prefix]}[0-9]/
+        if ds.dsid && opts.has_key?(:prefix)
+          raise "dsid supplied (#{ds.dsid}) does not conform to pattern #{opts[:prefix]}[number]" unless ds.dsid =~ /#{opts[:prefix]}[0-9]/
         end
         
         add_datastream(ds,opts)

--- a/lib/active_fedora/datastream_hash.rb
+++ b/lib/active_fedora/datastream_hash.rb
@@ -15,7 +15,7 @@ module ActiveFedora
     end 
 
     def []= (key, val)
-      @obj.inner_object.datastreams[key]=val# unless @obj.inner_object.new?
+      @obj.inner_object.datastreams[key]=val
       super
     end 
 

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -24,7 +24,7 @@ describe "Nested Rdf Objects" do
 
     let (:ds) do
       mock_obj = double(:mock_obj, :pid=>'test:124', :new_record? => true)
-      ds = SpecDatastream.new(mock_obj)
+      ds = SpecDatastream.new(mock_obj, 'descMd')
     end
 
     describe "#new_record?" do
@@ -162,7 +162,7 @@ END
 
       let (:ds) do
         mock_obj = double(:mock_obj, :pid=>'test:124', :new_record? => true)
-        ds = SpecDatastream.new(mock_obj)
+        ds = SpecDatastream.new(mock_obj, 'descMd')
       end
 
 
@@ -231,7 +231,7 @@ END
 
       let (:ds) do
         mock_obj = double(:mock_obj, :pid=>'test:124', :new_record? => true)
-        ds = SpecDatastream.new(mock_obj)
+        ds = SpecDatastream.new(mock_obj, 'descMd')
       end
 
 

--- a/spec/unit/base_datastream_management_spec.rb
+++ b/spec/unit/base_datastream_management_spec.rb
@@ -6,26 +6,6 @@ describe ActiveFedora::Base do
     @test_object = ActiveFedora::Base.new
   end
   
-  describe '.generate_dsid' do
-    it "should return a dsid that is not currently in use" do
-      dsids = Hash["DS1"=>1, "DS2"=>1]
-      @test_object.should_receive(:datastreams).and_return(dsids)
-      generated_id = @test_object.generate_dsid
-      generated_id.should_not be_nil
-      generated_id.should == "DS3"
-    end
-    it "should accept a prefix argument, default to using DS as prefix" do
-      @test_object.generate_dsid("FOO").should == "FOO1"  
-    end
-
-    it "if delete a datastream it should still use next index for a prefix" do
-      dsids = Hash["DS2"=>1]
-      @test_object.should_receive(:datastreams).and_return(dsids)
-      generated_id = @test_object.generate_dsid
-      generated_id.should_not be_nil
-      generated_id.should == "DS3"
-    end
-  end
   describe '.add_datastream' do
     it "should not call Datastream.save" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, 'ds_to_add')
@@ -40,18 +20,14 @@ describe ActiveFedora::Base do
     end
     it "should auto-assign dsids using auto-incremented integers if dsid is nil or an empty string" do 
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, nil)
-      ds.dsid.should == nil
+      ds.dsid.should == 'DS1'
+      @test_object.add_datastream(ds).should == 'DS1'
       ds_emptystringid = ActiveFedora::Datastream.new(@test_object.inner_object, '')
-      @test_object.stub(:generate_dsid => 'foo')
-     # ds.should_receive(:dsid=).with("foo")
-      @test_object.add_datastream(ds).should == 'foo'
-      @test_object.add_datastream(ds_emptystringid).should == 'foo'
+      @test_object.add_datastream(ds_emptystringid).should == 'DS2'
     end
     it "should accept a prefix option and apply it to automatically assigned dsids" do
-      ds = ActiveFedora::Datastream.new(@test_object.inner_object, nil)
-      ds.dsid.should == nil
-      @test_object.stub(:generate_dsid => "FOO")
-      @test_object.add_datastream(ds, :prefix => "FOO").should == 'FOO'
+      ds = ActiveFedora::Datastream.new(@test_object.inner_object, nil, :prefix=> "FOO")
+      ds.dsid.should == 'FOO1'
     end
   end
 end

--- a/spec/unit/datastream_spec.rb
+++ b/spec/unit/datastream_spec.rb
@@ -28,6 +28,21 @@ describe ActiveFedora::Datastream do
     ds2.mimeType.should == "text/bar"
   end
 
+  describe "#generate_dsid" do
+    subject {ActiveFedora::Datastream.new(@test_object.inner_object) }
+    let(:digital_object) { double(datastreams: {})}
+    it "should create an autoincrementing dsid" do
+      subject.send(:generate_dsid, digital_object, 'FOO').should == 'FOO1'
+    end
+
+    describe "when some datastreams exist" do
+      let(:digital_object) { double(datastreams: {'FOO56' => double})}
+      it "should start from the highest existing dsid" do
+        subject.send(:generate_dsid, digital_object, 'FOO').should == 'FOO57'
+      end
+    end
+  end
+
   describe ".size" do
     it "should lazily load the datastream size attribute from the fedora repository" do
       ds_profile = <<-EOS

--- a/spec/unit/datastreams_spec.rb
+++ b/spec/unit/datastreams_spec.rb
@@ -149,7 +149,7 @@ describe ActiveFedora::Datastreams do
     end
 
     it "should mint a dsid" do
-      ds = ActiveFedora::Datastream.new
+      ds = ActiveFedora::Datastream.new(subject.inner_object)
       subject.add_datastream(ds).should == 'DS1'
     end
   end
@@ -165,17 +165,6 @@ describe ActiveFedora::Datastreams do
       subject.metadata_streams.should include(ds1, ds2, ds3)
       subject.metadata_streams.should_not include(relsextds)
       subject.metadata_streams.should_not include(file_ds)
-    end
-  end
-
-  describe "#generate_dsid" do
-    it "should create an autoincrementing dsid" do
-      subject.generate_dsid('FOO').should == 'FOO1'
-    end
-
-    it "should start from the highest existin dsid" do
-      subject.stub(:datastreams => {'FOO56' => double()})
-      subject.generate_dsid('FOO').should == 'FOO57'
     end
   end
 

--- a/spec/unit/rdf_list_spec.rb
+++ b/spec/unit/rdf_list_spec.rb
@@ -95,14 +95,14 @@ describe ActiveFedora::RdfList do
   end
 
   describe "an empty list" do
-    subject { DemoList.new(double('inner object', :pid=>'foo', :new_record? =>true)).elementList.build } 
+    subject { DemoList.new(double('inner object', :pid=>'foo', :new_record? =>true), 'descMd').elementList.build } 
     it "should have to_ary" do
       subject.to_ary.should == []
     end
   end
 
   describe "a list that has a constructed element" do
-    let(:ds) { DemoList.new(double('inner object', :pid=>'foo', :new_record? =>true)) }
+    let(:ds) { DemoList.new(double('inner object', :pid=>'foo', :new_record? =>true), 'descMd') }
     let(:list) { ds.elementList.build } 
     let!(:topic) { list.topicElement.build }
     


### PR DESCRIPTION
This avoids a deprecation warning in rubydora. Fixes #367
