### PR TITLE
Allow chaining of #where with combination of string and hash arguments

### DIFF
--- a/lib/active_fedora/associations/association_scope.rb
+++ b/lib/active_fedora/associations/association_scope.rb
@@ -23,7 +23,7 @@ module ActiveFedora
           if reflection.source_macro == :belongs_to
           elsif reflection.source_macro == :has_and_belongs_to_many
           else
-            scope = scope.where( association.send(:find_predicate) => owner.internal_uri)
+            scope = scope.where( ActiveFedora::SolrService.construct_query_for_rel(association.send(:find_predicate) => owner.internal_uri))
           end
 
           

--- a/lib/active_fedora/relation/merger.rb
+++ b/lib/active_fedora/relation/merger.rb
@@ -14,7 +14,7 @@ module ActiveFedora
 
       def merge
         # TODO merge order
-        relation.where_values = relation.where_values.merge(other.where_values)
+        relation.where_values += other.where_values
         relation
       end
     end

--- a/lib/active_fedora/relation/query_methods.rb
+++ b/lib/active_fedora/relation/query_methods.rb
@@ -11,7 +11,7 @@ module ActiveFedora
     end
 
     def where_values
-      @values[:where] ||= {}
+      @values[:where] ||= []
     end
 
     def where_values=(values)
@@ -49,12 +49,18 @@ module ActiveFedora
     end
 
     def where!(values)
-      if values.is_a?(String)
-        self.where_values = values
-      else
-        self.where_values = self.where_values.merge(values)
-      end
+      self.where_values += build_where(values)
       self
+    end
+
+    def build_where(values)
+      return [] if values.blank?
+      case values
+      when Hash
+        [create_query_from_hash(values)]
+      else
+        [values]
+      end
     end
 
     # Order the returned records by the field and direction provided

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -82,7 +82,7 @@ describe "scoped queries" do
       end
 
       it "should chain where queries" do
-        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').where(ActiveFedora::SolrService.solr_name('foo', type: :string) => 'bar').where_values.should == {ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts', ActiveFedora::SolrService.solr_name('foo', type: :string) => 'bar'}
+        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').where("#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar").where_values.should == ["#{ActiveFedora::SolrService.solr_name('bar', type: :string)}:Peanuts", "#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar"]
       end
 
       it "should chain count" do

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -197,7 +197,7 @@ describe ActiveFedora::Base do
     end
     it "should allow conditions" do
       mock_result = {'response'=>{'numFound'=>7}}
-      ActiveFedora::SolrService.should_receive(:query).with("#{@model_query} AND (foo:bar)", :rows=>0, :raw=>true).and_return(mock_result)
+      ActiveFedora::SolrService.should_receive(:query).with("#{@model_query} AND foo:bar", :rows=>0, :raw=>true).and_return(mock_result)
       SpecModel::Basic.count(:conditions=>'foo:bar').should == 7
     end
 


### PR DESCRIPTION
I converted where_values to an array matching ActiveRecord and as mentioned here: https://github.com/projecthydra/hydra-head/pull/152

This was also reported as a regression by terrellt.
