### PR TITLE
Use a string for class property keys

### DIFF
--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -28,12 +28,6 @@ module ActiveFedora
       attribute_names.each_with_object({"id" => id}) {|key, hash| hash[key] = self[key] }
     end
 
-    # def changed?
-    #   super.tap do |res|
-    #     byebug
-    #   end
-    # end
-
     # Calling inspect may trigger a bunch of datastream loads, but it's mainly for debugging, so no worries.
     def inspect
       values = ["pid: #{pid.inspect}"]
@@ -45,7 +39,7 @@ module ActiveFedora
       if assoc = self.association(key.to_sym)
         # This is for id attributes stored in the rdf graph.
         assoc.reader
-      elsif self.class.properties.key?(key)
+      elsif self.class.properties.key?(key.to_s)
         # The attribute is stored in the RDF graph for this object
         resource[key]
       else
@@ -58,9 +52,9 @@ module ActiveFedora
       if assoc = self.association(key.to_sym)
         # This is for id attributes stored in the rdf graph.
         assoc.replace(value)
-      elsif self.class.properties.key?(key)
+      elsif self.class.properties.key?(key.to_s)
         # The attribute is stored in the RDF graph for this object
-        resource[key]=value
+        self.send(key.to_s+"=", value)
       else
         # The attribute is a delegate to a datastream
         array_setter(key, value)

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -2,32 +2,93 @@ require 'spec_helper'
 
 describe "delegating attributes" do
   before :all do
+    class PropertiesDatastream < ActiveFedora::OmDatastream
+      set_terminology do |t|
+        t.root(path: "fields")
+        t.depositor index_as: [:symbol, :stored_searchable]
+      end
+    end
     class TitledObject < ActiveFedora::Base
       has_metadata 'foo', type: ActiveFedora::SimpleDatastream do |m|
         m.field "title", :string
       end
       has_attributes :title, datastream: 'foo', multiple: false
     end
+    class RdfObject < ActiveFedora::Base
+      contains 'foo', class_name: PropertiesDatastream
+      has_attributes :depositor, datastream: :foo, multiple: false
+      property :resource_type, predicate: RDF::DC.type do |index|
+        index.as :stored_searchable, :facetable
+      end
+    end
   end
   after :all do
     Object.send(:remove_const, :TitledObject)
+    Object.send(:remove_const, :RdfObject)
+    Object.send(:remove_const, :PropertiesDatastream)
   end
 
-  describe "save" do
-    subject do
-      obj = TitledObject.create
-      obj.title = "Hydra for Dummies"
-      obj.save
-      obj
+  context "with a simple datastream" do
+    describe "save" do
+      subject do
+        obj = TitledObject.create
+        obj.title = "Hydra for Dummies"
+        obj.save
+        obj
+      end
+      it "should keep a list of changes after a successful save" do
+        expect(subject.previous_changes).to_not be_empty
+        expect(subject.previous_changes.keys).to include("title")
+      end
+      it "should clean out changes" do
+        expect(subject).to_not be_title_changed
+        expect(subject.changes).to be_empty
+      end
     end
-    it "should keep a list of changes after a successful save" do
-      expect(subject.previous_changes).to_not be_empty
-      expect(subject.previous_changes.keys).to include("title")
+  end
+
+  context "with an rdf property" do
+
+    subject { RdfObject.create }
+
+    describe "getting attributes" do
+
+      before do
+        subject.depositor = "foo"
+        subject.resource_type = "bar"
+        subject.save
+      end
+
+      specify "using strings for keys" do
+        expect(subject["depositor"]).to eql("foo")
+        expect(subject["resource_type"]).to eql(["bar"])
+      end
+      specify "using symbols for keys" do
+        expect(subject[:depositor]).to eql("foo")
+        expect(subject[:resource_type]).to eql(["bar"])
+      end
+
     end
-    it "should clean out changes" do
-      expect(subject).to_not be_title_changed
-      expect(subject.changes).to be_empty
+
+    describe "setting attributes" do
+      
+      after do
+        expect(subject.depositor).to eql("foo")
+        expect(subject.resource_type).to eql(["bar"])
+      end
+      specify "using strings for keys" do
+        subject["depositor"] = "foo"
+        subject["resource_type"] = "bar"
+        subject.save
+      end
+      specify "using symbols for keys" do
+        subject[:depositor] = "foo"
+        subject[:resource_type] = "bar"
+        subject.save
+      end
+
     end
+
   end
 end
 


### PR DESCRIPTION
ActiveFedora::Base.class.properties are strings, so getting and setting them should use strings for the keys. When setting values, ActiveTriples::Resource won’t save the value, so we call it as a method on the base object directly.

Not sure if this is a good solution, but it seems to fix the issue at #536.
