### PR TITLE
Add #any? for Rspec 3 support

### DIFF
--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -130,6 +130,14 @@ module ActiveFedora
         end
       end
 
+      def any?
+        if block_given?
+          load_target.any? { |*block_args| yield(*block_args) }
+        else
+          !empty?
+        end
+      end
+
       def to_ary
         load_target.dup
       end

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -21,6 +21,7 @@ describe "Collection members" do
         expect(library.books).not_to be_loaded
         expect(library.books.size).to eq(0)
         expect(library.books).to be_loaded
+        expect(library.books.any?).to be_false
       end
     end
   end
@@ -49,6 +50,11 @@ describe "Collection members" do
     end
     it "should load from solr with options" do
       expect(library.books.load_from_solr(rows: 0).size).to eq(0)
+    end
+    it "should respond to #any?" do
+      expect(library.books.any?).to be_true
+      expect(library.books.any? {|book| book.library == nil}).to be_false
+      expect(library.books.any? {|book| book.library == library}).to be_true
     end
   end
 end


### PR DESCRIPTION
When running avalon's tests against rspec 3.0.0.beta2, I ran into the following:
     Failure/Error: expect(master_file.mediaobject.reload.parts).not_to include master_file
     NoMethodError:
       undefined method `any?' for #ActiveFedora::Associations::HasManyAssociation:0x000000100806c8
