### PR TITLE
fixing misused RuntimeError in AF::Rdf::Resource

### DIFF
--- a/lib/active_fedora/rdf/resource.rb
+++ b/lib/active_fedora/rdf/resource.rb
@@ -318,7 +318,7 @@ module ActiveFedora::Rdf
         return RDF::Node(uri_or_str[2..-1]) if uri_or_str.start_with? '_:'
         return RDF::URI(uri_or_str) if RDF::URI(uri_or_str).valid? and (URI.scheme_list.include?(RDF::URI.new(uri_or_str).scheme.upcase) or RDF::URI.new(uri_or_str).scheme == 'info')
         return RDF::URI(self.base_uri.to_s + (self.base_uri.to_s[-1,1] =~ /(\/|#)/ ? '' : '/') + uri_or_str) if base_uri && !uri_or_str.start_with?(base_uri.to_s)
-        raise RuntimeError "could not make a valid RDF::URI from #{uri_or_str}"
+        raise RuntimeError, "could not make a valid RDF::URI from #{uri_or_str}"
       end
   end
 end

--- a/spec/unit/rdf_resource_spec.rb
+++ b/spec/unit/rdf_resource_spec.rb
@@ -29,6 +29,10 @@ describe ActiveFedora::Rdf::Resource do
       expect(subject.rdf_subject).to eq RDF::URI('http://example.org/moomin')
     end
 
+    it "should raise an error when setting to an invalid uri" do
+      expect{ subject.set_subject!('not_a_uri') }.to raise_error "could not make a valid RDF::URI from not_a_uri"
+    end
+
     describe 'when changing subject' do
       before do
         subject << RDF::Statement.new(subject.rdf_subject, RDF::DC.title, RDF::Literal('Comet in Moominland'))


### PR DESCRIPTION
This error gets raised when #set_subject! can't make a URI out of what it is passed.  

Currently, it throws the unhelpful NoMethodError: "undefined method `RuntimeError'...".  
