### PR TITLE
Adding start/offset option for queries

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -3,7 +3,7 @@ module ActiveFedora
     extend Deprecation
     self.deprecation_horizon = 'active-fedora version 8.0.0'
 
-    delegate :find, :first, :exists?, :where, :limit, :order, :delete_all, 
+    delegate :find, :first, :exists?, :where, :limit, :offset, :order, :delete_all, 
       :destroy_all, :count, :last, :find_with_conditions, :find_in_batches, :find_each, :to=>:all
 
     def self.extended(base)

--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -54,6 +54,7 @@ module ActiveFedora
       return @records if loaded?
       args = @klass == ActiveFedora::Base ? {:cast=>true} : {}
       args[:rows] = limit_value if limit_value
+      args[:start] = offset_value if offset_value
       args[:sort] = order_values if order_values
       
       @records = to_enum(:find_each, where_values, args).to_a
@@ -121,7 +122,7 @@ module ActiveFedora
 
     private
 
-    VALID_FIND_OPTIONS = [:order, :limit, :conditions, :cast]
+    VALID_FIND_OPTIONS = [:order, :limit, :start, :conditions, :cast]
     
     def apply_finder_options(options)
       relation = clone
@@ -131,7 +132,7 @@ module ActiveFedora
       finders = options.dup
       finders.delete_if { |key, value| value.nil? && key != :limit }
 
-      ([:order,:limit] & finders.keys).each do |finder|
+      ([:order,:limit,:start] & finders.keys).each do |finder|
         relation = relation.send(finder, finders[finder])
       end
 

--- a/lib/active_fedora/relation/query_methods.rb
+++ b/lib/active_fedora/relation/query_methods.rb
@@ -37,6 +37,15 @@ module ActiveFedora
       @values[:limit] = value
     end   
 
+    def offset_value
+      @values[:offset]
+    end
+
+    def offset_value=(value)
+      raise ImmutableRelation if loaded?
+      @values[:offset] = value
+    end   
+
     # Limits the returned records to those that match the provided search conditions
     #
     # @option [Hash] opts a hash of solr conditions
@@ -94,6 +103,23 @@ module ActiveFedora
 
     def limit!(value)
       self.limit_value = value
+      self
+    end
+
+    # Start the returned records at an offset position.
+    # Useful for paginated results
+    #
+    # @option [Integer] value the number of records offset
+    #
+    # @example
+    #  Person.where(name_t: 'Jones').offset(1000)
+    #    => [#<Person @id="foo:123" @name='Jones'>, #<Person @id="foo:125" @name='Jones'>, ...]
+    def offset(value)
+      spawn.offset!(value)
+    end
+
+    def offset!(value)
+      self.offset_value = value
       self
     end
 

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -76,6 +76,9 @@ describe "scoped queries" do
       it "should limit" do
         ModelIntegrationSpec::Basic.limit(1).should == [test_instance1]
       end
+      it "should offset" do
+        ModelIntegrationSpec::Basic.offset(1).should == [test_instance2, test_instance3]
+      end
 
       it "should chain queries" do
         ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').order(ActiveFedora::SolrService.solr_name('foo', :sortable) + ' asc').limit(1).should == [test_instance2]


### PR DESCRIPTION
Solr supports paginated results with the `start` option. This adds that
to the find/query methods.
