### PR TITLE
Allow non-default ds type configurations in named ds specs

### DIFF
--- a/lib/active_fedora/datastream_collections.rb
+++ b/lib/active_fedora/datastream_collections.rb
@@ -56,9 +56,12 @@ module ActiveFedora
             
         args.merge!({:mimeType=>args[:mime_type]}) if args.has_key?(:mime_type)
         
-        unless class_named_datastreams_desc[args[:name]].has_key?(:type) 
+        unless args.has_key?(:type) 
           #default to type ActiveFedora::Datastream
-          args.merge!({:type => "ActiveFedora::Datastream"})
+          args[:type] = "ActiveFedora::Datastream"
+        else
+          # stringify class/model names
+          args[:type] = args[:type].name if args[:type].is_a? Class
         end
         class_named_datastreams_desc[args[:name]]= args   
         create_named_datastream_finders(args[:name],args[:prefix])

--- a/spec/unit/datastream_collections_spec.rb
+++ b/spec/unit/datastream_collections_spec.rb
@@ -149,9 +149,10 @@ describe ActiveFedora::DatastreamCollections do
   
   describe '#add_named_file_datastream' do
     before do
+      class MockDS < ActiveFedora::Datastream; end
       class MockAddNamedFileDatastream < ActiveFedora::Base
         include ActiveFedora::DatastreamCollections
-        has_datastream :name=>"thumbnail",:prefix => "THUMB", :type=>ActiveFedora::Datastream, :mimeType=>"image/jpeg", :controlGroup=>'M'
+        has_datastream :name=>"thumbnail",:prefix => "THUMB", :type=>MockDS, :mimeType=>"image/jpeg", :controlGroup=>'M'
         has_datastream :name=>"high", :type=>ActiveFedora::Datastream, :mimeType=>"image/jpeg", :controlGroup=>'M' 
         has_datastream :name=>"anymime", :type=>ActiveFedora::Datastream, :controlGroup=>'M' 
       end
@@ -165,7 +166,7 @@ describe ActiveFedora::DatastreamCollections do
       f.stub(:content_type).and_return("image/jpeg")
       @test_object2.add_named_file_datastream("thumbnail",f)
       thumb = @test_object2.thumbnail.first
-      thumb.class.should == ActiveFedora::Datastream
+      thumb.class.should == MockDS
       thumb.mimeType.should == "image/jpeg"
       thumb.dsid.should == "THUMB1"
       thumb.controlGroup.should == "M"


### PR DESCRIPTION
the specified type in named ds specs (#has_datastream) was being ignored.
