### PR TITLE
Support fixity calls to Fedora

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -66,6 +66,7 @@ module ActiveFedora #:nodoc:
     autoload :FileConfigurator
     autoload :FilePathBuilder
     autoload :FilesHash
+    autoload :FixityService
     autoload :Indexing
     autoload :IndexingService
     autoload :LdpResource

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -77,6 +77,10 @@ module ActiveFedora
       @content = nil
     end
 
+    def check_fixity
+      FixityService.new(@ldp_source.subject).check
+    end
+
     def datastream_will_change!
       attribute_will_change! :profile
     end

--- a/lib/active_fedora/fixity_service.rb
+++ b/lib/active_fedora/fixity_service.rb
@@ -1,0 +1,39 @@
+module ActiveFedora
+  class FixityService
+    extend ActiveSupport::Concern
+
+    attr_accessor :target, :response
+
+    # Accepts an Fedora resource such as File.ldp_resource.subject
+    def initialize target  
+      @target = target
+    end
+
+    # Executes a fixity check on Fedora and saves the Faraday::Response.
+    # Returns true when the fixity check was successfully.
+    def check
+      @response = get_fixity_response_from_fedora
+      status.match("SUCCESS") ? true : false
+    end
+
+    def status
+      fixity_graph.query(predicate: status_url).map(&:object).first.to_s
+    end
+
+    private
+
+    def get_fixity_response_from_fedora
+      uri = target + "/fcr:fixity"
+      ActiveFedora.fedora.connection.get(uri)
+    end
+
+    def fixity_graph
+      RDF::Graph.new << RDF::Reader.for(:ttl).new(response.body)
+    end
+    
+    def status_url
+      RDF::URI("http://fedora.info/definitions/v4/repository#status")
+    end
+
+  end
+end

--- a/spec/integration/file_fixity_spec.rb
+++ b/spec/integration/file_fixity_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe "Checking fixity" do
+
+  before(:all) do
+    class MockAFBase < ActiveFedora::Base
+      contains "data", type: ActiveFedora::File, autocreate: true
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :MockAFBase)
+  end
+
+  subject do
+    obj = MockAFBase.create
+    obj.data.content = "some content"
+    obj.save
+    obj.data
+  end
+
+  context "with a valid resource" do
+    it "should return true for a successful fixity check" do
+      expect(subject.check_fixity).to be true
+    end
+  end
+  context "with missing resource" do
+    let(:parent) { ActiveFedora::Base.new(id: '1234') }
+    subject { ActiveFedora::File.new(parent, 'abcd') }
+    it "should raise an error" do
+      expect { subject.check_fixity }.to raise_error(Ldp::NotFound)
+    end
+  end
+
+end

--- a/spec/unit/fixity_service_spec.rb
+++ b/spec/unit/fixity_service_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe ActiveFedora::FixityService do
+
+  subject { ActiveFedora::FixityService.new("http://path/to/resource") }
+
+  it { is_expected.to respond_to(:target) }
+  it { is_expected.to respond_to(:response) }
+
+  describe "#check" do
+    context "with a passing result" do
+      let(:passing_response) do
+        instance_double("Response", body: '<subject> <http://fedora.info/definitions/v4/repository#status> "SUCCESS"^^<http://www.w3.org/2001/XMLSchema#string> .')
+      end
+      before do
+        subject.should_receive(:get_fixity_response_from_fedora).and_return(passing_response)
+      end
+      specify "returns true" do
+        expect(subject.check).to be true
+      end
+
+    end
+
+    context "with a failing result" do
+      let(:failing_response) do
+        instance_double("Response", body: '<subject> <http://fedora.info/definitions/v4/repository#status> "BAD_CHECKSUM"^^<http://www.w3.org/2001/XMLSchema#string> .')
+      end
+      before do
+        subject.should_receive(:get_fixity_response_from_fedora).and_return(failing_response)
+      end
+      specify "returns false" do
+        expect(subject.check).to be false
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Adds a Fixity module to ActiveFedora that can be used to call fixity
checks on resources.
