### PR TITLE
Refactors ActiveFedora::File#size to use two new methods, ActiveFedora::...

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -102,8 +102,16 @@ module ActiveFedora
       @original_name ||= fetch_original_name_from_headers
     end
 
-    def size
+    def persisted_size
       ldp_source.head.headers['Content-Length'].to_i
+    end
+
+    def dirty_size
+      content.size if changed? && content.respond_to?(:size)
+    end
+
+    def size
+      dirty_size || persisted_size
     end
 
     def has_content?


### PR DESCRIPTION
...File#persisted_size and ActiveFedora::File#dirty_size.

This fixes #560 where has_content? was returning false when there was unpersisted content, b/c it was only checking the size of persisted content.
