### PR TITLE
Deprecate calling .find with hash

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -52,6 +52,7 @@ module ActiveFedora
 
       if options.present?
         options = args.first unless args.empty?
+        Deprecation.warn(ActiveFedora::Base, "Calling .find with a hash has been deprecated and will not be allowed in active-fedora 10.0. Use .where instead")
         options = {conditions: options}
         apply_finder_options(options)
       else


### PR DESCRIPTION
Calling ActiveFedora::Base.find(id: “foo”) or any other usage with a
hash is deprecated. Use .where instead. Fixes #561 
