### PR TITLE
Making missing AF::Base objects act as Resources

### DIFF
--- a/lib/active_fedora/rdf/identifiable.rb
+++ b/lib/active_fedora/rdf/identifiable.rb
@@ -44,7 +44,11 @@ module ActiveFedora::Rdf::Identifiable
     # @see ActiveFedora::Rdf::Resource.from_uri
     # @param [RDF::URI] uri URI that is being looked up.
     def from_uri(uri,_)
-      self.find(pid_from_subject(uri))
+      begin
+        self.find(pid_from_subject(uri))
+      rescue ActiveFedora::ObjectNotFoundError
+        self.ds_specs[resource_datastream.to_s][:type].resource_class.new(uri)
+      end
     end
 
     ##

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -211,6 +211,17 @@ describe ActiveFedora::RDFDatastream do
       subject.reload
       expect(subject.descMetadata.creator.first).to be_kind_of(ActiveFedora::Base)
     end
+    context "when the AF:Base object is deleted" do
+      before do
+        subject.save
+        @new_object.destroy
+      end
+      it "should give back an AF::Rdf::Resource" do
+        subject.reload
+        expect(subject.descMetadata.creator.first).to be_kind_of(ActiveFedora::Rdf::Resource)
+        expect(subject.descMetadata.creator.first.rdf_subject).to eq @new_object.resource.rdf_subject
+      end
+    end
 
     it "should allow for deep attributes to be set directly" do
       subject.descMetadata.creator.first.title = "Bla"


### PR DESCRIPTION
AF::Base/Rdf::Identifiable objects that have been deleted or are otherwise missing from Fedora are now treated as a generic Rdf::Resource when encountered in another object's graph.
