### PR TITLE
Revert "clarified a comment"

### DIFF
--- a/lib/active_fedora/datastream_attribute.rb
+++ b/lib/active_fedora/datastream_attribute.rb
@@ -51,7 +51,7 @@ module ActiveFedora
           ActiveFedora::Base.logger.info "Couldn't get #{field} out of solr, because #{e.message}. Trying another way." if ActiveFedora::Base.logger
         end
       end
-      # Load from fedora (except OmDatastreams, which try to load from solr first)
+      # Load from fedora
       ds = datastream_for_attribute(obj, dsid)
       if ds.kind_of?(ActiveFedora::RDFDatastream)
         ds.send(field)


### PR DESCRIPTION
Reverts projecthydra/active_fedora#568

From @jcoyne:

```
It loads from solr if you instantiated the object viaload_instance_from_solr. It loads from fedora if you instantiated it with a find. It depends on the class of @inner_object
```
