### PR TITLE
Fix belongs_to cmodel inheritance.

### DIFF
--- a/lib/active_fedora/associations/belongs_to_association.rb
+++ b/lib/active_fedora/associations/belongs_to_association.rb
@@ -19,7 +19,7 @@ module ActiveFedora
         #   belongs_to :publisher, :property=>:has_member
         results = SolrService.query(ActiveFedora::SolrService.construct_query_for_pids(ids))
         results.each do |result|
-          return result['id'] if SolrService.class_from_solr_document(result) == klass
+          return result['id'] if SolrService.classes_from_solr_document(result).include? klass
         end
         return nil
       end

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -55,7 +55,18 @@ module ActiveFedora
           klass.find(hit[SOLR_DOCUMENT_ID], cast: true)
         end
       end
-    
+
+      #Returns all possible classes for the solr object
+      def classes_from_solr_document(hit, opts = {})
+        #Add ActiveFedora::Base as never stored in Solr explicitely.
+        classes = [ActiveFedora::Base]
+
+        hit[HAS_MODEL_SOLR_FIELD].each { |value| classes << Model.from_class_uri(value) }
+
+        classes
+      end
+
+      #Returns the best singular class for the solr object
       def class_from_solr_document(hit, opts = {})
         #Set the default starting point to the class specified, if available.
         best_model_match = Model.from_class_uri(opts[:class]) unless opts[:class].nil?


### PR DESCRIPTION
While has_many was still working as intended, some changes to
belongs_to broke a cmodel inheritance use case. This use case was
not adequately tested corrected and I've updated the appropriate
unit test to check for the below.

Given the following setup:

```
class SimpleCollection < ActiveFedora::Base
   has_many :objects, property: :is_part_of, class_name: 'Object'
 end

 class ComplexCollection < SimpleCollection
 end

 class Item < ActiveFedora::Base
   belongs_to :collection, :property=>:is_part_of, \
   :class_name=>''SimpleCollection”
 end
```

Doing the following should work:

```
object = Item.new
object.collection = ComplexCollection.create
object.save!

object.collection #returns the complex collection
```

In our exact use case, we have “SystemCollection” and
“OAICollection” that inherit from a base “Collection”
class. Before this fix, mapping to “Collection” would
return neither despite that being in their cmodel
structure since the code was updated to only look at an
exact class match.

As no one else is using inheritance that I am aware of,
this change should not impact any other hydra heads.
