### PR TITLE
Enabled class_name constantization on access

### DIFF
--- a/lib/active_fedora/rdf/node_config.rb
+++ b/lib/active_fedora/rdf/node_config.rb
@@ -16,6 +16,17 @@ module ActiveFedora
         self.respond_to?(value) ? self.send(value) : nil
       end
 
+      def class_name
+        if @class_name.kind_of?(String)
+          begin
+            new_class = @class_name.constantize
+            @class_name = new_class
+          rescue NameError
+          end
+        end
+        @class_name
+      end
+
       def with_index (&block)
         # needed for solrizer integration
         iobj = IndexObject.new

--- a/spec/unit/rdf_properties_spec.rb
+++ b/spec/unit/rdf_properties_spec.rb
@@ -49,6 +49,17 @@ describe ActiveFedora::Rdf::Properties do
       DummyProperties.property :title, :predicate => RDF::DC.title, :class_name => RDF::Literal
       expect(DummyProperties.properties[:title][:class_name]).to eq RDF::Literal
     end
+
+    it "should constantize string class names" do
+      DummyProperties.property :title, :predicate => RDF::DC.title, :class_name => "RDF::Literal"
+      expect(DummyProperties.properties[:title][:class_name]).to eq RDF::Literal
+    end
+
+    it "should keep strings which it can't constantize as strings" do
+      DummyProperties.property :title, :predicate => RDF::DC.title, :class_name => "FakeClassName"
+      expect(DummyProperties.properties[:title][:class_name]).to eq "FakeClassName"
+    end
+
   end
 
   context "when using a subclass" do


### PR DESCRIPTION
This fixes an issue where, in certian edge cases related to
Rdf::Identifiable, a class_name can be specified and used before the
class is defined.
