### PR TITLE
Adding error for bad nested attribute arguments

### DIFF
--- a/lib/active_fedora/rdf/list.rb
+++ b/lib/active_fedora/rdf/list.rb
@@ -103,6 +103,7 @@ module ActiveFedora::Rdf
             klass = properties[key[0..-12]]['class_name']
             klass = ActiveFedora.class_from_string(klass, final_parent.class) if klass.is_a? String
             value.is_a?(Hash) ? attributes_hash_to_list(values[key], klass) : attributes_to_list(value, klass)
+            values.delete key
           end
         end
         persist!

--- a/lib/active_fedora/rdf/resource.rb
+++ b/lib/active_fedora/rdf/resource.rb
@@ -84,6 +84,8 @@ module ActiveFedora::Rdf
           set_value(rdf_subject, key, value)
         elsif self.singleton_class.nested_attributes_options.keys.map{ |k| "#{k}_attributes"}.include?(key)
           send("#{key}=".to_sym, value)
+        else
+          raise ArgumentError, "No association found for name `#{key}'. Has it been defined yet?"
         end
       end
     end

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -128,6 +128,16 @@ describe "Nesting attribute behavior of RDFDatastream" do
           expect(subject.topic[0].elementList.first[0].rdf_subject).to eq 'http://library.ucsd.edu/ark:/20775/bb3333333x'
           expect(subject.personalName.first.rdf_subject).to eq  'http://library.ucsd.edu/ark:20775/jefferson'
         end
+        
+        it 'should fail when writing to a non-predicate' do
+          attributes = { topic_attributes: { '0' => { elementList_attributes: [{ topicElement_attributes: [{ fake_predicate:"Cosmology" }] }]}}}
+          expect{ subject.attributes = attributes }.to raise_error ArgumentError
+        end
+
+        it 'should fail when writing to a non-predicate with a setter method' do
+          attributes = { topic_attributes: { '0' => { elementList_attributes: [{ topicElement_attributes: [{ name:"Cosmology" }] }]}}}
+          expect{ subject.attributes = attributes }.to raise_error ArgumentError
+        end
       end
     end
 


### PR DESCRIPTION
Sending a bad argument to Rdf::Resource#attributes= previously failed
silently. This is a problem, since it makes modeling errors invisible to
nested attributes setters, leading to missing data. Other Rails nested
attributes seem to throw an ArgumentError. This PR mimics that behavior
and message.

Closes #393.
