### PR TITLE
Provide a sensible default for base_path

### DIFF
--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -9,7 +9,7 @@ module ActiveFedora
     end
 
     def base_path
-      @config[:base_path]
+      @config[:base_path] || '/'
     end
 
     def connection


### PR DESCRIPTION
This ensures that we don't encounter
`no implicit conversion of nil into String`
if the value is not set in the fedora.yml
