### PR TITLE
Query File for RDF.type fixes #599

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -79,7 +79,7 @@ module ActiveFedora
       @original_name = nil
       @mime_type = nil
       @content = nil
-      @digest = nil
+      @metadata = nil
     end
 
     def check_fixity
@@ -109,12 +109,17 @@ module ActiveFedora
       @mime_type || default_mime_type
     end
 
+    def metadata
+      @metadata ||= ActiveFedora::WithMetadata::MetadataNode.new(self)
+    end
+
     def original_name
       @original_name ||= fetch_original_name_from_headers
     end
 
     def digest
-      @digest ||= fetch_digest_from_description
+      response = metadata.ldp_source.graph.query(:predicate => RDF::URI.new("http://fedora.info/definitions/v4/repository#digest"))
+      response.map(&:object)
     end
 
     def persisted_size
@@ -219,12 +224,6 @@ module ActiveFedora
 
     def fetch_mime_type
       ldp_source.head.headers['Content-Type']
-    end
-
-    def fetch_digest_from_description
-      description = ActiveFedora::WithMetadata::MetadataNode.new(self)
-      response = description.ldp_source.graph.query(:predicate => RDF::URI.new("http://fedora.info/definitions/v4/repository#digest"))
-      response.map(&:object)
     end
 
     private

--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -15,7 +15,11 @@ module ActiveFedora
     # TODO: This only applies to objects. If we want the same for child resources, it would need to go
     # under fcr:metadata
     def model_type
-      resource.query(subject: resource.rdf_subject, predicate: RDF.type).objects
+      if self.respond_to?(:metadata)
+        metadata.ldp_source.graph.query(predicate: RDF.type).objects
+      else
+        resource.query(subject: resource.rdf_subject, predicate: RDF.type).objects
+      end
     end
 
     def versions

--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -122,7 +122,6 @@ describe "a versionable rdf datastream" do
       end
 
       it "should set model_type to versionable" do
-        pending "This isn't getting saved because it should probaly go on fcr:metadata"
         expect(subject.model_type).to include RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
       end
 
@@ -252,7 +251,6 @@ describe "a versionable OM datastream" do
       end
 
       it "should set model_type to versionable" do
-        pending "This isn't getting saved because it should probaly go on fcr:metadata"
         expect(subject.model_type).to include RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
       end
 
@@ -379,7 +377,6 @@ describe "a versionable binary datastream" do
       end
 
       it "should set model_type to versionable" do
-        pending "This isn't getting saved because it should probaly go on fcr:metadata"
         expect(subject.model_type).to include RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
       end
 


### PR DESCRIPTION
Addresses pending spec tests in versionable.rb. Refactors ActiveFedora::File to make its MetdataNode available for querying.
