### PR TITLE
Deprecates usage of #pid in favor of #id.

### DIFF
--- a/lib/active_fedora/associations/association_scope.rb
+++ b/lib/active_fedora/associations/association_scope.rb
@@ -22,7 +22,7 @@ module ActiveFedora
         chain.each_with_index do |reflection, i|
           if reflection.source_macro == :belongs_to
             # Create a partial solr query using the ids. We may add additional filters such as class_name later
-            scope = scope.where( ActiveFedora::SolrService.construct_query_for_pids([owner[reflection.foreign_key]]))
+            scope = scope.where( ActiveFedora::SolrService.construct_query_for_ids([owner[reflection.foreign_key]]))
           elsif reflection.source_macro == :has_and_belongs_to_many
           else
             scope = scope.where( ActiveFedora::SolrService.construct_query_for_rel(association.send(:find_predicate) => owner.id))

--- a/lib/active_fedora/associations/belongs_to_association.rb
+++ b/lib/active_fedora/associations/belongs_to_association.rb
@@ -42,7 +42,7 @@ module ActiveFedora
           candidate_classes = klass.descendants.select {|d| d.name }
           candidate_classes += [klass] unless klass == ActiveFedora::Base
           model_pairs = candidate_classes.inject([]) { |arr, klass| arr << [:has_model, klass.to_class_uri]; arr }
-          '(' + ActiveFedora::SolrService.construct_query_for_pids(ids) + ') AND (' +
+          '(' + ActiveFedora::SolrService.construct_query_for_ids(ids) + ') AND (' +
               ActiveFedora::SolrService.construct_query_for_rel(model_pairs, 'OR') + ')'
         end
 

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -34,7 +34,7 @@ module ActiveFedora
       def ids_reader
         if loaded?
           load_target.map do |record|
-            record.pid
+            record.id
           end
         else
           load_from_solr.map do |solr_record|

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -33,11 +33,11 @@ module ActiveFedora
       def find_target
         page_size = @reflection.options[:solr_page_size]
         page_size ||= 200
-        pids = owner[reflection.foreign_key]
-        return [] if pids.blank?
+        ids = owner[reflection.foreign_key]
+        return [] if ids.blank?
         solr_result = []
-        0.step(pids.size,page_size) do |startIdx|
-          query = ActiveFedora::SolrService.construct_query_for_pids(pids.slice(startIdx,page_size))
+        0.step(ids.size,page_size) do |startIdx|
+          query = ActiveFedora::SolrService.construct_query_for_ids(ids.slice(startIdx,page_size))
           solr_result += ActiveFedora::SolrService.query(query, rows: page_size)
         end
         return ActiveFedora::SolrService.reify_solr_results(solr_result)

--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -100,7 +100,7 @@ module ActiveFedora
                     end
                     # Check to see if the object still exists (may be already deleted).
                     # In Rails, they do this with an update_all to avoid callbacks and validations, we may need the same.
-                    record.save! if record.class.exists?(record.pid)
+                    record.save! if record.class.exists?(record.id)
                   end
                 end
               end

--- a/lib/active_fedora/associations/rdf.rb
+++ b/lib/active_fedora/associations/rdf.rb
@@ -54,7 +54,7 @@ module ActiveFedora
       def filter_by_class(candidate_uris)
         return [] if candidate_uris.empty?
         ids = candidate_uris.map {|uri| ActiveFedora::Base.uri_to_id(uri) }
-        results = ActiveFedora::SolrService.query(ActiveFedora::SolrService.construct_query_for_pids(ids), rows: 10000)
+        results = ActiveFedora::SolrService.query(ActiveFedora::SolrService.construct_query_for_ids(ids), rows: 10000)
 
         docs = results.select do |result|
           ActiveFedora::SolrService.classes_from_solr_document(result).any? { |klass|

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -30,7 +30,7 @@ module ActiveFedora
 
     # Calling inspect may trigger a bunch of datastream loads, but it's mainly for debugging, so no worries.
     def inspect
-      values = ["pid: #{pid.inspect}"]
+      values = ["id: #{id.inspect}"]
       values << self.class.attribute_names.map { |attr| "#{attr}: #{self[attr].inspect}" }
       "#<#{self.class} #{values.flatten.join(', ')}>"
     end

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -37,7 +37,11 @@ module ActiveFedora
       end
     end
 
-    alias pid id
+    # TODO: Remove after we no longer support #pid.
+    def pid
+      Deprecation.warn FedoraAttributes, "#{self.class}#pid is deprecated and will be removed in active-fedora 9.0. Use #{self.class}#id instead."
+      id
+    end
 
     def uri
       # TODO could we return a RDF::URI instead?

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -191,7 +191,7 @@ module ActiveFedora
       format_dsid(prefix, val)
     end
 
-    ### Provided so that an application can override how generated pids are formatted (e.g DS01 instead of DS1)
+    ### Provided so that an application can override how generated ids are formatted (e.g DS01 instead of DS1)
     def format_dsid(prefix, suffix)
       sprintf("%s%i", prefix,suffix)
     end
@@ -265,8 +265,8 @@ module ActiveFedora
           when 404
             # TODO
             # this happens because rdf_datastream calls datastream_content.
-            # which happens because it needs a PID even though it isn't saved.
-            # which happens because we don't know if something exists if you give it a pid
+            # which happens because it needs a ID even though it isn't saved.
+            # which happens because we don't know if something exists if you give it an id
             #raise ActiveFedora::ObjectNotFoundError, "Unable to find content at #{uri}"
             ''
           else

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -22,7 +22,7 @@ module ActiveFedora
         # Solrizer.set_field(solr_doc, 'object_state', state, :stored_sortable)
         Solrizer.set_field(solr_doc, 'active_fedora_model', self.class.inspect, :stored_sortable)
         solr_doc.merge!(SolrService::HAS_MODEL_SOLR_FIELD => has_model)
-        solr_doc.merge!(SOLR_DOCUMENT_ID.to_sym => pid)
+        solr_doc.merge!(SOLR_DOCUMENT_ID.to_sym => id)
         solr_doc.merge!(ActiveFedora::Base.profile_solr_name => to_json)
       end
       attached_files.each_value do |ds|
@@ -53,7 +53,7 @@ module ActiveFedora
     # Updates Solr index with self.
     def update_index
       if defined?( Solrizer::Fedora::Solrizer )
-        #logger.info("Trying to solrize pid: #{pid}")
+        #logger.info("Trying to solrize id: #{id}")
         solrizer = Solrizer::Fedora::Solrizer.new
         solrizer.solrize( self )
       else
@@ -74,7 +74,7 @@ module ActiveFedora
       # This method can be used instead of ActiveFedora::Model::ClassMethods.find.
       # It works similarly except it populates an object from Solr instead of Fedora.
       # It is most useful for objects used in read-only displays in order to speed up loading time.  If only
-      # a pid is passed in it will query solr for a corresponding solr document and then use it
+      # a id is passed in it will query solr for a corresponding solr document and then use it
       # to populate this object.
       #
       # If a value is passed in for optional parameter solr_doc it will not query solr again and just use the
@@ -82,8 +82,8 @@ module ActiveFedora
       #
       # It will anything stored within solr such as metadata and relationships.  Non-metadata attached files will not
       # be loaded and if needed you should use find instead.
-      def load_instance_from_solr(pid, solr_doc=nil)
-        SolrInstanceLoader.new(self, pid, solr_doc).object
+      def load_instance_from_solr(id, solr_doc=nil)
+        SolrInstanceLoader.new(self, id, solr_doc).object
       end
 
       def get_descendent_uris(uri)

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -43,9 +43,9 @@ module ActiveFedora
     # @param json [String] json to be parsed into attributes
     def init_with_json(json)
       attrs = JSON.parse(json)
-      pid = attrs.delete('id')
+      id = attrs.delete('id')
 
-      @orm = Ldp::Orm.new(build_ldp_resource(pid))
+      @orm = Ldp::Orm.new(build_ldp_resource(id))
       @association_cache = {}
       datastream_keys = self.class.child_resource_reflections.keys
       datastream_keys.each do |key|

--- a/lib/active_fedora/nested_attributes.rb
+++ b/lib/active_fedora/nested_attributes.rb
@@ -129,7 +129,7 @@ module ActiveFedora
         association.to_a
       else
         attribute_ids = attributes_collection.map {|a| a['id'] || a[:id] }.compact
-        attribute_ids.present? ? association.to_a.select{ |x| attribute_ids.include?(x.pid)} : []
+        attribute_ids.present? ? association.to_a.select{ |x| attribute_ids.include?(x.id)} : []
       end
 
       attributes_collection.each do |attributes|

--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -58,16 +58,16 @@ module ActiveFedora
         end
       end
 
-      pid = self.pid ## cache so it's still available after delete
+      id = self.id ## cache so it's still available after delete
       # Clear out the ETag  -- Remove when this bug is fixed: https://github.com/fcrepo4/fcrepo4/issues/442
       orm.resource.instance_variable_set :@get, nil
       begin
         @orm.resource.delete
       rescue Ldp::NotFound
-        raise ObjectNotFoundError, "Unable to find #{pid} in the repository"
+        raise ObjectNotFoundError, "Unable to find #{id} in the repository"
       end
 
-      ActiveFedora::SolrService.delete(pid) if ENABLE_SOLR_UPDATES
+      ActiveFedora::SolrService.delete(id) if ENABLE_SOLR_UPDATES
       freeze
     end
 
@@ -76,7 +76,7 @@ module ActiveFedora
     end
 
     def eradicate
-      self.class.eradicate(self.pid)
+      self.class.eradicate(self.id)
     end
 
     module ClassMethods
@@ -188,12 +188,12 @@ module ActiveFedora
     end
 
 
-    def assign_pid
+    def assign_id
     end
 
     def assign_rdf_subject
-      if !pid && new_pid = assign_pid
-        @orm = Ldp::Orm.new(LdpResource.new(ActiveFedora.fedora.connection, self.class.id_to_uri(new_pid), @resource))
+      if !id && new_id = assign_id
+        @orm = Ldp::Orm.new(LdpResource.new(ActiveFedora.fedora.connection, self.class.id_to_uri(new_id), @resource))
       else
         @orm = Ldp::Orm.new(LdpResource.new(ActiveFedora.fedora.connection, @orm.resource.subject, @resource, ActiveFedora.fedora.host + ActiveFedora.fedora.base_path))
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -31,7 +31,7 @@ module ActiveFedora
     # Returns an Array of objects of the Class that +find+ is being 
     # called on
     #
-    # @param[String,Hash] args either a pid or a hash of conditions
+    # @param[String,Hash] args either an id or a hash of conditions
     # @option args [Integer] :rows when :all is passed, the maximum number of rows to load from solr
     # @option args [Boolean] :cast when true, examine the model and cast it to the first known cModel
     def find(*args)
@@ -55,7 +55,7 @@ module ActiveFedora
         options = {conditions: options}
         apply_finder_options(options)
       else
-        raise ArgumentError, "#{self}.find() expects a pid. You provided `#{args.inspect}'" unless args.is_a? Array
+        raise ArgumentError, "#{self}.find() expects an id. You provided `#{args.inspect}'" unless args.is_a? Array
         find_with_ids(args, cast)
       end
     end
@@ -79,9 +79,9 @@ module ActiveFedora
       end
     end
 
-    # Returns true if object having the pid or matching the conditions exists in the repository
+    # Returns true if object having the id or matching the conditions exists in the repository
     # Returns false if param is false (or nil) 
-    # @param[ActiveFedora::Base, String, Hash] object, pid or hash of conditions
+    # @param[ActiveFedora::Base, String, Hash] object, id or hash of conditions
     # @return[boolean]
     def exists?(conditions)
       conditions = conditions.id if Base === conditions
@@ -166,18 +166,18 @@ module ActiveFedora
       end while docs.has_next?
     end
 
-    # Retrieve the Fedora object with the given pid, explore the returned object
+    # Retrieve the Fedora object with the given id, explore the returned object
     # Raises a ObjectNotFoundError if the object is not found.
-    # @param [String] pid of the object to load
+    # @param [String] id of the object to load
     # @param [Boolean] cast when true, cast the found object to the class of the first known model defined in it's RELS-EXT
     #
     # @example because the object hydra:dataset1 asserts it is a Dataset (hasModel http://fedora.info/definitions/v4/model#Dataset), return a Dataset object (not a Book).
     #   Book.find_one("hydra:dataset1")
-    def find_one(pid, cast=nil)
+    def find_one(id, cast=nil)
       if where_values.empty?
-        load_from_fedora(pid, cast)
+        load_from_fedora(id, cast)
       else
-        conditions = where_values + [ActiveFedora::SolrService.raw_query(SOLR_DOCUMENT_ID, pid)]
+        conditions = where_values + [ActiveFedora::SolrService.raw_query(SOLR_DOCUMENT_ID, id)]
         query = conditions.join(" AND ".freeze)
         to_enum(:find_each, query, {}).to_a.first
       end
@@ -266,7 +266,7 @@ module ActiveFedora
         elsif value.is_a? Array
           value.map { |val| "#{key}:#{RSolr.escape(val)}" }
         else
-          key = SOLR_DOCUMENT_ID if (key === :id || key === :pid)
+          key = SOLR_DOCUMENT_ID if (key === :id || key === :id)
           "#{key}:#{RSolr.escape(value)}"
         end
       end

--- a/lib/active_fedora/rspec_matchers/belong_to_associated_active_fedora_object_matcher.rb
+++ b/lib/active_fedora/rspec_matchers/belong_to_associated_active_fedora_object_matcher.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :belong_to_associated_active_fedora_object do |associatio
       )
     end
 
-    @subject = subject.class.find(subject.pid)
+    @subject = subject.class.find(subject.id)
     @actual_object = @subject.send(@association_name)
 
     @expected_object == @actual_object
@@ -19,15 +19,15 @@ RSpec::Matchers.define :belong_to_associated_active_fedora_object do |associatio
 
 
   description do
-    "#{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} matches ActiveFedora"
+    "#{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} matches ActiveFedora"
   end
 
   failure_message do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} to match"
+    "expected #{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} to match"
   end
 
   failure_message_when_negated do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} to NOT match"
+    "expected #{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} to NOT match"
   end
 
 end

--- a/lib/active_fedora/rspec_matchers/have_many_associated_active_fedora_objects_matcher.rb
+++ b/lib/active_fedora/rspec_matchers/have_many_associated_active_fedora_objects_matcher.rb
@@ -10,7 +10,7 @@ RSpec::Matchers.define :have_many_associated_active_fedora_objects do |associati
       )
     end
 
-    @subject = subject.class.find(subject.pid)
+    @subject = subject.class.find(subject.id)
     @actual_objects = @subject.send(@association_name)
 
     if @expected_objects
@@ -19,7 +19,7 @@ RSpec::Matchers.define :have_many_associated_active_fedora_objects do |associati
       if actual_count != expected_count
         raise(
           RSpec::Expectations::ExpectationNotMetError,
-          "#{@subject.class} PID=#{@subject.pid} relationship: #{@association_name.inspect} count <Expected Count: #{expected_count}> <Actual: #{actual_count}>"
+          "#{@subject.class} ID=#{@subject.id} relationship: #{@association_name.inspect} count <Expected Count: #{expected_count}> <Actual: #{actual_count}>"
         )
       end
       intersection = @actual_objects & @expected_objects
@@ -31,15 +31,15 @@ RSpec::Matchers.define :have_many_associated_active_fedora_objects do |associati
 
 
   description do
-    "#{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} matches ActiveFedora"
+    "#{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} matches ActiveFedora"
   end
 
   failure_message do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} to match"
+    "expected #{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} to match"
   end
 
   failure_message_when_negated do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} association: #{@association_name.inspect} to NOT match"
+    "expected #{@subject.class} ID=#{@subject.id} association: #{@association_name.inspect} to NOT match"
   end
 
 end

--- a/lib/active_fedora/rspec_matchers/have_predicate_matcher.rb
+++ b/lib/active_fedora/rspec_matchers/have_predicate_matcher.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :have_predicate do |predicate|
         "expect(subject).to have_predicate(<predicate>).with_objects(<objects[]>)"
       )
     end
-    @subject = subject.class.find(subject.pid)
+    @subject = subject.class.find(subject.id)
     @actual_objects = @subject.relationships(predicate)
 
     if @expected_objects
@@ -18,7 +18,7 @@ RSpec::Matchers.define :have_predicate do |predicate|
       if actual_count != expected_count
         raise(
           RSpec::Expectations::ExpectationNotMetError,
-          "#{@subject.class} PID=#{@subject.pid} relationship: #{@predicate.inspect} count <Expected Count: #{expected_count}> <Actual: #{actual_count}>"
+          "#{@subject.class} ID=#{@subject.id} relationship: #{@predicate.inspect} count <Expected Count: #{expected_count}> <Actual: #{actual_count}>"
         )
       end
       intersection = @actual_objects & @expected_objects
@@ -31,15 +31,15 @@ RSpec::Matchers.define :have_predicate do |predicate|
 
 
   description do
-    "#{@subject.class} PID=#{@subject.pid} relationship: #{@predicate.inspect} matches Fedora"
+    "#{@subject.class} ID=#{@subject.id} relationship: #{@predicate.inspect} matches Fedora"
   end
 
   failure_message do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} relationship: #{@predicate.inspect} to match"
+    "expected #{@subject.class} ID=#{@subject.id} relationship: #{@predicate.inspect} to match"
   end
 
   failure_message_when_negated do |text|
-    "expected #{@subject.class} PID=#{@subject.pid} relationship: #{@predicate.inspect} to NOT match"
+    "expected #{@subject.class} ID=#{@subject.id} relationship: #{@predicate.inspect} to NOT match"
   end
 
 end

--- a/lib/active_fedora/solr_instance_loader.rb
+++ b/lib/active_fedora/solr_instance_loader.rb
@@ -1,19 +1,19 @@
 module ActiveFedora
   class FedoraSolrMismatchError < ActiveFedora::ObjectNotFoundError
-    def initialize(pid, solr_document_id)
-      super("Solr record id and pid do not match; Solr ID=#{solr_document_id}, PID=#{pid}")
+    def initialize(fedora_id, solr_document_id)
+      super("Solr ID and Fedora ID do not match; Solr ID=#{solr_document_id}, Fedora ID=#{fedora_id}")
     end
   end
 
   # Responsible for loading an ActiveFedora::Base proxy from a Solr document.
   class SolrInstanceLoader
-    attr_reader :context, :pid
-    private :context, :pid
-    def initialize(context, pid, solr_doc = nil)
+    attr_reader :context, :id
+    private :context, :id
+    def initialize(context, id, solr_doc = nil)
       @context = context
-      @pid = pid
+      @id = id
       @solr_doc = solr_doc
-      validate_solr_doc_and_pid!(@solr_doc)
+      validate_solr_doc_and_id!(@solr_doc)
     end
 
     def object
@@ -31,21 +31,21 @@ module ActiveFedora
 
     def solr_doc
       @solr_doc ||= begin
-        result = context.find_with_conditions(:id=>pid)
+        result = context.find_with_conditions(id: id)
         if result.empty?
-          raise ActiveFedora::ObjectNotFoundError, "Object #{pid} not found in solr"
+          raise ActiveFedora::ObjectNotFoundError, "Object #{id} not found in solr"
         end
         @solr_doc = result.first
-        validate_solr_doc_and_pid!(@solr_doc)
+        validate_solr_doc_and_id!(@solr_doc)
         @solr_doc
       end
     end
 
-    def validate_solr_doc_and_pid!(document)
+    def validate_solr_doc_and_id!(document)
       return true if document.nil?
       solr_id = document[SOLR_DOCUMENT_ID]
-      if pid != solr_id
-        raise ActiveFedora::FedoraSolrMismatchError.new(pid, solr_id)
+      if id != solr_id
+        raise ActiveFedora::FedoraSolrMismatchError.new(id, solr_id)
       end
     end
 
@@ -57,7 +57,7 @@ module ActiveFedora
       @profile_json ||= begin
         profile_json = Array(solr_doc[ActiveFedora::Base.profile_solr_name]).first
         unless profile_json.present?
-          raise ActiveFedora::ObjectNotFoundError, "Object #{pid} does not contain a solrized profile"
+          raise ActiveFedora::ObjectNotFoundError, "Object #{id} does not contain a solrized profile"
         end
         profile_json
       end

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -84,12 +84,12 @@ module ActiveFedora
         best_model_match || ActiveFedora::Base
       end
 
-      # Construct a solr query for a list of pids
-      # This is used to get a solr response based on the list of pids in an object's RELS-EXT relationhsips
-      # If the pid_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
-      # @param [Array] pid_array the pids that you want included in the query
-      def construct_query_for_pids(pid_array)
-        q = pid_array.reject { |x| x.blank? }.map { |pid| raw_query(SOLR_DOCUMENT_ID, pid) }
+      # Construct a solr query for a list of ids
+      # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
+      # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
+      # @param [Array] id_array the ids that you want included in the query
+      def construct_query_for_ids(id_array)
+        q = id_array.reject { |x| x.blank? }.map { |id| raw_query(SOLR_DOCUMENT_ID, id) }
         q.empty? ? "id:NEVER_USE_THIS_ID" : q.join(" OR ".freeze)
       end
 

--- a/lib/generators/active_fedora/model/templates/model_spec.rb.erb
+++ b/lib/generators/active_fedora/model/templates/model_spec.rb.erb
@@ -12,7 +12,7 @@ describe <%= class_name %> do
     before { subject.save! }
     after { subject.destroy }
     it 'should exist' do
-      expect(<%= class_name %>.exists?(subject.pid)).to be true
+      expect(<%= class_name %>.exists?(subject.id)).to be true
     end
   end
 

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -110,7 +110,7 @@ describe ActiveFedora::Base do
           expect(@library.book_ids).to eq []
           @library.books << @book
           expect(@library.books).to eq [@book]
-          expect(@library.book_ids).to eq [@book.pid]
+          expect(@library.book_ids).to eq [@book.id]
 
         end
 
@@ -124,13 +124,13 @@ describe ActiveFedora::Base do
 
         end
         it "should let you set an array of object ids" do
-          @library.book_ids = [@book.pid, @book2.pid]
+          @library.book_ids = [@book.id, @book2.id]
           expect(@library.books).to eq [@book, @book2]
         end
 
         it "setter should wipe out previously saved relations" do
-          @library.book_ids = [@book.pid, @book2.pid]
-          @library.book_ids = [@book2.pid]
+          @library.book_ids = [@book.id, @book2.id]
+          @library.book_ids = [@book2.id]
           expect(@library.books).to eq [@book2]
 
         end
@@ -139,7 +139,7 @@ describe ActiveFedora::Base do
           @library.save
           @library.books = [@book, @book2]
           @library.save
-          @library = Library.find(@library.pid)
+          @library = Library.find(@library.id)
           expect(@library.books).to eq [@book, @book2]
         end
 
@@ -151,13 +151,13 @@ describe ActiveFedora::Base do
           @book.save
           @book2.save
 
-          @library = Library.find(@library.pid)
+          @library = Library.find(@library.id)
           expect(@library.books).to eq [@book, @book2]
 
           solr_resp =  @library.books(:response_format=>:solr)
           expect(solr_resp.size).to eq 2
-          expect(solr_resp[0]['id']).to eq @book.pid
-          expect(solr_resp[1]['id']).to eq @book2.pid
+          expect(solr_resp[0]['id']).to eq @book.id
+          expect(solr_resp[1]['id']).to eq @book2.id
 
         end
 
@@ -178,9 +178,9 @@ describe ActiveFedora::Base do
           @book.library_id = nil
         end
         it "should be settable from the book side" do
-          @book.library_id = @library.pid
+          @book.library_id = @library.id
           expect(@book.library).to eq @library
-          expect(@book.library.pid).to eq @library.pid
+          expect(@book.library.id).to eq @library.id
           @book.attributes= {:library_id => nil }
           expect(@book.library_id).to be_nil
         end
@@ -206,11 +206,11 @@ describe ActiveFedora::Base do
         it "should have many books once it has been saved" do
           @library.books << @book
 
-          expect(@book.library.pid).to eq @library.pid
+          expect(@book.library.id).to eq @library.id
           @library.books.reload
           expect(@library.books).to eq [@book]
 
-          @library2 = Library.find(@library.pid)
+          @library2 = Library.find(@library.id)
           expect(@library2.books).to eq [@book]
         end
 
@@ -219,7 +219,7 @@ describe ActiveFedora::Base do
           @library.books << @book << @book_2
           @library.save
 
-          @library2 = Library.find(@library.pid)
+          @library2 = Library.find(@library.id)
           expect(@library2.books.size).to eq 2
           @book_2.reload
           @book_2.delete
@@ -229,7 +229,7 @@ describe ActiveFedora::Base do
           @book.author = @person
           @book.save
           new_book = Book.find(@book.id)
-          expect(new_book.author_id).to eq @person.pid
+          expect(new_book.author_id).to eq @person.id
           expect(new_book.author).to be_kind_of Person
         end
 
@@ -240,10 +240,10 @@ describe ActiveFedora::Base do
 
           new_book = Book.find(@book.id)
 
-          expect(new_book.publisher_id).to eq @publisher.pid
+          expect(new_book.publisher_id).to eq @publisher.id
           expect(new_book.publisher).to be_kind_of Publisher
 
-          expect(new_book.author_id).to eq @person.pid
+          expect(new_book.author_id).to eq @person.id
           expect(new_book.author).to be_kind_of Person
         end
 
@@ -286,11 +286,11 @@ describe ActiveFedora::Base do
       end
       it "should set the association" do
         @book.library = @library
-        expect(@book.library.pid).to eq @library.pid
+        expect(@book.library.id).to eq @library.id
         @book.save
 
 
-        expect(Book.find(@book.pid).library.pid).to eq@library.pid
+        expect(Book.find(@book.id).library.id).to eq@library.id
         
       end
       it "should clear the association" do
@@ -298,7 +298,7 @@ describe ActiveFedora::Base do
         @book.library = nil
         @book.save
 
-        expect(Book.find(@book.pid).library).to be_nil
+        expect(Book.find(@book.id).library).to be_nil
       end
 
       it "should replace the association" do
@@ -308,7 +308,7 @@ describe ActiveFedora::Base do
         @book.save
         @book.library = @library2
         @book.save
-        expect(Book.find(@book.pid).library.pid).to eq @library2.pid
+        expect(Book.find(@book.id).library.id).to eq @library2.id
 
       end
 
@@ -323,9 +323,9 @@ describe ActiveFedora::Base do
         @book.publisher = @publisher2
         @book.save!
 
-        new_book = Book.find(@book.pid)
-        expect(new_book.publisher.pid).to eq @publisher2.pid
-        expect(new_book.author.pid).to eq @author.pid
+        new_book = Book.find(@book.id)
+        expect(new_book.publisher.id).to eq @publisher2.id
+        expect(new_book.author.id).to eq @author.id
       end
 
       it "should only clear the matching class association" do
@@ -336,16 +336,16 @@ describe ActiveFedora::Base do
         @book.author = nil
         @book.save
 
-        expect(Book.find(@book.pid).author).to be_nil
-        expect(Book.find(@book.pid).publisher.pid).to eq @publisher.pid
+        expect(Book.find(@book.id).author).to be_nil
+        expect(Book.find(@book.id).publisher.id).to eq @publisher.id
       end
 
       it "should be able to be set by id" do
-        @book.library_id = @library.pid
-        expect(@book.library_id).to eq @library.pid
-        expect(@book.library.pid).to eq @library.pid
+        @book.library_id = @library.id
+        expect(@book.library_id).to eq @library.id
+        expect(@book.library.id).to eq @library.id
         @book.save
-        expect(Book.find(@book.pid).library_id).to eq @library.pid
+        expect(Book.find(@book.id).library_id).to eq @library.id
       end
 
       after do
@@ -384,16 +384,16 @@ describe ActiveFedora::Base do
       end
 
       it "should load the association stored in the parent" do
-        @reloaded_course = Course.find(@course.pid)
+        @reloaded_course = Course.find(@course.id)
         expect(@reloaded_course.textbooks).to eq [@t1, @t2]
       end
 
       it "should allow a parent to be deleted from the has_many association" do
-        @reloaded_course = Course.find(@course.pid)
+        @reloaded_course = Course.find(@course.id)
         @t1.courses.delete(@reloaded_course)
         @reloaded_course.save
 
-        @reloaded_course = Course.find(@course.pid)
+        @reloaded_course = Course.find(@course.id)
         expect(@reloaded_course.textbooks).to eq [@t2]
       end
 
@@ -407,12 +407,12 @@ describe ActiveFedora::Base do
       end
 
       it "should allow a child to be deleted from the has_and_belongs_to_many association" do
-        @reloaded_course = Course.find(@course.pid)
+        @reloaded_course = Course.find(@course.id)
         @reloaded_course.textbooks.delete(@t1)
         @reloaded_course.save
         @t1.save
 
-        @reloaded_course = Course.find(@course.pid)
+        @reloaded_course = Course.find(@course.id)
         expect(@reloaded_course.textbooks).to eq [@t2]
       end
     end

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -81,8 +81,8 @@ describe ActiveFedora::AttachedFiles do
       end
 
       it "Should update datastream" do
-        expect(DSTest.find(file.pid).attached_files['test_ds'].content).to eq 'Foobar'
-        expect(DSTest.find(file.pid).test_ds.content).to eq 'Foobar'
+        expect(DSTest.find(file.id).attached_files['test_ds'].content).to eq 'Foobar'
+        expect(DSTest.find(file.id).test_ds.content).to eq 'Foobar'
       end
     end
 

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -18,12 +18,12 @@ describe "A base object with metadata" do
     end
 
     it "should save the datastream." do
-      obj = ActiveFedora::Base.find(@obj.pid)
+      obj = ActiveFedora::Base.find(@obj.id)
       expect(obj.foo).to_not be_new_record
       expect(obj.foo.person).to eq ['bob']
       person_field = ActiveFedora::SolrService.solr_name('foo__person', type: :string)
-      solr_result = ActiveFedora::SolrService.query("{!raw f=id}#{@obj.pid}", :fl=>"id #{person_field}").first
-      expect(solr_result).to eq("id"=>@obj.pid, person_field =>['bob'])
+      solr_result = ActiveFedora::SolrService.query("{!raw f=id}#{@obj.id}", :fl=>"id #{person_field}").first
+      expect(solr_result).to eq("id"=>@obj.id, person_field =>['bob'])
     end
   end
 
@@ -39,14 +39,14 @@ describe "A base object with metadata" do
         @release.save!
       end
       it "should save the datastream." do
-        expect(MockAFBaseRelationship.find(@release.pid).foo.person).to eq ['frank']
+        expect(MockAFBaseRelationship.find(@release.id).foo.person).to eq ['frank']
         person_field = ActiveFedora::SolrService.solr_name('foo__person', type: :string)
-        expect(ActiveFedora::SolrService.query("id:\"#{@release.pid}\"", :fl=>"id #{person_field}").first).to eq("id"=>@release.pid, person_field =>['frank'])
+        expect(ActiveFedora::SolrService.query("id:\"#{@release.id}\"", :fl=>"id #{person_field}").first).to eq("id"=>@release.id, person_field =>['frank'])
       end
     end
     describe "when trying to create it again" do
       it "should raise an error" do
-        expect { MockAFBaseRelationship.create(pid: @release.pid) }.to raise_error(ActiveFedora::IllegalOperation)
+        expect { MockAFBaseRelationship.create(id: @release.id) }.to raise_error(ActiveFedora::IllegalOperation)
         @release.reload
         expect(@release.foo.person).to include('test foo content')
       end
@@ -60,7 +60,7 @@ describe "A base object with metadata" do
       @object.foo.person = 'bob'
       @object.save
 
-      @object2 = @object.class.find(@object.pid)
+      @object2 = @object.class.find(@object.id)
 
       @object2.foo.person = 'dave'
       @object2.save
@@ -98,8 +98,8 @@ describe ActiveFedora::Base do
       it { should be_empty }
     end
 
-    describe "pid" do
-      subject { obj.pid }
+    describe "id" do
+      subject { obj.id }
       it { should_not be_nil }
     end
 
@@ -113,7 +113,7 @@ describe ActiveFedora::Base do
 
       it 'updates the modification time field in solr' do
         expect { obj.save }.to change {
-          ActiveFedora::SolrService.query("id:\"#{obj.pid}\"").first['system_modified_dtsi']
+          ActiveFedora::SolrService.query("id:\"#{obj.id}\"").first['system_modified_dtsi']
         }
       end
     end
@@ -132,7 +132,7 @@ describe ActiveFedora::Base do
       it "should delete the object from Fedora and Solr" do
         expect {
           obj.delete
-        }.to change { ActiveFedora::Base.exists?(obj.pid) }.from(true).to(false)
+        }.to change { ActiveFedora::Base.exists?(obj.id) }.from(true).to(false)
       end
     end
   end
@@ -143,10 +143,10 @@ describe ActiveFedora::Base do
     it "should return true for objects that exist" do
       expect(ActiveFedora::Base.exists?(obj)).to be true
     end
-    it "should return true for pids that exist" do
-      expect(ActiveFedora::Base.exists?(obj.pid)).to be true
+    it "should return true for ids that exist" do
+      expect(ActiveFedora::Base.exists?(obj.id)).to be true
     end
-    it "should return false for pids that don't exist" do
+    it "should return false for ids that don't exist" do
       expect(ActiveFedora::Base.exists?('test:missing_object')).to be false
     end
     it "should return false for nil" do

--- a/spec/integration/bug_spec.rb
+++ b/spec/integration/bug_spec.rb
@@ -30,12 +30,12 @@ describe 'bugs' do
     @test_object.someData.fubar=['initial']
     @test_object.save!
 
-    x = FooHistory.find(@test_object.pid)
+    x = FooHistory.find(@test_object.id)
     x.someData.fubar = ["replacement"] # set a new value
     x.save!
 
 
-    x = FooHistory.find(@test_object.pid)
+    x = FooHistory.find(@test_object.id)
     expect(x.someData.fubar).to eq ["replacement"] # recall the value
     x.save
   end

--- a/spec/integration/delete_all_spec.rb
+++ b/spec/integration/delete_all_spec.rb
@@ -37,16 +37,16 @@ describe ActiveFedora::Base do
 
     describe "when a model is missing" do
       let(:model3) { SpecModel::Basic.create! }
-      let!(:pid) { model3.pid }
+      let!(:id) { model3.id }
       before { model3.orm.delete }
       after do
         ActiveFedora::SolrService.instance.conn.tap do |conn|
-          conn.delete_by_query "id:\"#{pid}\""
+          conn.delete_by_query "id:\"#{id}\""
           conn.commit
         end
       end
       it "should be able to skip a missing model" do
-        expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{pid} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
+        expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{id} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
         SpecModel::Basic.destroy_all
         expect(SpecModel::Basic.count).to eq 1
       end

--- a/spec/integration/eradicate_spec.rb
+++ b/spec/integration/eradicate_spec.rb
@@ -16,7 +16,7 @@ describe ActiveFedora::Base do
     let(:ghost) do
       obj = ActiveFedora::Base.create
       obj.destroy
-      obj.pid
+      obj.id
     end
     context "in a typical sitation" do
       specify "it cannot be reused" do
@@ -42,12 +42,12 @@ describe ActiveFedora::Base do
   describe "a model with no tombstones" do
     let(:lazarus) do
       body = ResurrectionModel.create
-      soul = body.pid
+      soul = body.id
       body.destroy
       return soul
     end
     it "should allow reusing a uri" do
-      expect(ResurrectionModel.create(pid: lazarus)).to be_kind_of(ResurrectionModel)
+      expect(ResurrectionModel.create(id: lazarus)).to be_kind_of(ResurrectionModel)
     end
   end
 

--- a/spec/integration/full_featured_model_spec.rb
+++ b/spec/integration/full_featured_model_spec.rb
@@ -66,7 +66,7 @@ describe ActiveFedora::Base do
     END
     sample_narrator = 'Addelson, Frances'
     sample_bio = <<-END
-    Rochelle Ruthchild interviewed Frances Addleson on October 18, November 14, and December 10, 1997.   The interview thoroughly examined the trajectory of Frances\' life from birth until the time of the interview. As a young child, Frances\' father died during the influenza epidemic, and her mother was not equipped to care for her and her siblings.  Consequently, they were placed in a Jewish foster home. Although her experience was mostly positive, this experience would leave life-long effects.  Frances attended Radcliffe upon the urging of a mentor and later obtained her Master\'s degree in social work from Simmons College in 1954.  In the 1940\'s, she returned to work while her children were still young; a rather unusual event for that time period.  While working as a social worker at Beth Israel Hospital in the early 1970\'s, she helped counsel countless women who came to the hospital seeking abortions before the procedure was officially legalized during the landmark Roe vs. Wade decision in 1973.  Frances would later write two articles that were published in medical journals about her experience during this time.  Although not a very religious person, Frances felt connected to the Jewish notion of social justice and remained very active until an accident in the late 1990\'s.
+    Rochelle Ruthchild interviewed Frances Addleson on October 18, November 14, and December 10, 1997.   The interview thoroughly examined the trajectory of Frances\' life from birth until the time of the interview. As a young child, Frances\' father died during the influenza eidemic, and her mother was not equipped to care for her and her siblings.  Consequently, they were placed in a Jewish foster home. Although her experience was mostly positive, this experience would leave life-long effects.  Frances attended Radcliffe upon the urging of a mentor and later obtained her Master\'s degree in social work from Simmons College in 1954.  In the 1940\'s, she returned to work while her children were still young; a rather unusual event for that time period.  While working as a social worker at Beth Israel Hospital in the early 1970\'s, she helped counsel countless women who came to the hospital seeking abortions before the procedure was officially legalized during the landmark Roe vs. Wade decision in 1973.  Frances would later write two articles that were published in medical journals about her experience during this time.  Although not a very religious person, Frances felt connected to the Jewish notion of social justice and remained very active until an accident in the late 1990\'s.
     END
     sample_interviewer = "Ruthchild, & Rochelle"
 
@@ -78,7 +78,7 @@ describe ActiveFedora::Base do
                                     :notes => sample_notes, :hard_copy_availability => sample_hard_copy_availability, :hard_copy_location => "Archives", :other_contributor => sample_other_contributor,
                                     :restrictions => "None", :series => "My Series", :location => sample_location]
 
-    @dublin_core_sample_values = Hash[:creator => 'Matt && McClain', :publisher => "Jewish Womens's Archive", :description => "description", :identifier => "jwa:sample_pid", 
+    @dublin_core_sample_values = Hash[:creator => 'Matt && McClain', :publisher => "Jewish Womens's Archive", :description => "description", :identifier => "jwa:sample_id", 
                                     :title => "title", 
                                     #:alt_title => "alt_title", :subject => "subject", 
                                     #:subject_heading => "subject heading", 
@@ -92,7 +92,7 @@ describe ActiveFedora::Base do
                                     :format => "format", :medium => "medium"]
     @signigicant_passages_sample_values = {}
     @sensitive_passages_sample_values = {}
-    @sample_xml = "<xml><fields><system_create_date>REMOVED</system_create_date><system_modified_date>REMOVED</system_modified_date><active_fedora_model_s>OralHistory</active_fedora_model_s><id>changeme:14527</id><subject_heading>subject heading</subject_heading><type>type</type><rights>rights</rights><publisher>publisher</publisher><creation_date>creation date</creation_date><identifier>jwa:sample_pid</identifier><format>format</format><extent>extent</extent><language>language</language><description>description</description><title>title</title><medium>medium</medium><spatial_coverage>spatial coverage</spatial_coverage><alt_title>alt_title</alt_title><temporal_coverage>temporal coverage</temporal_coverage><subject>subject</subject><creator>creator</creator><abstract>abstract</abstract><other_contributor>Sally Ride</other_contributor><transcript_editor>Transcript Editor</transcript_editor><restrictions>None</restrictions><bio>Biographic info</bio><series>My Series</series><notes>My Note</notes><location>location</location><hard_copy_availability>Yes</hard_copy_availability><narrator>Narrator</narrator><hard_copy_location>Archives</hard_copy_location><interviewer>Interviewer</interviewer></fields><content/></xml>"
+    @sample_xml = "<xml><fields><system_create_date>REMOVED</system_create_date><system_modified_date>REMOVED</system_modified_date><active_fedora_model_s>OralHistory</active_fedora_model_s><id>changeme:14527</id><subject_heading>subject heading</subject_heading><type>type</type><rights>rights</rights><publisher>publisher</publisher><creation_date>creation date</creation_date><identifier>jwa:sample_id</identifier><format>format</format><extent>extent</extent><language>language</language><description>description</description><title>title</title><medium>medium</medium><spatial_coverage>spatial coverage</spatial_coverage><alt_title>alt_title</alt_title><temporal_coverage>temporal coverage</temporal_coverage><subject>subject</subject><creator>creator</creator><abstract>abstract</abstract><other_contributor>Sally Ride</other_contributor><transcript_editor>Transcript Editor</transcript_editor><restrictions>None</restrictions><bio>Biographic info</bio><series>My Series</series><notes>My Note</notes><location>location</location><hard_copy_availability>Yes</hard_copy_availability><narrator>Narrator</narrator><hard_copy_location>Archives</hard_copy_location><interviewer>Interviewer</interviewer></fields><content/></xml>"
 
   end
 
@@ -138,7 +138,7 @@ describe ActiveFedora::Base do
 
     @test_history.save
 
-    @solr_result = OralHistory.find_with_conditions(:id=>@test_history.pid)[0]
+    @solr_result = OralHistory.find_with_conditions(:id=>@test_history.id)[0]
     @properties_sample_values.each_pair do |field, value|
       next if field == :hard_copy_availability #FIXME HYDRA-824
       next if field == :location #FIXME HYDRA-825

--- a/spec/integration/has_and_belongs_to_many_associations_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_associations_spec.rb
@@ -50,7 +50,7 @@ describe ActiveFedora::Base do
         end
         @book.save
         expect(@book.topics.count).to eq 12
-        book2 = Book.find(@book.pid)
+        book2 = Book.find(@book.id)
         expect(book2.topics.count).to eq 12
       end
 
@@ -81,18 +81,18 @@ describe ActiveFedora::Base do
         expect(book.topics).to eq [topic1]
         expect(book['topic_ids']).to eq [topic1.id]
         expect(topic1['book_ids']).to eq [book.id]
-        expect(Topic.find(topic1.pid).books).to eq [book] #Can't have saved it because book isn't saved yet.
+        expect(Topic.find(topic1.id).books).to eq [book] #Can't have saved it because book isn't saved yet.
       end
 
       it "should save new child objects" do
         book.topics << Topic.new
-        expect(book.topics.first.pid).to_not be_nil
+        expect(book.topics.first.id).to_not be_nil
       end
 
       it "should clear out the old associtions" do
         book.topics = [topic1]
         book.topics = [topic2]
-        expect(book.topic_ids).to eq [topic2.pid]
+        expect(book.topic_ids).to eq [topic2.id]
       end
 
       context "with members" do
@@ -143,7 +143,7 @@ describe ActiveFedora::Base do
         expect(collection['book_ids']).to be_empty
       end
       it "should load the collections" do
-        reloaded = Book.find(book.pid)
+        reloaded = Book.find(book.id)
         expect(reloaded.collections).to eq [collection]
       end
 
@@ -193,7 +193,7 @@ describe ActiveFedora::Base do
         book.save!
         book.reload
         expect(book.collections).to eq [collection2]
-        expect(Collection.find(collection1.pid)).to_not be_nil
+        expect(Collection.find(collection1.id)).to_not be_nil
       end
 
       it "destroy should cause the entries to be removed from RELS-EXT, but not destroy the original record" do
@@ -203,7 +203,7 @@ describe ActiveFedora::Base do
         book.save!
         book.reload
         expect(book.collections).to eq [collection2]
-        expect(Collection.find(collection1.pid)).to_not be_nil
+        expect(Collection.find(collection1.id)).to_not be_nil
       end
     end
 

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -37,7 +37,7 @@ describe "Collection members" do
     end
 
     it "should read book_ids from solr" do
-      expect(library.book_ids).to eq [book.pid]
+      expect(library.book_ids).to eq [book.id]
     end
     it "should read books from solr" do
       expect(library.books).to eq [book]
@@ -49,7 +49,7 @@ describe "Collection members" do
       expect(library.books).to be_loaded
     end
     it "should load from solr" do
-      expect(library.books.load_from_solr.map {|r| r["id"]}).to eq([book.pid])
+      expect(library.books.load_from_solr.map {|r| r["id"]}).to eq([book.id])
     end
     it "should load from solr with options" do
       expect(library.books.load_from_solr(rows: 0).size).to eq(0)

--- a/spec/integration/model_spec.rb
+++ b/spec/integration/model_spec.rb
@@ -7,7 +7,7 @@ describe ActiveFedora::Model do
       
       class Base < ActiveFedora::Base
         include ActiveFedora::Model
-        def self.pid_namespace
+        def self.id_namespace
           "foo"
         end
         has_metadata :name => "properties", :type => ActiveFedora::SimpleDatastream, :autocreate => true 
@@ -39,16 +39,16 @@ describe ActiveFedora::Model do
   end
 
   describe '#find' do
-    describe "#find with a valid pid without cast" do
-      subject { ActiveFedora::Base.find(@test_instance.pid) }
+    describe "#find with a valid id without cast" do
+      subject { ActiveFedora::Base.find(@test_instance.id) }
       it { should be_instance_of ModelIntegrationSpec::Basic }
     end
-    describe "#find with a valid pid with cast of false" do
-      subject { ActiveFedora::Base.find(@test_instance.pid, cast: false) }
+    describe "#find with a valid id with cast of false" do
+      subject { ActiveFedora::Base.find(@test_instance.id, cast: false) }
       it { should be_instance_of ActiveFedora::Base }
     end
-    describe "#find with a valid pid without cast on a model extending Base" do
-      subject { ModelIntegrationSpec::Basic.find(@test_instance.pid) }
+    describe "#find with a valid id without cast on a model extending Base" do
+      subject { ModelIntegrationSpec::Basic.find(@test_instance.id) }
       it { should be_instance_of ModelIntegrationSpec::Basic }
     end
   end

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -49,9 +49,9 @@ describe "NestedAttribute behavior" do
   it "should update the child objects" do
     @car, @bar1, @bar2 = create_car_with_bars
 
-    @car.update bars_attributes: [{id: @bar1.pid, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: @bar2.pid, _destroy: '1', uno: 'bar2 uno'}]
-    expect(Bar.find(@bar1.pid).uno).to eq 'bar1 uno'
-    expect(Bar.where(:id => @bar2.pid).first).to be_nil
+    @car.update bars_attributes: [{id: @bar1.id, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: @bar2.id, _destroy: '1', uno: 'bar2 uno'}]
+    expect(Bar.find(@bar1.id).uno).to eq 'bar1 uno'
+    expect(Bar.where(:id => @bar2.id).first).to be_nil
     expect(Bar.where(:uno => "newbar uno").first).to_not be_nil
 
     bars = @car.bars(true)
@@ -63,7 +63,7 @@ describe "NestedAttribute behavior" do
     @car, @bar1, @bar2 = create_car_with_bars(CarAllBlank)
 
     expect(@car.bars.count).to eq 2
-    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}]
+    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}]
     expect(@car.bars(true).count).to eq 2
 
     @bar1.reload
@@ -73,7 +73,7 @@ describe "NestedAttribute behavior" do
   it "should reject attributes based on proc" do
     @car, @bar1, @bar2 = create_car_with_bars(CarProc)
 
-    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]
+    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}, {:id=>@bar2.id, :dos=>"bar2 dos"}]
     @bar1.reload
     @bar2.reload
     expect(@bar1.uno).to eq "bar1 uno"
@@ -83,7 +83,7 @@ describe "NestedAttribute behavior" do
   it "should reject attributes base on method name" do
     @car, @bar1, @bar2 = create_car_with_bars(CarSymbol)
 
-    @car.update bars_attributes: [{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]
+    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}, {:id=>@bar2.id, :dos=>"bar2 dos"}]
     @bar1.reload
     @bar2.reload
     expect(@bar1.uno).to eq "bar1 uno"

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -47,7 +47,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
   end
 
   it "should save content properly upon save" do
-    foo = RdfTest.new('test:1') #Pid needs to match the subject in the loaded file
+    foo = RdfTest.new('test:1') #ID needs to match the subject in the loaded file
     foo.title = 'Hamlet'
     foo.save
     expect(foo.title).to eq 'Hamlet'
@@ -67,7 +67,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
     expect(foo).to receive(:update_index).once
     foo.title = "title1"
     foo.save
-    foo = RdfTest.find(foo.pid)
+    foo = RdfTest.find(foo.id)
     expect(foo).to receive(:update_index).once
     foo.title = "The Work2"
     foo.save
@@ -115,7 +115,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
     @subject.part = ["this is a part"]
     @subject.save
 
-    loaded = RdfTest.find(@subject.pid)
+    loaded = RdfTest.find(@subject.id)
     expect(loaded.title).to eq 'War and Peace'
     expect(loaded.based_near).to eq ['Moscow, Russia']
     expect(loaded.related_url).to eq ['http://en.wikipedia.org/wiki/War_and_Peace']
@@ -126,7 +126,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
     @subject.part = ["part 1", "part 2"]
     @subject.save
 
-    loaded = RdfTest.find(@subject.pid)
+    loaded = RdfTest.find(@subject.id)
     expect(loaded.part).to eq ['part 1', 'part 2']
   end
 

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -113,18 +113,18 @@ describe "scoped queries" do
     end
 
     describe "when one of the objects in solr isn't in fedora" do
-      let!(:pid) { test_instance2.pid }
+      let!(:id) { test_instance2.id }
       before { test_instance2.orm.delete }
       after do
         ActiveFedora::SolrService.instance.conn.tap do |conn|
-          conn.delete_by_query "id:\"#{pid}\""
+          conn.delete_by_query "id:\"#{id}\""
           conn.commit
         end
         test_instance1.delete
         test_instance3.delete
       end
       it "should log an error" do
-        expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{pid} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
+        expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{id} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
         expect(ModelIntegrationSpec::Basic.all).to eq [test_instance1, test_instance3]
       end
     end

--- a/spec/integration/solr_instance_loader_spec.rb
+++ b/spec/integration/solr_instance_loader_spec.rb
@@ -13,7 +13,7 @@ describe ActiveFedora::SolrInstanceLoader do
     end
   end
 
-  let!(:obj) { Foo.create!(pid: 'test-123', foo: ["baz"], bar: 'quix', title: ['My Title']) }
+  let!(:obj) { Foo.create!(id: 'test-123', foo: ["baz"], bar: 'quix', title: ['My Title']) }
 
   after do
     # obj.destroy
@@ -25,7 +25,7 @@ describe ActiveFedora::SolrInstanceLoader do
     subject { loader.object }
 
     context "with context" do
-      let(:loader) { ActiveFedora::SolrInstanceLoader.new(Foo, obj.pid) }
+      let(:loader) { ActiveFedora::SolrInstanceLoader.new(Foo, obj.id) }
 
       it "should find the document in solr" do
         expect(subject).to be_instance_of Foo
@@ -34,7 +34,7 @@ describe ActiveFedora::SolrInstanceLoader do
     end
 
     context "without context" do
-      let(:loader) { ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, obj.pid) }
+      let(:loader) { ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, obj.id) }
 
       it "should find the document in solr" do
         expect_any_instance_of(ActiveFedora::Datastream).to_not receive(:retrieve_content)
@@ -57,7 +57,7 @@ describe ActiveFedora::SolrInstanceLoader do
   context "with a solr doc" do
     let(:profile) { { "foo"=>["baz"], "bar"=>"quix", "title"=>["My Title"]}.to_json }
     let(:doc) { { 'id' => 'test-123', 'has_model_ssim'=>['Foo'], 'object_profile_ssm' => profile } }
-    let(:loader) { ActiveFedora::SolrInstanceLoader.new(Foo, obj.pid, doc) }
+    let(:loader) { ActiveFedora::SolrInstanceLoader.new(Foo, obj.id, doc) }
 
     subject { loader.object }
 

--- a/spec/integration/solr_service_spec.rb
+++ b/spec/integration/solr_service_spec.rb
@@ -4,7 +4,7 @@ describe ActiveFedora::SolrService do
   describe "#reify_solr_results" do
     before(:each) do
       class FooObject < ActiveFedora::Base
-        def self.pid_namespace
+        def self.id_namespace
           "foo"
         end
   
@@ -32,7 +32,7 @@ describe ActiveFedora::SolrService do
       Object.send(:remove_const, :FooObject)
     end
     it "should return an array of objects that are of the class stored in active_fedora_model_s" do
-      query = "id\:#{RSolr.escape(@test_object.pid)} OR id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.escape(@test_object.id)} OR id\:#{RSolr.escape(@foo_object.id)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result)
       expect(result.length).to eq 2
@@ -42,7 +42,7 @@ describe ActiveFedora::SolrService do
     end
     
     it 'should #reify a lightweight object as a new instance' do
-      query = "id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.escape(@foo_object.id)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       expect(result.first).to be_instance_of FooObject

--- a/spec/samples/oral_history_sample.xml
+++ b/spec/samples/oral_history_sample.xml
@@ -9,7 +9,7 @@
 		<rights>rights</rights>
 		<publisher>publisher</publisher>
 		<creation_date>creation date</creation_date>
-		<identifier>jwa:sample_pid</identifier>
+		<identifier>jwa:sample_id</identifier>
 		<format>format</format>
 		<extent>extent</extent>
 		<language>language</language>

--- a/spec/samples/oral_history_xml.xml
+++ b/spec/samples/oral_history_xml.xml
@@ -8,7 +8,7 @@
   <field name="rights_text">rights</field>
   <field name="publisher_field">publisher</field>
   <field name="creation_date">creation date</field>
-  <field name="identifier_field">jwa:sample_pid</field>
+  <field name="identifier_field">jwa:sample_id</field>
   <field name="format_field">format</field>
   <field name="extent_field">extent</field>
   <field name="language_field">language</field>

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -81,21 +81,21 @@ describe ActiveFedora::Base do
 
       describe "inspect" do
         it "should show the attributes" do
-          expect(subject.inspect).to eq "#<BarHistory2 pid: nil, cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
+          expect(subject.inspect).to eq "#<BarHistory2 id: nil, cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
         end
 
-        describe "with a pid" do
-          before { allow(subject).to receive(:pid).and_return('test:123') }
+        describe "with a id" do
+          before { allow(subject).to receive(:id).and_return('test:123') }
 
-          it "should show a pid" do
-            expect(subject.inspect).to eq "#<BarHistory2 pid: \"test:123\", cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
+          it "should show a id" do
+            expect(subject.inspect).to eq "#<BarHistory2 id: \"test:123\", cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
           end
         end
 
         describe "with no attributes" do
           subject { ActiveFedora::Base.new }
-          it "should show a pid" do
-            expect(subject.inspect).to eq "#<ActiveFedora::Base pid: nil>"
+          it "should show a id" do
+            expect(subject.inspect).to eq "#<ActiveFedora::Base id: nil>"
           end
         end
 
@@ -115,7 +115,7 @@ describe ActiveFedora::Base do
           end
 
           it "should show the library_id" do
-            expect(subject.inspect).to eq "#<BarHistory3 pid: nil, cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil, library_id: \"#{library.pid}\">"
+            expect(subject.inspect).to eq "#<BarHistory3 id: nil, cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil, library_id: \"#{library.id}\">"
           end
         end
       end

--- a/spec/unit/base_active_model_spec.rb
+++ b/spec/unit/base_active_model_spec.rb
@@ -46,7 +46,7 @@ describe ActiveFedora::Base do
     describe "update_attributes" do
       it "should set attributes and save " do
         @n.update_attributes(:fubar=>"baz", :duck=>"Quack")
-        @q = BarHistory.find(@n.pid)
+        @q = BarHistory.find(@n.id)
         expect(@q.fubar).to eq "baz"
         expect(@q.duck).to eq "Quack"
       end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-@@last_pid = 0
+@@last_id = 0
 
 describe ActiveFedora::Base do
   it_behaves_like "An ActiveModel"
@@ -24,7 +24,7 @@ describe ActiveFedora::Base do
 
     before :each do
       ids.each do |id|
-        ActiveFedora::Base.create pid: id
+        ActiveFedora::Base.create id: id
       end
     end
 
@@ -83,48 +83,48 @@ describe ActiveFedora::Base do
       Object.send(:remove_const, :FooInherited)
     end
 
-    def increment_pid
-      @@last_pid += 1
+    def increment_id
+      @@last_id += 1
     end
 
     before do
-      @this_pid = increment_pid.to_s
+      @this_id = increment_id.to_s
       @test_object = ActiveFedora::Base.new
-      allow(@test_object).to receive(:assign_pid).and_return(@this_pid)
+      allow(@test_object).to receive(:assign_id).and_return(@this_id)
     end
 
 
     describe '#new' do
       before do
-        allow_any_instance_of(FooHistory).to receive(:assign_pid).and_return(@this_pid)
+        allow_any_instance_of(FooHistory).to receive(:assign_id).and_return(@this_id)
       end
       context "with no arguments" do
-        it "should not get a pid on init" do
-          expect(FooHistory.new.pid).to be_nil
+        it "should not get an id on init" do
+          expect(FooHistory.new.id).to be_nil
         end
       end
 
-      context "with a pid argument" do
-        it "should be able to create with a custom pid" do
+      context "with an id argument" do
+        it "should be able to create with a custom id" do
           expect(FooHistory).to receive(:id_to_uri).and_call_original
           f = FooHistory.new('baz_1')
           expect(f.id).to eq 'baz_1'
-          expect(f.pid).to eq 'baz_1'
+          expect(f.id).to eq 'baz_1'
         end
       end
 
       context "with a hash argument" do
-        context "that has a pid" do
-          it "should be able to create with a custom pid" do
+        context "that has an id" do
+          it "should be able to create with a custom id" do
             expect(FooHistory).to receive(:id_to_uri).and_call_original
-            f = FooHistory.new(pid: 'baz_1')
+            f = FooHistory.new(id: 'baz_1')
             expect(f.id).to eq 'baz_1'
-            expect(f.pid).to eq 'baz_1'
+            expect(f.id).to eq 'baz_1'
           end
         end
 
-        context "that doesn't have a pid" do
-          it "should be able to create with a custom pid" do
+        context "that doesn't have an id" do
+          it "should be able to create with a custom id" do
             f = FooHistory.new(fubar: ['baz_1'])
             expect(f.id).to be_nil
           end
@@ -243,12 +243,12 @@ describe ActiveFedora::Base do
         end
       end
 
-      context "when assign pid returns a value" do
-        context "an no pid has been set" do
+      context "when assign id returns a value" do
+        context "an no id has been set" do
 
-          it "should set the pid" do
+          it "should set the id" do
             @test_object.save
-            expect(@test_object.pid).to eq @this_pid
+            expect(@test_object.id).to eq @this_id
           end
 
           context "and the object has properties" do
@@ -257,7 +257,7 @@ describe ActiveFedora::Base do
               class WithProperty < ActiveFedora::Base
                 property :title, predicate: RDF::DC.title
               end
-              allow(test_object).to receive(:assign_pid).and_return(@this_pid)
+              allow(test_object).to receive(:assign_id).and_return(@this_id)
               test_object.save
             end
             after do
@@ -265,20 +265,20 @@ describe ActiveFedora::Base do
             end
 
             it "should update the resource" do
-              expect(test_object.resource.rdf_subject).to eq RDF::URI.new("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{@this_pid}")
+              expect(test_object.resource.rdf_subject).to eq RDF::URI.new("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{@this_id}")
               expect(test_object.title).to eq ['foo']
             end
           end
         end
 
-        context "when a pid is set" do
+        context "when an id is set" do
           before do
-            @test_object = ActiveFedora::Base.new(pid: '999')
-            allow(@test_object).to receive(:assign_pid).and_return(@this_pid)
+            @test_object = ActiveFedora::Base.new(id: '999')
+            allow(@test_object).to receive(:assign_id).and_return(@this_id)
           end
-          it "should not set the pid" do
+          it "should not set the id" do
             @test_object.save
-            expect(@test_object.pid).to eq '999'
+            expect(@test_object.id).to eq '999'
           end
         end
       end
@@ -298,10 +298,10 @@ describe ActiveFedora::Base do
         expect(@test_object).to respond_to(:to_solr)
       end
 
-      it "should add pid, system_create_date, system_modified_date from object attributes" do
+      it "should add id, system_create_date, system_modified_date from object attributes" do
         expect(@test_object).to receive(:create_date).and_return(DateTime.parse("2012-03-04T03:12:02Z")).twice
         expect(@test_object).to receive(:modified_date).and_return(DateTime.parse("2012-03-07T03:12:02Z")).twice
-        allow(@test_object).to receive(:pid).and_return('changeme:123')
+        allow(@test_object).to receive(:id).and_return('changeme:123')
         solr_doc = @test_object.to_solr
         expect(solr_doc[ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)]).to eql("2012-03-04T03:12:02Z")
         expect(solr_doc[ActiveFedora::SolrService.solr_name("system_modified", :stored_sortable, type: :date)]).to eql("2012-03-07T03:12:02Z")

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -41,9 +41,9 @@ describe ActiveFedora::Base do
 
     it "should make the associations immutable" do
       expect {
-        subject.library_id = Library.create!.pid
+        subject.library_id = Library.create!.id
       }.to raise_error RuntimeError, "can't modify frozen Book"
-      expect(subject.library_id).to eq library.pid
+      expect(subject.library_id).to eq library.id
     end
 
     describe "when the association is set via an id" do

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -88,7 +88,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "an instance with a custom subject" do
     before do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        rdf_subject { |ds| "http://localhost:8983/fedora/rest/test/#{ds.pid}/content" }
+        rdf_subject { |ds| "http://localhost:8983/fedora/rest/test/#{ds.id}/content" }
         property :created, predicate: RDF::DC.created
         property :title, predicate: RDF::DC.title
         property :publisher, predicate: RDF::DC.publisher
@@ -96,7 +96,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
         property :related_url, predicate: RDF::RDFS.seeAlso
       end
       @subject = MyDatastream.new(inner_object, 'mixed_rdf')
-      allow(@subject).to receive(:pid).and_return 'test:1'
+      allow(@subject).to receive(:id).and_return 'test:1'
       allow(@subject).to receive(:new_record?).and_return  false
       allow(@subject).to receive(:datastream_content).and_return datastream_content
     end

--- a/spec/unit/persistence_spec.rb
+++ b/spec/unit/persistence_spec.rb
@@ -45,9 +45,9 @@ describe ActiveFedora::Persistence do
 
   describe "destroy" do
     subject { ActiveFedora::Base.create! }
-    it "should not clear the pid" do
+    it "should not clear the id" do
       subject.destroy
-      expect(subject.pid).not_to be_nil
+      expect(subject.id).not_to be_nil
     end
   end
 

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -43,9 +43,9 @@ describe ActiveFedora::Base do
   
   describe '#find' do
     describe "with :cast false" do
-      describe "and a pid is specified" do
+      describe "and an id is specified" do
         it "should raise an exception if it is not found" do
-          expect { SpecModel::Basic.find("_PID_") }.to raise_error ActiveFedora::ObjectNotFoundError
+          expect { SpecModel::Basic.find("_ID_") }.to raise_error ActiveFedora::ObjectNotFoundError
         end
       end
     end
@@ -165,7 +165,7 @@ describe ActiveFedora::Base do
       it 'should return one object' do
         SpecModel::Basic.class == SpecModel::Basic
       end
-      it 'should return the last object sorted by pid' do
+      it 'should return the last object sorted by id' do
         SpecModel::Basic.last == @c
         SpecModel::Basic.last != @a 
       end
@@ -186,7 +186,7 @@ describe ActiveFedora::Base do
       it 'should return one object' do
         SpecModel::Basic.class == SpecModel::Basic
       end
-      it 'should return the last object sorted by pid' do
+      it 'should return the last object sorted by id' do
         SpecModel::Basic.first == @a
         SpecModel::Basic.first != @c 
       end
@@ -249,7 +249,7 @@ describe ActiveFedora::Base do
 
   describe "#load_from_fedora" do
     let(:relation) { ActiveFedora::Relation.new(ActiveFedora::Base) }
-    before { @obj = SpecModel::Basic.create(pid: "test:123") }
+    before { @obj = SpecModel::Basic.create(id: "test:123") }
     after { @obj.destroy }
     it "should cast when klass == ActiveFedora::Base and cast argument is nil" do
       expect(relation.send(:load_from_fedora, "test:123", nil)).to be_a SpecModel::Basic

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -108,7 +108,7 @@ describe ActiveFedora::RDFDatastream do
 
         context "and it is found again" do
           before do
-            @object = DummyAsset.find(subject.pid)
+            @object = DummyAsset.find(subject.id)
           end
 
           it "should serialize to content" do
@@ -223,7 +223,7 @@ describe ActiveFedora::RDFDatastream do
     context "when the object with a relationship is saved" do
       before do
         subject.save
-        @object = subject.class.find(subject.pid)
+        @object = subject.class.find(subject.id)
       end
 
       it "should be retrievable" do
@@ -234,7 +234,7 @@ describe ActiveFedora::RDFDatastream do
     context "when the object with a relationship is frozen" do
       before do
         subject.save
-        @object = subject.class.find(subject.pid)
+        @object = subject.class.find(subject.id)
         @object.freeze
         subject.freeze
       end

--- a/spec/unit/rdfxml_rdf_datastream_spec.rb
+++ b/spec/unit/rdfxml_rdf_datastream_spec.rb
@@ -8,7 +8,7 @@ describe ActiveFedora::RdfxmlRDFDatastream do
         property :publisher, :predicate => RDF::DC.publisher
       end
       @subject = MyRdfxmlDatastream.new(inner_object, 'mixed_rdf')
-      allow(@subject).to receive(:pid).and_return('test:1')
+      allow(@subject).to receive(:id).and_return('test:1')
     end
     after(:each) do
       Object.send(:remove_const, :MyRdfxmlDatastream)

--- a/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
@@ -3,27 +3,27 @@ require 'ostruct'
 require "active_fedora/rspec_matchers/belong_to_associated_active_fedora_object_matcher"
 
 describe RSpec::Matchers, "belong_to_associated_active_fedora_object_matcher" do
-  subject { OpenStruct.new(:pid => pid )}
-  let(:pid) { 123 }
+  subject { OpenStruct.new(:id => id )}
+  let(:id) { 123 }
   let(:object1) { Object.new }
   let(:object2) { Object.new }
   let(:association) { :association }
 
   it 'should match when association is properly stored in fedora' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(association).and_return(object1)
     expect(subject).to belong_to_associated_active_fedora_object(association).with_object(object1)
   end
 
   it 'should not match when association is different' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(association).and_return(object1)
     expect {
       expect(subject).to belong_to_associated_active_fedora_object(association).with_object(object2)
     }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
-        /expected #{subject.class} PID=#{pid} association: #{association.inspect}/
+        /expected #{subject.class} ID=#{id} association: #{association.inspect}/
       )
     )
   end

--- a/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
@@ -3,28 +3,28 @@ require 'ostruct'
 require "active_fedora/rspec_matchers/have_many_associated_active_fedora_objects_matcher"
 
 describe RSpec::Matchers, "have_many_associated_active_fedora_objects_matcher" do
-  subject { OpenStruct.new(:pid => pid )}
-  let(:pid) { 123 }
+  subject { OpenStruct.new(:id => id )}
+  let(:id) { 123 }
   let(:object1) { Object.new }
   let(:object2) { Object.new }
   let(:object3) { Object.new }
   let(:association) { :association }
 
   it 'should match when association is properly stored in fedora' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(association).and_return([object1,object2])
     expect(subject).to have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
   end
 
   it 'should not match when association is different' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(association).and_return([object1,object3])
     expect {
       expect(subject).to have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
     }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
-        /expected #{subject.class} PID=#{pid} association: #{association.inspect}/
+        /expected #{subject.class} ID=#{id} association: #{association.inspect}/
       )
     )
   end

--- a/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
@@ -3,28 +3,28 @@ require 'ostruct'
 require "active_fedora/rspec_matchers/have_predicate_matcher"
 
 describe RSpec::Matchers, "have_predicate_matcher" do
-  subject { OpenStruct.new(:pid => pid )}
-  let(:pid) { 123 }
+  subject { OpenStruct.new(:id => id )}
+  let(:id) { 123 }
   let(:object1) { Object.new }
   let(:object2) { Object.new }
   let(:object3) { Object.new }
   let(:predicate) { :predicate }
 
   it 'should match when relationship is "what we have in Fedora"' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(:relationships).with(predicate).and_return([object1,object2])
     expect(subject).to have_predicate(predicate).with_objects([object1, object2])
   end
 
   it 'should not match when relationship is different' do
-    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject.class).to receive(:find).with(id).and_return(subject)
     expect(subject).to receive(:relationships).with(predicate).and_return([object1,object3])
     expect {
       expect(subject).to have_predicate(predicate).with_objects([object1, object2])
     }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
-        /expected #{subject.class} PID=#{pid} relationship: #{predicate.inspect}/
+        /expected #{subject.class} ID=#{id} relationship: #{predicate.inspect}/
       )
     )
   end

--- a/spec/unit/solr_config_options_spec.rb
+++ b/spec/unit/solr_config_options_spec.rb
@@ -22,7 +22,7 @@ describe ActiveFedora do
       SOLR_DOCUMENT_ID = "id"
     end
     it "should be used by ActiveFedora::Base.to_solr" do
-      @test_object.stub(pid: 'changeme:123')
+      @test_object.stub(id: 'changeme:123')
       SOLR_DOCUMENT_ID = "MY_SAMPLE_ID"
       expect(@test_object.to_solr[SOLR_DOCUMENT_ID.to_sym]).to eq 'changeme:123'
       expect(@test_object.to_solr[:id]).to be_nil
@@ -54,7 +54,7 @@ describe ActiveFedora do
       @test_object.save
     end
     it "should prevent Base.delete from deleting the corresponding Solr document if false" do
-      expect(ActiveFedora::SolrService.instance.conn).to receive(:delete).with(@test_object.pid).never
+      expect(ActiveFedora::SolrService.instance.conn).to receive(:delete).with(@test_object.id).never
       expect(@test_object).to receive(:delete)
       @test_object.delete
     end

--- a/spec/unit/solr_service_spec.rb
+++ b/spec/unit/solr_service_spec.rb
@@ -37,33 +37,33 @@ describe ActiveFedora::SolrService do
   describe "reify solr results" do
     before(:all) do
       class AudioRecord
-        attr_accessor :pid
-        def self.connection_for_pid(pid)
+        attr_accessor :id
+        def self.connection_for_id(id)
         end
       end
-      @sample_solr_hits = [{"id"=>"my:_PID1_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]},
-                           {"id"=>"my:_PID2_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]},
-                           {"id"=>"my:_PID3_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]}]
+      @sample_solr_hits = [{"id"=>"my:_ID1_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]},
+                           {"id"=>"my:_ID2_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]},
+                           {"id"=>"my:_ID3_", ActiveFedora::SolrService.solr_name("has_model", :symbol)=>["AudioRecord"]}]
     end
     describe ".reify_solr_result" do
       it "should use .find to instantiate objects" do
-        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID1_", cast: true)
         ActiveFedora::SolrService.reify_solr_result(@sample_solr_hits.first)
       end
     end
     describe ".reify_solr_results" do
       it "should use AudioRecord.find to instantiate objects" do
-        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
-        expect(AudioRecord).to receive(:find).with("my:_PID2_", cast: true)
-        expect(AudioRecord).to receive(:find).with("my:_PID3_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID2_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID3_", cast: true)
         ActiveFedora::SolrService.reify_solr_results(@sample_solr_hits)
       end
     end
     describe ".lazy_reify_solr_results" do
       it "should lazily reify solr results" do
-        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
-        expect(AudioRecord).to receive(:find).with("my:_PID2_", cast: true)
-        expect(AudioRecord).to receive(:find).with("my:_PID3_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID2_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_ID3_", cast: true)
         ActiveFedora::SolrService.lazy_reify_solr_results(@sample_solr_hits).each {|r| r}
       end
     end
@@ -71,17 +71,17 @@ describe ActiveFedora::SolrService do
 
   describe "raw_query" do
     it "should generate a raw query clause" do
-      expect(ActiveFedora::SolrService.raw_query('id', "my:_PID1_")).to eq '_query_:"{!raw f=id}my:_PID1_"'
+      expect(ActiveFedora::SolrService.raw_query('id', "my:_ID1_")).to eq '_query_:"{!raw f=id}my:_ID1_"'
     end
   end
   
-  describe '#construct_query_for_pids' do
-    it "should generate a useable solr query from an array of Fedora pids" do
-      expect(ActiveFedora::SolrService.construct_query_for_pids(["my:_PID1_", "my:_PID2_", "my:_PID3_"])).to eq '_query_:"{!raw f=id}my:_PID1_" OR _query_:"{!raw f=id}my:_PID2_" OR _query_:"{!raw f=id}my:_PID3_"'
+  describe '#construct_query_for_ids' do
+    it "should generate a useable solr query from an array of Fedora ids" do
+      expect(ActiveFedora::SolrService.construct_query_for_ids(["my:_ID1_", "my:_ID2_", "my:_ID3_"])).to eq '_query_:"{!raw f=id}my:_ID1_" OR _query_:"{!raw f=id}my:_ID2_" OR _query_:"{!raw f=id}my:_ID3_"'
 
     end
     it "should return a valid solr query even if given an empty array as input" do
-      expect(ActiveFedora::SolrService.construct_query_for_pids([""])).to eq "id:NEVER_USE_THIS_ID"
+      expect(ActiveFedora::SolrService.construct_query_for_ids([""])).to eq "id:NEVER_USE_THIS_ID"
       
     end
   end


### PR DESCRIPTION
The method is defined in ActiveFedora::FedoraAttributes and includedin ActiveFedora::Base.
Replaces references to "pid" in other method names and comments with "id".

Closes #407.
