### PR TITLE
Factors out behavior from ActiveFedora::Rdf::ObjectResource to mixin

### DIFF
--- a/lib/active_fedora/rdf.rb
+++ b/lib/active_fedora/rdf.rb
@@ -4,6 +4,7 @@ module ActiveFedora
     autoload :Indexing
     autoload :Identifiable
     autoload :ObjectResource
+    autoload :Persistence
 
     # Aliases for deprecated ActiveFedora::Rdf Classes/Modules
     # TODO: Remove in 8.0.0

--- a/lib/active_fedora/rdf/object_resource.rb
+++ b/lib/active_fedora/rdf/object_resource.rb
@@ -1,20 +1,12 @@
-module ActiveFedora::Rdf
-  ##
-  # A class of RdfResources to act as the primary/root resource associated
-  # with a Datastream and ActiveFedora::Base object.
-  #
-  # @see ActiveFedora::RDFDatastream
-  class ObjectResource < ActiveTriples::Resource
-    configure :base_uri => 'info:fedora/'
-    attr_accessor :datastream
-
-    def persist!
-      return false unless datastream and datastream.respond_to? :digital_object
-      @persisted ||= datastream.digital_object.save
-    end
-
-    def persisted?
-      @persisted ||= (not datastream.new?)
+module ActiveFedora
+  module Rdf
+    ##
+    # A class of RdfResources to act as the primary/root resource associated
+    # with a Datastream and ActiveFedora::Base object.
+    #
+    # @see ActiveFedora::RDFDatastream
+    class ObjectResource < ActiveTriples::Resource
+      include Persistence
     end
   end
 end

--- a/lib/active_fedora/rdf/persistence.rb
+++ b/lib/active_fedora/rdf/persistence.rb
@@ -1,0 +1,31 @@
+module ActiveFedora
+  module Rdf
+    #
+    # Mixin for adding datastream persistence to an ActiveTriples::Resource 
+    # descendant so that it may be used to back an ActiveFedora::RDFDatastream.
+    #
+    # @see ActiveFedora::RDFDatastream.resource_class
+    # @see ActiveFedora::Rdf::ObjectResource
+    #
+    module Persistence
+      extend ActiveSupport::Concern
+
+      included do
+        configure :base_uri => 'info:fedora/'
+        attr_accessor :datastream
+      end
+     
+      # Overrides ActiveTriples::Resource
+      def persist!
+        return false unless datastream and datastream.respond_to? :digital_object
+        @persisted ||= datastream.digital_object.save
+      end
+
+      # Overrides ActiveTriples::Resource
+      def persisted?
+        @persisted ||= (not datastream.new?)
+      end
+
+    end
+  end
+end

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -18,6 +18,9 @@ module ActiveFedora
 
       # Utility method which can be overridden to determine the object
       # resource that is created.
+      # 
+      # @return [Class] the object resource class
+      #   Must be a descendant of ActiveTriples::Resource and include ActiveFedora::Rdf::Persistence.
       def resource_class
         Rdf::ObjectResource
       end


### PR DESCRIPTION
ActiveFedora::Rdf::Persistence.

The change allows any ActiveTriples::Resource descendant which includes the mixin
to be used as the resource class for an ActiveFedora::RDFDatastream, rather than
requiring an ObjectResource subclass.
