### PR TITLE
Files should be independent of the ActiveFedora::Base object.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -63,6 +63,7 @@ module ActiveFedora #:nodoc:
     autoload :FedoraAttributes
     autoload :File
     autoload :FileConfigurator
+    autoload :FilePathBuilder
     autoload :FilesHash
     autoload :Indexing
     autoload :LdpResource

--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -71,21 +71,21 @@ module ActiveFedora
         dsid = ds_uri.to_s.sub(uri + '/', '')
         reflection = local_ds_specs.delete(dsid)
         ds = reflection ? reflection.build_datastream(self) : ActiveFedora::File.new(self, dsid)
-        attach_file(ds)
+        attach_file(ds, dsid)
         configure_datastream(attached_files[dsid], reflection)
       end
       local_ds_specs.each do |name, reflection|
         ds = reflection.build_datastream(self)
-        attach_file(ds)
+        attach_file(ds, name)
         configure_datastream(ds, reflection)
       end
     end
 
     # Adds datastream to the object.
     # @return [String] dsid of the added datastream
-    def attach_file(file, opts={})
-      attached_files[file.dsid] = file
-      file.dsid
+    def attach_file(file, dsid, opts={})
+      attached_files[dsid] = file
+      dsid
     end
 
     def add_datastream(datastream, opts={})
@@ -112,7 +112,8 @@ module ActiveFedora
     # @option opts [String] :original_name The original name of the file (used for Content-Disposition)
     def add_file_datastream(file, opts={})
       attrs = {blob: file, prefix: opts[:prefix]}
-      ds = create_datastream(self.class.datastream_class_for_name(opts[:dsid]), opts[:dsid], attrs)
+      file_path = FilePathBuilder.build(self, opts[:dsid], opts[:prefix])
+      ds = create_datastream(self.class.datastream_class_for_name(file_path), file_path, attrs)
       ds.mime_type = if opts[:mimeType]
         Deprecation.warn AttachedFiles, "The :mimeType option to add_file_datastream is deprecated and will be removed in active-fedora 9.0. Use :mime_type instead", caller
         opts[:mimeType]
@@ -120,9 +121,8 @@ module ActiveFedora
         opts[:mime_type]
       end
       ds.original_name = opts[:original_name] if opts.key?(:original_name)
-      attach_file(ds).tap do |dsid|
-        self.class.build_datastream_accessor(dsid) unless respond_to? dsid
-      end
+      attach_file(ds, file_path)
+      self.class.build_datastream_accessor(file_path) unless respond_to? file_path
     end
 
     def create_datastream(type, dsid, opts={})

--- a/lib/active_fedora/datastreams/nokogiri_datastreams.rb
+++ b/lib/active_fedora/datastreams/nokogiri_datastreams.rb
@@ -21,7 +21,7 @@ module ActiveFedora
             ## Load up the template
             xml = self.class.xml_template
           else
-            xml = Nokogiri::XML::Document.parse(datastream_content)
+            xml = Nokogiri::XML::Document.parse(remote_content)
           end
           self.class.decorate_ng_xml xml
         end
@@ -50,7 +50,7 @@ module ActiveFedora
         @ng_xml = nil
       end
 
-      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
+      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods
       def ng_xml_will_change!
         changed_attributes['ng_xml'] = nil
       end
@@ -58,19 +58,19 @@ module ActiveFedora
       def ng_xml_doesnt_change!
         changed_attributes.delete('ng_xml')
       end
-      
-      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods 
+
+      # don't want content eagerly loaded by proxy, so implementing methods that would be implemented by define_attribute_methods
       def ng_xml_changed?
         changed_attributes.has_key? 'ng_xml'
       end
 
-      def datastream_content
+      def remote_content
         @datastream_content ||= Nokogiri::XML(super).to_xml {|config| config.no_declaration}.strip
       end
-      
+
       def content=(new_content)
-        if datastream_content != new_content
-          ng_xml_will_change! 
+        if remote_content != new_content
+          ng_xml_will_change!
           @ng_xml = Nokogiri::XML::Document.parse(new_content)
           super(@ng_xml.to_s.strip)
         end
@@ -102,7 +102,7 @@ module ActiveFedora
               raise "You can only pass instances of Nokogiri::XML::Node into this method.  You passed in #{xml}"
           end
         end
-        
+
         return xml.to_xml.strip
       end
 
@@ -118,7 +118,6 @@ module ActiveFedora
       def xml_loaded
         instance_variable_defined? :@ng_xml
       end
-    
     end
   end
 end

--- a/lib/active_fedora/delegated_attribute.rb
+++ b/lib/active_fedora/delegated_attribute.rb
@@ -16,7 +16,7 @@ module ActiveFedora
     def primary_solr_name
       @datastream ||= datastream_class.new(ActiveFedora::Base.new, dsid)
       if @datastream.respond_to?(:primary_solr_name)
-        @datastream.primary_solr_name(field)
+        @datastream.primary_solr_name(field, dsid)
       else
         raise NoMethodError, "the datastream '#{datastream_class}' doesn't respond to 'primary_solr_name'"
       end

--- a/lib/active_fedora/file_path_builder.rb
+++ b/lib/active_fedora/file_path_builder.rb
@@ -1,0 +1,24 @@
+module ActiveFedora
+  class FilePathBuilder
+    # Builds a relative path for a file
+    def self.build(digital_object, name, prefix)
+      name = nil if name == ''
+      prefix ||= 'DS'
+      name || generate_dsid(digital_object, prefix)
+    end
+
+    # return a valid dsid that is not currently in use.  Uses a prefix (default "DS") and an auto-incrementing integer
+    # Example: if there are already datastreams with IDs DS1 and DS2, this method will return DS3.  If you specify FOO as the prefix, it will return FOO1.
+    def self.generate_dsid(digital_object, prefix)
+      return unless digital_object
+      matches = digital_object.attached_files.keys.map {|d| data = /^#{prefix}(\d+)$/.match(d); data && data[1].to_i}.compact
+      val = matches.empty? ? 1 : matches.max + 1
+      format_dsid(prefix, val)
+    end
+
+    ### Provided so that an application can override how generated ids are formatted (e.g DS01 instead of DS1)
+    def self.format_dsid(prefix, suffix)
+      sprintf("%s%i", prefix,suffix)
+    end
+  end
+end

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -25,8 +25,8 @@ module ActiveFedora
         solr_doc.merge!(SOLR_DOCUMENT_ID.to_sym => id)
         solr_doc.merge!(ActiveFedora::Base.profile_solr_name => to_json)
       end
-      attached_files.each_value do |ds|
-        solr_doc.merge! ds.to_solr()
+      attached_files.each do |name, ds|
+        solr_doc.merge! ds.to_solr(solr_doc, name: name )
       end
       solr_doc = solrize_relationships(solr_doc) unless opts[:model_only]
       solr_doc

--- a/lib/active_fedora/om_datastream.rb
+++ b/lib/active_fedora/om_datastream.rb
@@ -29,8 +29,8 @@ module ActiveFedora
 
     # Return a hash suitable for indexing in solr. Every field name is prefixed with the
     # value returned by the +prefix+ method.
-    def to_solr(solr_doc = {})
-      prefix = self.prefix
+    def to_solr(solr_doc = {}, opts = {})
+      prefix = self.prefix(opts[:name])
       solr_doc.merge super({}).each_with_object({}) { |(key, value), new| new[[prefix,key].join] = value }
     end
 
@@ -87,16 +87,16 @@ module ActiveFedora
     #     </mods:role>
     #     </mods:name>
     #   </mods>
-    def update_indexed_attributes(params={}, opts={})    
+    def update_indexed_attributes(params={}, opts={})
       if self.class.terminology.nil?
         raise "No terminology is set for this OmDatastream class.  Cannot perform update_indexed_attributes"
       end
-      # remove any fields from params that this datastream doesn't recognize    
+      # remove any fields from params that this datastream doesn't recognize
       # make sure to make a copy of params so not to modify hash that might be passed to other methods
       current_params = params.clone
-      current_params.delete_if do |term_pointer,new_values| 
+      current_params.delete_if do |term_pointer,new_values|
         if term_pointer.kind_of?(String)
-          ActiveFedora::Base.logger.warn "WARNING: #{dsid} ignoring {#{term_pointer.inspect} => #{new_values.inspect}} because #{term_pointer.inspect} is a String (only valid OM Term Pointers will be used).  Make sure your html has the correct field_selector tags in it." if ActiveFedora::Base.logger
+          ActiveFedora::Base.logger.warn "WARNING: #{self.class.name} ignoring {#{term_pointer.inspect} => #{new_values.inspect}} because #{term_pointer.inspect} is a String (only valid OM Term Pointers will be used).  Make sure your html has the correct field_selector tags in it." if ActiveFedora::Base.logger
           true
         else
           !self.class.terminology.has_term?(*OM.destringify(term_pointer))

--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -200,8 +200,8 @@ module ActiveFedora
     end
 
     def assign_uri_to_attached_files
-      attached_files.each do |_, ds|
-        ds.digital_object= self
+      attached_files.each do |name, ds|
+        ds.uri= "#{uri}/#{name}"
       end
     end
 

--- a/lib/active_fedora/qualified_dublin_core_datastream.rb
+++ b/lib/active_fedora/qualified_dublin_core_datastream.rb
@@ -148,7 +148,7 @@ module ActiveFedora
        Nokogiri::XML::Document.parse("<dc xmlns:dcterms='http://purl.org/dc/terms/' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'/>")
     end
 
-    def to_solr(solr_doc = Hash.new) # :nodoc:
+    def to_solr(solr_doc = Hash.new, opts = {}) # :nodoc:
       @fields.each do |field_key, field_info|
         things = send(field_key)
         if things

--- a/lib/active_fedora/rdf/datastream_indexing.rb
+++ b/lib/active_fedora/rdf/datastream_indexing.rb
@@ -3,8 +3,8 @@ module ActiveFedora::Rdf
     extend ActiveSupport::Concern
     include Indexing
 
-    def apply_prefix(name)
-      prefix + name.to_s
+    def apply_prefix(name, file_path)
+      prefix(file_path) + name.to_s
     end
   end
 end

--- a/lib/active_fedora/rdf/indexing.rb
+++ b/lib/active_fedora/rdf/indexing.rb
@@ -6,7 +6,7 @@ module ActiveFedora
         include Solrizer::Common
       end
 
-      def apply_prefix(name)
+      def apply_prefix(name, file_path)
         name.to_s
       end
 
@@ -20,19 +20,19 @@ module ActiveFedora
               elsif val.kind_of? ActiveTriples::Resource
                 val = val.solrize
               end
-              self.class.create_and_insert_terms(apply_prefix(field_key), val, field_info[:behaviors], solr_doc)
+              self.class.create_and_insert_terms(apply_prefix(field_key, opts[:name]), val, field_info[:behaviors], solr_doc)
             end
           end
         end
       end
 
       # Gives the primary solr name for a column. If there is more than one indexer on the field definition, it gives the first
-      def primary_solr_name(field)
+      def primary_solr_name(field, file_path)
         config = self.class.config_for_term_or_uri(field)
         return nil unless config # punt on index names for deep nodes!
         if behaviors = config.behaviors
           behaviors.each do |behavior|
-            result = ActiveFedora::SolrService.solr_name(apply_prefix(field), behavior, type: config.type)
+            result = ActiveFedora::SolrService.solr_name(apply_prefix(field, file_path), behavior, type: config.type)
             return result if Solrizer::DefaultDescriptors.send(behavior).evaluate_suffix(:text).stored?
           end
           raise RuntimeError "no stored fields were found"

--- a/lib/active_fedora/rdf/persistence.rb
+++ b/lib/active_fedora/rdf/persistence.rb
@@ -16,11 +16,11 @@ module ActiveFedora
         configure :base_uri => BASE_URI unless base_uri
         attr_accessor :datastream
       end
-     
+
       # Overrides ActiveTriples::Resource
       def persist!
-        return false unless datastream and datastream.respond_to? :digital_object
-        @persisted ||= datastream.digital_object.save
+        return false unless datastream and datastream.respond_to? :save
+        @persisted ||= datastream.save
       end
 
       # Overrides ActiveTriples::Resource

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -13,7 +13,17 @@ module ActiveFedora
           return @subject_block = block
         end
 
-        @subject_block ||= lambda { |ds| ds.digital_object.uri }
+        @subject_block ||= lambda { |ds| parent_uri(ds) }
+      end
+
+      # Trim the last segment off the URI to get the parents uri
+      def parent_uri(ds)
+        m = /^(.*)\/[^\/]*$/.match(ds.uri)
+        if m
+          m[1]
+        else
+          RDF::URI.new(nil)
+        end
       end
 
       ##
@@ -26,13 +36,13 @@ module ActiveFedora
           raise ArgumentError, "#{self} already has a resource_class #{@resource_class}, cannot redefine it to #{klass}" if @resource_class and klass != @resource_class
           raise ArgumentError, "#{klass} must be a subclass of ActiveTriples::Resource" unless klass < ActiveTriples::Resource
         end
-        
+
         @resource_class ||= begin
                               klass = Class.new(klass || ActiveTriples::Resource)
                               klass.send(:include, Rdf::Persistence)
                               klass
                             end
-      end                                                    
+      end
     end
 
     before_save do
@@ -40,6 +50,10 @@ module ActiveFedora
         ActiveFedora::Base.logger.warn "Cowardly refusing to save a datastream with empty content: #{self.inspect}" if ActiveFedora::Base.logger
         false
       end
+    end
+
+    def parent_uri
+      self.class.parent_uri(self)
     end
 
     def metadata?
@@ -56,9 +70,9 @@ module ActiveFedora
       content
     end
 
-    def digital_object=(new_object)
+    def uri=(uri)
       super
-      resource.set_subject!(digital_object.uri) if resource.rdf_subject.value.blank?
+      resource.set_subject!(parent_uri) if resource.rdf_subject.value.blank?
     end
 
     def content_changed?
@@ -82,13 +96,13 @@ module ActiveFedora
       @resource ||= begin
                       klass = self.class.resource_class
                       klass.properties.merge(self.class.properties).each do |prop, config|
-                        klass.property(config.term, 
-                                       predicate: config.predicate, 
-                                       class_name: config.class_name, 
+                        klass.property(config.term,
+                                       predicate: config.predicate,
+                                       class_name: config.class_name,
                                        multivalue: config.multivalue)
                       end
                       klass.accepts_nested_attributes_for(*nested_attributes_options.keys) unless nested_attributes_options.blank?
-                      uri_stub = digital_object ? self.class.rdf_subject.call(self) : nil
+                      uri_stub = self.class.rdf_subject.call(self)
 
                       r = klass.new(uri_stub)
                       r.datastream = self
@@ -121,13 +135,13 @@ module ActiveFedora
     end
 
     def serialize
-      resource.set_subject!(digital_object.uri) if digital_object.id and rdf_subject.node?
+      resource.set_subject!(parent_uri) if parent_uri and rdf_subject.node?
       resource.dump serialization_format
     end
 
     def deserialize(data=nil)
       return RDF::Graph.new if new_record? && data.nil?
-      data ||= datastream_content
+      data ||= remote_content
 
       # Because datastream_content can return nil, we should check that here.
       return RDF::Graph.new if data.nil?

--- a/lib/active_fedora/simple_datastream.rb
+++ b/lib/active_fedora/simple_datastream.rb
@@ -81,7 +81,7 @@ module ActiveFedora
        Nokogiri::XML::Document.parse("<fields/>")
     end
 
-    def to_solr(solr_doc = Hash.new) # :nodoc:
+    def to_solr(solr_doc = Hash.new, opts = {}) # :nodoc:
       @fields.each do |field_key, field_info|
         next if field_key == :location ## FIXME HYDRA-825
         things = send(field_key)

--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -34,7 +34,6 @@ module ActiveFedora
     def create_version
       resp = ActiveFedora.fedora.connection.post(versions_url, nil, {slug: version_name})
       @versions_graph = nil
-      reload
       resp.success?
     end
 

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -110,9 +110,9 @@ describe ActiveFedora::AttachedFiles do
       let(:mds2) { ActiveFedora::QualifiedDublinCoreDatastream.new(obj, "qdc") }
       before do
         fds = ActiveFedora::File.new(obj, "fds")
-        obj.attach_file(mds1)
-        obj.attach_file(mds2)
-        obj.attach_file(fds)
+        obj.attach_file(mds1, 'md1')
+        obj.attach_file(mds2, 'qdc')
+        obj.attach_file(fds, 'fds')
       end
 
       it "should return all of the datastreams from the object that are kinds of OmDatastream " do
@@ -136,13 +136,13 @@ describe ActiveFedora::AttachedFiles do
       let(:ds) { ActiveFedora::File.new(obj, 'DS1') }
 
       it "should be able to add datastreams" do
-        expect(obj.attach_file(ds)).to eq 'DS1'
+        expect(obj.attach_file(ds, 'DS1')).to eq 'DS1'
       end
 
       it "adding and saving should add the datastream to the datastreams array" do
         ds.content = fixture('dino.jpg').read
         expect(obj.attached_files).to_not have_key("DS1")
-        obj.attach_file(ds)
+        obj.attach_file(ds, 'DS1')
         obj.save
         expect(obj.attached_files).to have_key("DS1")
       end
@@ -156,7 +156,7 @@ describe ActiveFedora::AttachedFiles do
       let(:ds) { ActiveFedora::File.new(obj, 'DS1').tap {|ds| ds.content = "foo"; ds.save } }
 
       it "should retrieve blobs that match the saved blobs" do
-        obj.attach_file(ds)
+        obj.attach_file(ds, 'DS1')
         expect(obj.reload.attached_files["DS1"].content).to eq "foo"
       end
     end

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -203,7 +203,7 @@ END
         Object.send(:remove_const, :SpecDatastream)
       end
 
-      let(:parent) { double('inner object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/124", id: '124', new_record?: true) }
+      let(:parent) { ActiveFedora::Base.new id: '124' }
       let (:ds) { SpecDatastream.new(parent, 'descMd') }
 
 

--- a/spec/integration/file_spec.rb
+++ b/spec/integration/file_spec.rb
@@ -4,6 +4,13 @@ require 'active_fedora'
 require "rexml/document"
 
 describe ActiveFedora::File do
+  context "stand alone operation" do
+    it "should save" do
+      subject.content = "some stuff"
+      subject.save
+      expect(subject).not_to be_new_record
+    end
+  end
 
   context "when autocreate is true" do
     before(:all) do
@@ -27,11 +34,6 @@ describe ActiveFedora::File do
     describe "the datastream" do
       subject { descMetadata }
       it { should be_a_kind_of(ActiveFedora::File) }
-    end
-
-    describe "dsid" do
-      subject { descMetadata.dsid }
-      it { should eql("descMetadata") }
     end
 
     describe "#content" do
@@ -64,7 +66,7 @@ describe ActiveFedora::File do
       let(:datastream) { ActiveFedora::File.new(test_object, dsid).tap { |ds| ds.content = content } }
 
       before do
-        test_object.attach_file(datastream)
+        test_object.attach_file(datastream, dsid)
         test_object.save
       end
 

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -155,7 +155,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
     before do
       # reopening existing class
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        rdf_subject { |ds| RDF::URI.new("http://oregondigital.org/ns/#{ds.digital_object.id.split(':')[1]}") }
+        rdf_subject { |ds| RDF::URI.new("http://oregondigital.org/ns/#{parent_uri(ds).split('/')[-1].split(':')[1]}") }
         property :dctype, predicate: RDF::DC.type
       end
       subject.rdf.dctype = "Frog"

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Nesting attribute behavior of RDFDatastream" do
   describe ".attributes=" do
-    let(:parent) { double('inner object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234", id: '1234', new_record?: true) }
+    let(:parent) { ActiveFedora::Base.new(id: '1234') }
 
     describe "complex properties" do
       before do

--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -271,7 +271,7 @@ describe "a versionable OM datastream" do
 
       context "two times" do
 
-        before do  
+        before do
           subject.title = "Surrender and prepare to be boarded"
           subject.save
           subject.create_version
@@ -299,8 +299,8 @@ describe "a versionable OM datastream" do
             subject.restore_version(first_version)
           end
 
-          it "should still have two unique versions" do          
-            expect(subject.versions.size).to eq 2      
+          it "should still have two unique versions" do
+            expect(subject.versions.size).to eq 2
           end
 
           it "should load the restored datastream's content" do

--- a/spec/samples/hydra-mods_article_datastream.rb
+++ b/spec/samples/hydra-mods_article_datastream.rb
@@ -154,8 +154,8 @@ module Hydra
       return builder.doc
     end
 
-    def prefix
-      "#{dsid.underscore}__"
+    def prefix(name)
+      "#{name.underscore}__"
     end
     
     # Generates a new Person node
@@ -509,8 +509,8 @@ module Hydra
         ["data", "supporting file", "profile", "lorem ipsum", "dolor"]
       end
 
-    def to_solr(solr_doc=Hash.new)
-      solr_doc = super(solr_doc)
+    def to_solr(solr_doc=Hash.new, opts={})
+      solr_doc = super
             
       ::Solrizer::Extractor.insert_solr_field_value(solr_doc, Solrizer.default_field_mapper.solr_name('object_type', :facetable), "Article")
       ::Solrizer::Extractor.insert_solr_field_value(solr_doc, Solrizer.default_field_mapper.solr_name('mods_journal_title_info', :facetable), "Unknown") if solr_doc["mods_journal_title_info_facet"].nil? 

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -141,13 +141,13 @@ describe ActiveFedora::AttachedFiles do
   describe "#attach_file" do
     it "should add the datastream to the object" do
       ds = double(:dsid => 'Abc')
-      subject.attach_file(ds)
+      subject.attach_file(ds, 'Abc')
       expect(subject.attached_files['Abc']).to eq ds
     end
 
     it "should mint a dsid" do
       ds = ActiveFedora::File.new(subject)
-      expect(subject.attach_file(ds)).to eq 'DS1'
+      expect(subject.attach_file(ds, 'DS1')).to eq 'DS1'
     end
   end
 
@@ -164,11 +164,6 @@ describe ActiveFedora::AttachedFiles do
   end
 
   describe "#create_datastream" do
-    it "should mint a DSID" do
-      ds = subject.create_datastream(ActiveFedora::File, nil, {})
-      expect(ds.dsid).to eq 'DS1'
-    end
-
     it "should raise an argument error if the supplied dsid is nonsense" do
       expect { subject.create_datastream(ActiveFedora::File, 0) }.to raise_error(ArgumentError)
     end

--- a/spec/unit/base_datastream_management_spec.rb
+++ b/spec/unit/base_datastream_management_spec.rb
@@ -2,32 +2,19 @@ require 'spec_helper'
 
 describe ActiveFedora::Base do
 
-  before(:each) do
-    @test_object = ActiveFedora::Base.new
-  end
-
   describe '.attach_file' do
+    let(:test_object) { ActiveFedora::Base.new }
+    let(:ds) { ActiveFedora::File.new(@test_object, 'ds_to_add') }
+
     it "should not call File.save" do
-      ds = ActiveFedora::File.new(@test_object, 'ds_to_add')
       expect(ds).to receive(:save).never
-      @test_object.attach_file(ds)
+      test_object.attach_file(ds, 'ds1')
     end
+
     it "should add the datastream to the datastreams_in_memory array" do
-      ds = ActiveFedora::File.new(@test_object, 'ds_to_add')
-      expect(@test_object.attached_files).to_not have_key(ds.dsid)
-      @test_object.attach_file(ds)
-      expect(@test_object.attached_files).to have_key(ds.dsid)
-    end
-    it "should auto-assign dsids using auto-incremented integers if dsid is nil or an empty string" do
-      ds = ActiveFedora::File.new(@test_object, nil)
-      expect(ds.dsid).to eq 'DS1'
-      expect(@test_object.attach_file(ds)).to eq 'DS1'
-      ds_emptystringid = ActiveFedora::File.new(@test_object, '')
-      expect(@test_object.attach_file(ds_emptystringid)).to eq 'DS2'
-    end
-    it "should accept a prefix option and apply it to automatically assigned dsids" do
-      ds = ActiveFedora::File.new(@test_object, nil, :prefix=> "FOO")
-      expect(ds.dsid).to eq 'FOO1'
+      expect(test_object.attached_files).to_not have_key('ds_to_add')
+      test_object.attach_file(ds, 'ds_to_add')
+      expect(test_object.attached_files).to have_key('ds_to_add')
     end
   end
 end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -188,19 +188,21 @@ describe ActiveFedora::Base do
 
       describe "dynamic accessors" do
         before do
-          test_history.attach_file(ds)
-          test_history.class.build_datastream_accessor(ds.dsid)
+          test_history.attach_file(ds, dsid)
+          test_history.class.build_datastream_accessor(dsid)
         end
 
         describe "when the file is named with dash" do
-          let(:ds) {double(:dsid=>'eac-cpf')}
+          let(:dsid) { 'eac-cpf' }
+          let(:ds) { double }
           it "should convert dashes to underscores" do
             expect(test_history.eac_cpf).to eq ds
           end
         end
 
         describe "when the file is named with underscore" do
-          let (:ds) { double(:dsid=>'foo_bar') }
+          let(:dsid) { 'foo_bar' }
+          let (:ds) { double }
           it "should preserve the underscore" do
             expect(test_history.foo_bar).to eq ds
           end

--- a/spec/unit/file_path_builder_spec.rb
+++ b/spec/unit/file_path_builder_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe ActiveFedora::FilePathBuilder do
+  describe ".build" do
+    let(:parent) { ActiveFedora::Base.new(id: '1234') }
+    subject { ActiveFedora::FilePathBuilder.build(parent, nil, 'FOO') }
+
+    it { should eq 'FOO1' }
+
+    context "when some datastreams exist" do
+      before do
+        allow(parent).to receive(:attached_files).and_return('FOO56' => double)
+      end
+
+      it { should eq 'FOO57' }
+    end
+  end
+end

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ActiveFedora::Datastream do
-  let(:parent) { double('inner object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234", id: '1234', new_record?: true) }
+  let(:parent) { ActiveFedora::Base.new(id: '1234') }
   let(:datastream) { ActiveFedora::Datastream.new(parent, 'abcd') }
 
   subject { datastream }
@@ -35,33 +35,16 @@ describe ActiveFedora::Datastream do
     end
   end
 
-  describe "#generate_dsid" do
-    let(:parent) { double('inner object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234", id: '1234',
-                          new_record?: true, attached_files: datastreams) }
-
-    subject { ActiveFedora::Datastream.new(parent, nil, prefix: 'FOO') }
-
-    let(:datastreams) { { } }
-
-    it "should set the dsid" do
-      expect(subject.dsid).to eq 'FOO1'
-    end
+  describe "#uri" do
+    let(:parent) { ActiveFedora::Base.new(id: '1234') }
+    subject { ActiveFedora::Datastream.new(parent, 'FOO1') }
 
     it "should set the uri" do
       expect(subject.uri).to eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234/FOO1"
     end
-
-    context "when some datastreams exist" do
-      let(:datastreams) { {'FOO56' => double} }
-
-      it "should start from the highest existing dsid" do
-        expect(subject.dsid).to eq 'FOO57'
-      end
-    end
   end
 
   context "content" do
-    
     let(:mock_conn) do
       Faraday.new do |builder|
         builder.adapter :test, conn_stubs do |stub|
@@ -75,12 +58,16 @@ describe ActiveFedora::Datastream do
 
     let(:conn_stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.head('/fedora/rest/test/1234/abcd') { [200, {'Content-Length' => '9999' }] }
+        stub.head(path) { [200, {'Content-Length' => '9999' }] }
       end
     end
 
+    let(:path) { '/fedora/rest/test/1234/abcd' }
+
+    let(:ldp_source) { Ldp::Resource.new(mock_client, path) }
+
     before do
-      allow(subject).to receive(:ldp_connection).and_return(mock_client)
+      allow(subject).to receive(:ldp_source).and_return(ldp_source)
     end
 
     describe '#persisted_size' do
@@ -155,6 +142,7 @@ describe ActiveFedora::Datastream do
         end
 
       end
+
       context "when content is zero" do
         let(:conn_stubs) do
           Faraday::Adapter::Test::Stubs.new do |stub|
@@ -166,7 +154,6 @@ describe ActiveFedora::Datastream do
         end
       end
     end
-  
   end
 
   context "when the datastream has local content" do

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe ActiveFedora::RDFDatastream do
-  let(:parent) { double(new_record?: true, uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/test:1", id: 'test:1') }
+  let(:parent) { ActiveFedora::Base.new(id: 'test-1') }
   describe "a new instance" do
     subject { ActiveFedora::RDFDatastream.new(parent, 'descMetadata') }
     it { should be_metadata }
@@ -82,7 +82,7 @@ describe ActiveFedora::RDFDatastream do
     let(:ds) do
       ActiveFedora::NtriplesRDFDatastream.new(parent, 'descMetadata').tap do |datastream|
         datastream.stub(:new_record?).and_return(false)
-        datastream.stub(:datastream_content).and_return("<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT'))
+        datastream.stub(:remote_content).and_return("<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT'))
       end
     end
     it "should not error on access" do

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -120,7 +120,7 @@ describe ActiveFedora::RDFDatastream do
           end
 
           it "should have datastream content" do
-            expect(@object.descMetadata.datastream_content).not_to be_blank
+            expect(@object.descMetadata.remote_content).not_to be_blank
           end
         end
       end

--- a/spec/unit/rdfxml_rdf_datastream_spec.rb
+++ b/spec/unit/rdfxml_rdf_datastream_spec.rb
@@ -78,7 +78,7 @@ describe ActiveFedora::RdfxmlRDFDatastream do
     end
 
     describe "a new instance" do
-      subject { MyDatastream.new(double('parent object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/123", new_record?: true), 'descMetadata', about: "http://library.ucsd.edu/ark:/20775/") }
+      subject { MyDatastream.new(ActiveFedora::Base.new(id: '123'), 'descMetadata', about: "http://library.ucsd.edu/ark:/20775/") }
       it "should have a subject" do
         expect(subject.rdf_subject.to_s).to eq "http://library.ucsd.edu/ark:/20775/"
       end
@@ -86,7 +86,7 @@ describe ActiveFedora::RdfxmlRDFDatastream do
     end
 
     describe "an instance with content" do
-      let(:parent) { double('parent object', uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/234", id: 'foo',  new_record?: true) }
+      let(:parent) {ActiveFedora::Base.new(id: '234') }
       subject do
         subject = MyDatastream.new(parent, 'descMetadata', about: "http://library.ucsd.edu/ark:/20775/")
         subject.content = File.new('spec/fixtures/damsObjectModel.xml').read
@@ -97,9 +97,6 @@ describe ActiveFedora::RdfxmlRDFDatastream do
       end
       it "should have mimeType" do
         expect(subject.mime_type).to eq 'text/xml'
-      end
-      it "should have dsid" do
-        expect(subject.dsid).to eq 'descMetadata'
       end
       it "should have fields" do
         expect(subject.resource_type).to eq ["image"]

--- a/spec/unit/simple_datastream_spec.rb
+++ b/spec/unit/simple_datastream_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe ActiveFedora::SimpleDatastream do
 
-  let(:digital_object) { double(new_record?: false, uri: "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/foo123") }
+  let(:digital_object) { ActiveFedora::Base.new(id: 'foo123')}
   let(:sample_xml) { "<fields><coverage>coverage1</coverage><coverage>coverage2</coverage><creation_date>2012-01-15</creation_date><mydate>fake-date</mydate><publisher>publisher1</publisher></fields>" }
 
   before do


### PR DESCRIPTION
This enables files to be created and saved without a container.
