### PR TITLE
Fixed bug in ActiveFedora::FinderMethods#load_from_fedora 

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -168,13 +168,11 @@ module ActiveFedora
     protected
 
     def load_from_fedora(pid, cast)
-      cast = true if self == ActiveFedora::Base && cast.nil?
-      inner = DigitalObject.find(@klass, pid)
-      af_base = @klass.allocate.init_with(inner)
+      cast = true if klass == ActiveFedora::Base && cast.nil?
+      inner = DigitalObject.find(klass, pid)
+      af_base = klass.allocate.init_with(inner)
       cast ? af_base.adapt_to_cmodel : af_base
-
     end
-
 
     def find_with_ids(ids, cast)
       expects_array = ids.first.kind_of?(Array)

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -288,4 +288,14 @@ describe ActiveFedora::Base do
       ActiveFedora::Base.find_with_conditions('chunky:monkey').should == mock_result
     end
   end
+
+  describe "#load_from_fedora" do
+    let(:relation) { ActiveFedora::Relation.new(ActiveFedora::Base) }
+    before { @obj = SpecModel::Basic.create(pid: "test:123") }
+    after { @obj.destroy }
+    it "should cast when klass == ActiveFedora::Base and cast argument is nil" do
+      expect(relation.send(:load_from_fedora, "test:123", nil)).to be_a SpecModel::Basic
+    end
+  end
+
 end


### PR DESCRIPTION
so that it casts when klass is ActiveFedora::Base and `cast' argument is nil, as intended.
Fixes #431 since by default it calls load_from_fedora(pid, nil) on each hit.
