### PR TITLE
Removed duplicate properties hash from AF::Rdf

### DIFF
--- a/lib/active_fedora/rdf/node_config.rb
+++ b/lib/active_fedora/rdf/node_config.rb
@@ -11,6 +11,10 @@ module ActiveFedora
         raise ArgumentError, "Invalid arguments for Rdf Node configuration: #{args} on #{predicate}" unless args.empty?
       end
 
+      def [](value)
+        value = value.to_sym
+        self.respond_to?(value) ? self.send(value) : nil
+      end
 
       def with_index (&block)
         # needed for solrizer integration

--- a/lib/active_fedora/rdf/properties.rb
+++ b/lib/active_fedora/rdf/properties.rb
@@ -17,7 +17,7 @@ module ActiveFedora::Rdf
   # You can pass a block to either to set index behavior.
   module Properties
     extend Deprecation
-    attr_accessor :properties
+    attr_accessor :config
 
     ##
     # Registers properties for Resource-like classes
@@ -25,37 +25,23 @@ module ActiveFedora::Rdf
     # @param [Hash]  opts for this property, must include a :predicate
     # @yield [index] index sets solr behaviors for the property
     def property(name, opts={}, &block)
-      config[name] = ActiveFedora::Rdf::NodeConfig.new(name, opts[:predicate], opts.except(:predicate)).tap do |config|
+      self.config[name] = ActiveFedora::Rdf::NodeConfig.new(name, opts[:predicate], opts.except(:predicate)).tap do |config|
         config.with_index(&block) if block_given?
       end
       behaviors = config[name].behaviors.flatten if config[name].behaviors and not config[name].behaviors.empty?
-
-      self.properties[name] = {
-        behaviors: behaviors,
-        type: config[name].type,
-        class_name: config[name].class_name,
-        predicate: config[name].predicate,
-        term: config[name].term,
-        multivalue: config[name].multivalue
-      }
       register_property(name)
-    end
-
-    def properties
-      @properties ||= if superclass.respond_to? :properties
-        superclass.properties.dup
-      else
-        {}.with_indifferent_access
-      end
     end
 
     def config
       @config ||= if superclass.respond_to? :config
-        superclass.properties.dup
+        superclass.config.dup
       else
         {}.with_indifferent_access
       end
     end
+
+    alias_method :properties, :config
+    alias_method :properties=, :config=
 
     def config_for_term_or_uri(term)
       return config[term.to_sym] unless term.kind_of? RDF::Resource

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -62,7 +62,7 @@ module ActiveFedora
     # set_value, get_value, and property accessors are delegated to this object.
     def resource
       @resource ||= begin
-                      r = self.class.resource_class.new(digital_object ? self.class.rdf_subject.call(self) : nil)
+                      r = self.singleton_class.resource_class.new(digital_object ? self.class.rdf_subject.call(self) : nil)
                       r.singleton_class.properties = self.class.properties
                       r.singleton_class.properties.keys.each do |property|
                         r.singleton_class.send(:register_property, property)

--- a/lib/active_fedora/rdf/resource.rb
+++ b/lib/active_fedora/rdf/resource.rb
@@ -80,7 +80,7 @@ module ActiveFedora::Rdf
       values = values.with_indifferent_access
       set_subject!(values.delete(:id)) if values.has_key?(:id) and node?
       values.each do |key, value|
-        if self.singleton_class.properties.keys.include?(key)
+        if properties.keys.include?(key)
           set_value(rdf_subject, key, value)
         elsif self.singleton_class.nested_attributes_options.keys.map{ |k| "#{k}_attributes"}.include?(key)
           send("#{key}=".to_sym, value)


### PR DESCRIPTION
The properties hash duplicated functionality from NodeConfig. This strips it out.
