### PR TITLE
Raise error unless orm.new? fixes #409

### DIFF
--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -44,6 +44,14 @@ describe "A base object with metadata" do
         expect(ActiveFedora::SolrService.query("id:\"#{@release.pid}\"", :fl=>"id #{person_field}").first).to eq("id"=>@release.pid, person_field =>['frank'])
       end
     end
+    describe "when trying to create it again" do
+      it "should raise an error" do
+        expect { MockAFBaseRelationship.create(pid: @release.pid) }.to raise_error(ActiveFedora::IllegalOperation)
+        @release.reload
+        expect(@release.foo.person).to include('test foo content')
+      end
+
+    end
   end
 
   describe '#reload' do


### PR DESCRIPTION
Raise an error if we’re initializing a new ActiveFedora::Base object using an orm resource that isn’t new. In other words, we don’t want to create new objects with URIs that already exist in the repository.
