### PR TITLE
Set default mimeType for NtriplesRDFDatastream to 'application/n-triples'

### DIFF
--- a/lib/active_fedora/rdf/ntriples_rdf_datastream.rb
+++ b/lib/active_fedora/rdf/ntriples_rdf_datastream.rb
@@ -3,7 +3,7 @@ require 'rdf/ntriples'
 module ActiveFedora
   class NtriplesRDFDatastream < RDFDatastream
     def self.default_attributes
-      super.merge(:controlGroup => 'M', :mimeType => 'text/plain')
+      super.merge(:controlGroup => 'M', :mimeType => 'application/n-triples')
     end
 
     def serialization_format

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -25,7 +25,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
       @subject.controlGroup.should == 'M'
     end
     it "should have mimeType" do
-      @subject.mimeType.should == 'text/plain'
+      @subject.mimeType.should == 'application/n-triples'
     end
     it "should have dsid" do
       @subject.dsid.should == 'descMetadata'


### PR DESCRIPTION
Per W3C recommendation: http://www.w3.org/TR/n-triples/#n-triples-mediatype
Fixes #464
