### PR TITLE
Use the headers to get Content-Disposition

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -211,8 +211,7 @@ module ActiveFedora
     end
 
     def fetch_original_name_from_headers
-      # TODO the HEAD didn't have Content-Disposition. Could this be a Fedora bug?
-      m = ldp_source.get.headers['Content-Disposition'].match(/filename="(?<filename>[^"]*)";/)
+      m = ldp_source.head.headers['Content-Disposition'].match(/filename="(?<filename>[^"]*)";/)
       m[:filename]
     end
 


### PR DESCRIPTION
Previously Fedora-4 didn't return Content-Disposition on the HEAD, but
it does now.
