### PR TITLE
Adds :update_index option to `save'

### DIFF
--- a/lib/active_fedora/callbacks.rb
+++ b/lib/active_fedora/callbacks.rb
@@ -236,7 +236,7 @@ module ActiveFedora
       run_callbacks(:save) { super }
     end
 
-    def create #:nodoc:
+    def create(*) #:nodoc:
       run_callbacks(:create) { super }
     end
 

--- a/spec/unit/persistence_spec.rb
+++ b/spec/unit/persistence_spec.rb
@@ -52,4 +52,46 @@ describe ActiveFedora::Persistence do
       expect(subject.pid).not_to be_nil
     end
   end
+
+  describe "save" do
+    subject { ActiveFedora::Base.new }
+    context "when called with option :update_index=>false" do
+      context "on a new record" do
+        it "should not update the index" do
+          expect(subject).to receive(:persist).with(false)
+          subject.save(update_index: false)
+        end
+      end
+      context "on a persisted record" do
+        before do
+          allow(subject).to receive(:new_record?) { false }
+          allow(subject.inner_object).to receive(:save) { true }
+        end
+        it "should not update the index" do
+          expect(subject).to receive(:persist).with(false)
+          subject.save(update_index: false)
+        end        
+      end
+    end
+    context "when called with option :update_index=>true" do
+      context "on create" do
+        before { allow(subject).to receive(:create_needs_index?) { false } }
+        it "should not override `create_needs_index?'" do
+          expect(subject).to receive(:persist).with(false)
+          subject.save(update_index: true)
+        end
+      end
+      context "on update" do
+        before do
+          allow(subject).to receive(:new_record?) { false }
+          allow(subject.inner_object).to receive(:save) { true }
+          allow(subject).to receive(:update_needs_index?) { false }
+        end
+        it "should not override `update_needs_index?'" do
+          expect(subject).to receive(:persist).with(false)
+          subject.save(update_index: true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Passing a false value will prevent `update_index` from being called after the object is persisted.  The `create_needs_index?` and `update_needs_index?` methods, however, will not be overridden when they return `false`.
