### PR TITLE
Rely on autosave associations when setting nested attributes

### DIFF
--- a/lib/active_fedora/nested_attributes.rb
+++ b/lib/active_fedora/nested_attributes.rb
@@ -64,7 +64,7 @@ module ActiveFedora
         attr_names.each do |association_name|
           if reflection = reflect_on_association(association_name)
             reflection.options[:autosave] = true
-            # add_autosave_association_callbacks(reflection)
+            add_autosave_association_callbacks(reflection)
             ## TODO this ought to work, but doesn't seem to do the class inheritance right
 
             nested_attributes_options = self.nested_attributes_options.dup
@@ -81,8 +81,6 @@ module ActiveFedora
 
               def #{association_name}_attributes=(attributes)
                 assign_nested_attributes_for_#{type}_association(:#{association_name}, attributes)
-                ## in lieu of autosave_association_callbacks just save all of em.
-                send(:#{association_name}).each {|obj| obj.marked_for_destruction? ? obj.destroy : obj.save}
               end
             eoruby
           else

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -49,7 +49,7 @@ describe "NestedAttribute behavior" do
   it "should update the child objects" do
     @car, @bar1, @bar2 = create_car_with_bars
 
-    @car.attributes = {bars_attributes: [{id: @bar1.pid, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: @bar2.pid, _destroy: '1', uno: 'bar2 uno'}]}
+    @car.update bars_attributes: [{id: @bar1.pid, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: @bar2.pid, _destroy: '1', uno: 'bar2 uno'}]
     expect(Bar.find(@bar1.pid).uno).to eq 'bar1 uno'
     expect(Bar.where(:id => @bar2.pid).first).to be_nil
     expect(Bar.where(:uno => "newbar uno").first).to_not be_nil
@@ -63,7 +63,7 @@ describe "NestedAttribute behavior" do
     @car, @bar1, @bar2 = create_car_with_bars(CarAllBlank)
 
     expect(@car.bars.count).to eq 2
-    @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}]}
+    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}]
     expect(@car.bars(true).count).to eq 2
 
     @bar1.reload
@@ -73,7 +73,7 @@ describe "NestedAttribute behavior" do
   it "should reject attributes based on proc" do
     @car, @bar1, @bar2 = create_car_with_bars(CarProc)
 
-    @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]}
+    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]
     @bar1.reload
     @bar2.reload
     expect(@bar1.uno).to eq "bar1 uno"
@@ -83,7 +83,7 @@ describe "NestedAttribute behavior" do
   it "should reject attributes base on method name" do
     @car, @bar1, @bar2 = create_car_with_bars(CarSymbol)
 
-    @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]}
+    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]
     @bar1.reload
     @bar2.reload
     expect(@bar1.uno).to eq "bar1 uno"


### PR DESCRIPTION
This brings us closer to parity with ActiveRecord and fixes a problem
present in https://github.com/projecthydra/hydra-head/pull/211
