### PR TITLE
Corrected method call to :loaded! in HasManyAssociation (fixes #383)

### DIFF
--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -23,7 +23,7 @@ module ActiveFedora
         # If there's nothing in the database and @target has no new records
         # we are certain the current target is an empty array. This is a
         # documented side-effect of the method that may avoid an extra SELECT.
-        @target ||= [] and loaded if count == 0
+        @target ||= [] and loaded! if count == 0
 
         return count
       end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -105,9 +105,9 @@ describe ActiveFedora::Base do
 
         it "should let you shift onto the association" do
           @library.new_record?.should be_true
-          @library.books.size == 0
+          @library.books.size.should == 0
           @library.books.should == []
-          @library.book_ids.should ==[]
+          @library.book_ids.should == []
           @library.books << @book
           @library.books.should == [@book]
           @library.book_ids.should ==[@book.pid]

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Looking up collection members" do
+describe "Collection members" do
   before :all do
     class Library < ActiveFedora::Base 
       has_many :books
@@ -14,7 +14,17 @@ describe "Looking up collection members" do
     Object.send(:remove_const, :Book)
     Object.send(:remove_const, :Library)
   end
-  describe "of has_many" do
+  describe "size of has_many" do
+    let(:library) { Library.create }
+    context "when no members" do
+      it "should cache the count" do
+        expect(library.books).not_to be_loaded
+        expect(library.books.size).to eq(0)
+        expect(library.books).to be_loaded
+      end
+    end
+  end
+  describe "looking up has_many" do
     let(:book) { Book.create }
     let(:library) { Library.create() }
     before do


### PR DESCRIPTION
The test added to has_many_associations_spec.rb fails without the fix.

The changes to associations_spec.rb were incidental -- one to change an equality statement into an expectation.
