### PR TITLE
Deprecate confusing attribute setter behaviors

### DIFF
--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -3,6 +3,7 @@ module ActiveFedora
     extend ActiveSupport::Concern
     extend ActiveSupport::Autoload
     include ActiveModel::Dirty
+    extend Deprecation
     
     autoload :Serializers
 
@@ -138,6 +139,13 @@ module ActiveFedora
       def create_attribute_setter(field, dsid, args)
         find_or_create_defined_attribute(field, dsid, args)
         define_method "#{field}=".to_sym do |v|
+          if self.class.multiple?(field)
+            unless v.nil? || v.respond_to?(:each)
+              Deprecation.warn(ActiveFedora::Attributes, "Setting an attribute defined as multiple to a scalar value is deprecated and will raise an ArgumentError in active-fedora 8.0.0")
+            end
+          elsif v.respond_to?(:each) # unique
+            Deprecation.warn(ActiveFedora::Attributes, "Setting an attribute defined as unique to an enumerable value is deprecated and will raise an ArgumentError in active-fedora 8.0.0")
+          end
           self[field]=v
         end
       end

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -99,7 +99,25 @@ describe ActiveFedora::Base do
       end
     end
 
-
+    describe "deprecated behavior" do
+      before(:all) do
+        @behavior = ActiveFedora::Attributes.deprecation_behavior
+        ActiveFedora::Attributes.deprecation_behavior = :raise
+      end
+      after(:all) do
+        ActiveFedora::Attributes.deprecation_behavior = @behavior
+      end
+      it "should deprecate passing a string to a multiple attribute writer" do
+        expect { subject.fubar = "Quack" }.to raise_error
+        expect { subject.fubar = ["Quack"] }.not_to raise_error
+        expect { subject.fubar = nil }.not_to raise_error
+      end
+      it "should deprecate passing an enumerable to a unique attribute writer" do
+        expect { subject.cow = "Low" }.not_to raise_error
+        expect { subject.cow = ["Low"] }.to raise_error
+        expect { subject.cow = nil }.not_to raise_error
+      end
+    end
 
     it "should reveal the unique properties" do
       BarHistory2.unique?(:horse).should be_false


### PR DESCRIPTION
Deprecate setting multiple attribute to scalar value
Deprecate setting unique attribute to enumerable value
