### PR TITLE
Use .eradiate for tombstones

### DIFF
--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -75,6 +75,10 @@ module ActiveFedora
       delete
     end
 
+    def eradicate
+      self.class.eradicate(self.pid)
+    end
+
     module ClassMethods
       # Creates an object (or multiple objects) and saves it to the repository, if validations pass.
       # The resulting object is returned whether the object was saved successfully to the repository or not.
@@ -108,6 +112,29 @@ module ActiveFedora
           object
         end
       end
+
+      # Removes an object's tombstone so another object with the same uri may be created.
+      # NOTE: this is in violation of the linked data platform and is only here as a convience
+      # method. It shouldn't be used in the general course of repository operations.
+      def eradicate(uri)
+        gone?(uri) ? delete_tombstone(uri) : false
+      end
+
+      private 
+      
+      def gone? uri
+        ActiveFedora::Base.find(uri)
+        false
+      rescue Ldp::Gone
+        true
+      end
+
+      def delete_tombstone uri
+        tombstone = ActiveFedora::Base.id_to_uri(uri) + "/fcr:tombstone"
+        ActiveFedora.fedora.connection.delete(tombstone)
+        true
+      end
+    
     end
 
   protected

--- a/spec/integration/eradicate_spec.rb
+++ b/spec/integration/eradicate_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+
+  before(:all) do
+    class ResurrectionModel < ActiveFedora::Base
+      after_destroy :eradicate
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :ResurrectionModel)
+  end
+
+  context "when an object is has already been deleted" do
+    let(:ghost) do
+      obj = ActiveFedora::Base.create
+      obj.destroy
+      obj.pid
+    end
+    context "in a typical sitation" do
+      specify "it cannot be reused" do
+        expect { ActiveFedora::Base.create(ghost) }.to raise_error(Ldp::Gone)
+      end
+    end
+    specify "remove its tombstone" do
+      expect(ActiveFedora::Base.eradicate(ghost)).to be true
+    end
+  end
+
+  context "when an object has just been deleted" do
+    let(:zombie) do
+      obj = ActiveFedora::Base.create
+      obj.destroy
+      return obj
+    end
+    specify "remove its tombstone" do
+      expect(zombie.eradicate).to be true
+    end
+  end
+
+  describe "a model with no tombstones" do
+    let(:lazarus) do
+      body = ResurrectionModel.create
+      soul = body.pid
+      body.destroy
+      return soul
+    end
+    it "should allow reusing a uri" do
+      expect(ResurrectionModel.create(pid: lazarus)).to be_kind_of(ResurrectionModel)
+    end
+  end
+
+end


### PR DESCRIPTION
Provides a way to re-use URIs by removing the `fcr:tombstone` resources that Fedora leaves behind to prevent their re-use. Technically, this is way to circumvent LDP rules. Also note that in typical operations, re-using an existing URI will result in a Ldp::Gone error. If everyone's comfortable with that error, no more needs to be done.
