### PR TITLE
Passes all content setting through the deserialization method.

### DIFF
--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -33,14 +33,14 @@ module ActiveFedora
     def metadata?
       true
     end
-    
+
     def content
       serialize
     end
 
     def content=(content)
       resource.clear!
-      resource << RDF::Reader.for(serialization_format).new(content)
+      resource << deserialize(content)
       content
     end
 
@@ -69,7 +69,7 @@ module ActiveFedora
                       end
                       r.datastream = self
                       r.singleton_class.accepts_nested_attributes_for(*nested_attributes_options.keys) unless nested_attributes_options.blank?
-                      r << RDF::Reader.for(serialization_format).new(datastream_content) if datastream_content
+                      r << deserialize
                       r
                     end
     end

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -63,4 +63,26 @@ describe ActiveFedora::RDFDatastream do
       result.dump(:ntriples).should == "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n’ \" .\n"
     end
   end
+
+  describe 'content=' do
+    let(:ds) {ActiveFedora::NtriplesRDFDatastream.new}
+    it "should be able to handle non-utf-8 characters" do
+      data = "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT')
+      ds.content = data
+      expect(ds.resource.dump(:ntriples)).to eq "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n’ \" .\n"
+    end
+  end
+
+  describe 'legacy non-utf-8 characters' do
+    let(:ds) do
+      datastream = ActiveFedora::NtriplesRDFDatastream.new
+      datastream.stub(:new?).and_return(false)
+      datastream.stub(:datastream_content).and_return("<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT'))
+      datastream
+    end
+    it "should not error on access" do
+      expect(ds.resource.dump(:ntriples)).to eq "<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n’ \" .\n"
+    end
+  end
+
 end


### PR DESCRIPTION
This centralizes handling of non-utf8 characters and closes #387.
