### PR TITLE
Adding data.nil? guard for deserialize

### DIFF
--- a/lib/active_fedora/rdf_datastream.rb
+++ b/lib/active_fedora/rdf_datastream.rb
@@ -73,8 +73,11 @@ module ActiveFedora
     def deserialize(data = nil)
       repository = RDF::Repository.new
       return repository if new? and data.nil?
-
       data ||= datastream_content
+
+      # Because datastream_content can return nil, we should check that here.
+      return repository if data.nil?
+
       data.force_encoding('utf-8')
       RDF::Reader.for(serialization_format).new(data) do |reader|
         reader.each_statement do |statement|


### PR DESCRIPTION
In some cases a datastream_content is nil (because lower level
exceptions are being swallowed).

This fix ensures that we don't throw a NoMethodError on
`data.force_encoding('utf-8')` when data is nil.

This manifested in the case of Curate's soft delete behavior.
