### PR TITLE
Replaces ActiveFedora::Indexing.urls_from_sitemap_index with ActiveFedor...

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "linkeddata"
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '~> 0.0.8'
+  s.add_dependency "rdf-ldp"
 
   s.add_development_dependency "rdoc"
   s.add_development_dependency "yard"

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/except'
 require 'active_triples'
+require 'rdf/ldp'
 
 SOLR_DOCUMENT_ID = Solrizer.default_field_mapper.id_field unless defined?(SOLR_DOCUMENT_ID)
 ENABLE_SOLR_UPDATES = true unless defined?(ENABLE_SOLR_UPDATES)


### PR DESCRIPTION
...a::Indexing.get_descendent_uris, and uses it to make reindex_everything work again.
