### PR TITLE
Define ActiveFedora::Rollback so it can be used in AutosaveAssociation

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -23,6 +23,7 @@ module ActiveFedora #:nodoc:
   class UnregisteredPredicateError < RuntimeError; end # :nodoc:
   class RecordNotSaved < RuntimeError; end # :nodoc:
   class IllegalOperation < RuntimeError; end # :nodoc:
+  class Rollback < RuntimeError; end # :nodoc:
 
 
   eager_autoload do


### PR DESCRIPTION
ActiveFedora::Rollback is raised in AutosaveAssociation but it isn't defined so an uninitialized constant error is thrown.  This fixes that by defining it with the other error class declarations.
