### PR TITLE
Consistent use of RDF constant

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -69,10 +69,10 @@ module ActiveFedora #:nodoc:
     autoload :Persistence
     autoload :QualifiedDublinCoreDatastream
     autoload :Querying
-    autoload :Rdf
+    autoload :RDF
     autoload_under 'rdf' do
       autoload :RDFDatastream
-      autoload :RdfxmlRDFDatastream
+      autoload :RDFXMLDatastream
       autoload :NtriplesRDFDatastream
       autoload :FedoraRdfResource
     end

--- a/lib/active_fedora/associations.rb
+++ b/lib/active_fedora/associations.rb
@@ -15,8 +15,8 @@ module ActiveFedora
     autoload :Association,           'active_fedora/associations/association'
     autoload :AssociationScope,      'active_fedora/associations/association_scope'
     autoload :SingularAssociation,   'active_fedora/associations/singular_association'
-    autoload :Rdf,                   'active_fedora/associations/rdf'
-    autoload :SingularRdf,           'active_fedora/associations/singular_rdf'
+    autoload :RDF,                   'active_fedora/associations/rdf'
+    autoload :SingularRDF,           'active_fedora/associations/singular_rdf'
     autoload :CollectionAssociation, 'active_fedora/associations/collection_association'
     autoload :CollectionProxy,       'active_fedora/associations/collection_proxy'
 

--- a/lib/active_fedora/associations/builder/association.rb
+++ b/lib/active_fedora/associations/builder/association.rb
@@ -34,7 +34,7 @@ module ActiveFedora::Associations::Builder
     # Returns the RDF predicate as defined by the :property attribute
     def predicate
       predicate = options[:property]
-      return predicate if predicate.kind_of? RDF::URI
+      return predicate if predicate.kind_of? ::RDF::URI
       ActiveFedora::Predicates.find_graph_predicate(predicate)
     end
 

--- a/lib/active_fedora/associations/builder/belongs_to.rb
+++ b/lib/active_fedora/associations/builder/belongs_to.rb
@@ -12,7 +12,7 @@ module ActiveFedora::Associations::Builder
       if options[:property]
         Deprecation.warn BelongsTo, "the :property option to belongs_to is deprecated and will be removed in active-fedora 10.0. Use :predicate instead", caller(5)
       end
-      if options[:predicate] && !options[:predicate].kind_of?(RDF::URI)
+      if options[:predicate] && !options[:predicate].kind_of?(::RDF::URI)
         raise ArgumentError, "Predicate must be a kind of RDF::URI"
       end
 

--- a/lib/active_fedora/associations/rdf.rb
+++ b/lib/active_fedora/associations/rdf.rb
@@ -1,13 +1,13 @@
 module ActiveFedora
   module Associations
-    class Rdf < SingularAssociation #:nodoc:
+    class RDF < SingularAssociation #:nodoc:
 
       def replace(values)
         raise "can't modify frozen #{owner.class}" if owner.frozen?
         destroy
         values.each do |value|
           uri = ActiveFedora::Base.id_to_uri(value)
-          owner.resource.insert [owner.rdf_subject, reflection.predicate, RDF::URI.new(uri)]
+          owner.resource.insert [owner.rdf_subject, reflection.predicate, ::RDF::URI.new(uri)]
         end
         owner.send(:attribute_will_change!, reflection.name)
       end
@@ -62,7 +62,7 @@ module ActiveFedora
           }
         end
 
-        docs.map {|doc| RDF::URI.new(ActiveFedora::Base.id_to_uri(doc['id']))}
+        docs.map {|doc| ::RDF::URI.new(ActiveFedora::Base.id_to_uri(doc['id']))}
       end
 
       ##

--- a/lib/active_fedora/associations/singular_rdf.rb
+++ b/lib/active_fedora/associations/singular_rdf.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class SingularRdf < Rdf #:nodoc:
+    class SingularRDF < RDF #:nodoc:
 
       def replace(value)
         super(Array(value))

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -3,14 +3,14 @@ module ActiveFedora
     extend ActiveSupport::Concern
 
     included do
-      include Rdf::Indexing
+      include RDF::Indexing
       include ActiveTriples::Properties
       include ActiveTriples::Reflection
       delegate :rdf_subject,  :get_values, to: :resource
 
-      property :has_model, predicate: RDF::URI.new("http://fedora.info/definitions/v4/rels-ext#hasModel")
-      property :create_date, predicate: ActiveFedora::Rdf::Fcrepo.created
-      property :modified_date, predicate: ActiveFedora::Rdf::Fcrepo.lastModified
+      property :has_model, predicate: ::RDF::URI.new("http://fedora.info/definitions/v4/rels-ext#hasModel")
+      property :create_date, predicate: ActiveFedora::RDF::Fcrepo.created
+      property :modified_date, predicate: ActiveFedora::RDF::Fcrepo.lastModified
 
       def create_date
         super.first
@@ -28,7 +28,7 @@ module ActiveFedora
     end
 
     def id
-      if uri.kind_of?(RDF::URI) && uri.value.blank?
+      if uri.kind_of?(::RDF::URI) && uri.value.blank?
         nil
       elsif uri.present?
         self.class.uri_to_id(URI.parse(uri))

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -28,7 +28,7 @@ module ActiveFedora
         @ldp_source = Ldp::Resource::BinarySource.new(ldp_connection, parent_or_url_or_hash, content, ActiveFedora.fedora.host + ActiveFedora.fedora.base_path)
       when ActiveFedora::Base
         Deprecation.warn File, "Initializing a file by passing a container is deprecated. Initialize with a uri instead. This capability will be removed in active-fedora 10.0"
-        uri = if parent_or_url_or_hash.uri.kind_of?(RDF::URI) && parent_or_url_or_hash.uri.value.empty?
+        uri = if parent_or_url_or_hash.uri.kind_of?(::RDF::URI) && parent_or_url_or_hash.uri.value.empty?
           nil
         else
           "#{parent_or_url_or_hash.uri}/#{dsid}"
@@ -118,7 +118,7 @@ module ActiveFedora
     end
 
     def digest
-      response = metadata.ldp_source.graph.query(:predicate => RDF::URI.new("http://fedora.info/definitions/v4/repository#digest"))
+      response = metadata.ldp_source.graph.query(:predicate => ::RDF::URI.new("http://fedora.info/definitions/v4/repository#digest"))
       response.map(&:object)
     end
 

--- a/lib/active_fedora/fixity_service.rb
+++ b/lib/active_fedora/fixity_service.rb
@@ -29,11 +29,11 @@ module ActiveFedora
     end
 
     def fixity_graph
-      RDF::Graph.new << RDF::Reader.for(:ttl).new(response.body)
+      ::RDF::Graph.new << ::RDF::Reader.for(:ttl).new(response.body)
     end
 
     def status_url
-      RDF::URI("http://fedora.info/definitions/v4/repository#status")
+      ::RDF::URI("http://fedora.info/definitions/v4/repository#status")
     end
 
   end

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -79,7 +79,7 @@ module ActiveFedora
 
       def get_descendent_uris(uri)
         resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
-        immediate_descendent_uris = resource.graph.query(predicate: RDF::LDP.contains).map { |descendent| descendent.object.to_s }
+        immediate_descendent_uris = resource.graph.query(predicate: ::RDF::LDP.contains).map { |descendent| descendent.object.to_s }
         all_descendents_uris = [uri]
         immediate_descendent_uris.each do |descendent_uri|
           all_descendents_uris += get_descendent_uris(descendent_uri)

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -74,7 +74,7 @@ module ActiveFedora
       end
 
       def rdf_subject
-        RDF::URI.new(nil)
+        ::RDF::URI.new(nil)
       end
 
       def insert(vals)

--- a/lib/active_fedora/predicates.rb
+++ b/lib/active_fedora/predicates.rb
@@ -6,7 +6,7 @@ module ActiveFedora
         namespace = match[1]
         predicate = match[2]
         Predicates.predicate_mappings[namespace].invert[predicate]
-      elsif predicate.kind_of? RDF::URI
+      elsif predicate.kind_of? ::RDF::URI
         predicate.to_s.split('/', 4).last.gsub(/(\/|#)/, '_').underscore
       else
         raise "Unable to parse predicate: #{predicate}"
@@ -44,7 +44,7 @@ module ActiveFedora
     def self.vocabularies(vocabs = {})
       @vocabularies ||= vocabs
       predicate_mappings.keys.each do |ns| 
-        @vocabularies[ns] = RDF::Vocabulary.new(ns) unless @vocabularies.has_key? ns
+        @vocabularies[ns] = ::RDF::Vocabulary.new(ns) unless @vocabularies.has_key? ns
       end
       @vocabularies
     end

--- a/lib/active_fedora/rdf.rb
+++ b/lib/active_fedora/rdf.rb
@@ -1,5 +1,5 @@
 module ActiveFedora
-  module Rdf
+  module RDF
     extend ActiveSupport::Autoload
     autoload :DatastreamIndexing
     autoload :Fcrepo

--- a/lib/active_fedora/rdf/datastream_indexing.rb
+++ b/lib/active_fedora/rdf/datastream_indexing.rb
@@ -1,4 +1,4 @@
-module ActiveFedora::Rdf
+module ActiveFedora::RDF
   module DatastreamIndexing
     extend ActiveSupport::Concern
     include Indexing

--- a/lib/active_fedora/rdf/fcrepo.rb
+++ b/lib/active_fedora/rdf/fcrepo.rb
@@ -1,5 +1,5 @@
 require 'rdf'
-class ActiveFedora::Rdf::Fcrepo < RDF::StrictVocabulary("http://fedora.info/definitions/v4/repository#")
+class ActiveFedora::RDF::Fcrepo < RDF::StrictVocabulary("http://fedora.info/definitions/v4/repository#")
 
     # Property definitions
     property :hasContent, comment: %(Defining where the fedora object has content.)

--- a/lib/active_fedora/rdf/indexing.rb
+++ b/lib/active_fedora/rdf/indexing.rb
@@ -1,5 +1,5 @@
 module ActiveFedora
-  module Rdf
+  module RDF
     module Indexing
       extend ActiveSupport::Concern
       included do
@@ -15,7 +15,7 @@ module ActiveFedora
           fields.each do |field_key, field_info|
             values = resource.get_values(field_key)
             Array(values).each do |val|
-              if val.kind_of? RDF::URI
+              if val.kind_of? ::RDF::URI
                 val = val.to_s
               elsif val.kind_of? ActiveTriples::Resource
                 val = val.solrize

--- a/lib/active_fedora/rdf/ldp.rb
+++ b/lib/active_fedora/rdf/ldp.rb
@@ -1,5 +1,5 @@
 require 'rdf'
-class ActiveFedora::Rdf::Ldp < RDF::StrictVocabulary("http://www.w3.org/ns/ldp#")
+class ActiveFedora::RDF::Ldp < RDF::StrictVocabulary("http://www.w3.org/ns/ldp#")
   # Property definitions
   property :contains
   property :member

--- a/lib/active_fedora/rdf/persistence.rb
+++ b/lib/active_fedora/rdf/persistence.rb
@@ -1,11 +1,11 @@
 module ActiveFedora
-  module Rdf
+  module RDF
     #
     # Mixin for adding datastream persistence to an ActiveTriples::Resource 
     # descendant so that it may be used to back an ActiveFedora::RDFDatastream.
     #
     # @see ActiveFedora::RDFDatastream.resource_class
-    # @see ActiveFedora::Rdf::ObjectResource
+    # @see ActiveFedora::RDF::ObjectResource
     #
     module Persistence
       extend ActiveSupport::Concern

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -1,7 +1,7 @@
 module ActiveFedora
   class RDFDatastream < File
     include ActiveTriples::NestedAttributes
-    include Rdf::DatastreamIndexing
+    include RDF::DatastreamIndexing
     include ActiveTriples::Properties
     include ActiveTriples::Reflection
 
@@ -22,13 +22,13 @@ module ActiveFedora
         if m
           m[1]
         else
-          RDF::URI.new(nil)
+          ::RDF::URI.new(nil)
         end
       end
 
       ##
       # @param [Class] an object to set as the resource class, Must be a descendant of 
-      # ActiveTriples::Resource and include ActiveFedora::Rdf::Persistence.
+      # ActiveTriples::Resource and include ActiveFedora::RDF::Persistence.
       #
       # @return [Class] the object resource class
       def resource_class(klass=nil)
@@ -39,7 +39,7 @@ module ActiveFedora
 
         @resource_class ||= begin
                               klass = Class.new(klass || ActiveTriples::Resource)
-                              klass.send(:include, Rdf::Persistence)
+                              klass.send(:include, RDF::Persistence)
                               klass
                             end
       end
@@ -144,14 +144,14 @@ module ActiveFedora
     end
 
     def deserialize(data=nil)
-      return RDF::Graph.new if new_record? && data.nil?
+      return ::RDF::Graph.new if new_record? && data.nil?
       data ||= remote_content
 
       # Because datastream_content can return nil, we should check that here.
-      return RDF::Graph.new if data.nil?
+      return ::RDF::Graph.new if data.nil?
 
       data.force_encoding('utf-8')
-      RDF::Graph.new << RDF::Reader.for(serialization_format).new(data)
+      ::RDF::Graph.new << ::RDF::Reader.for(serialization_format).new(data)
     end
 
     def serialization_format

--- a/lib/active_fedora/rdf/rdfxml_datastream.rb
+++ b/lib/active_fedora/rdf/rdfxml_datastream.rb
@@ -1,7 +1,7 @@
 require 'rdf/rdfxml'
 
 module ActiveFedora
-  class RdfxmlRDFDatastream < RDFDatastream
+  class RDFXMLDatastream < RDFDatastream
     def serialization_format
       :rdfxml 
     end

--- a/lib/active_fedora/rdf/rels_ext.rb
+++ b/lib/active_fedora/rdf/rels_ext.rb
@@ -1,5 +1,5 @@
 require 'rdf'
-class ActiveFedora::Rdf::RelsExt < RDF::StrictVocabulary("http://fedora.info/definitions/v4/rels-ext#")
+class ActiveFedora::RDF::RelsExt < RDF::StrictVocabulary("http://fedora.info/definitions/v4/rels-ext#")
   property :hasAnnotation
   property :hasCollectionMember
   property :hasConstituent

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -13,7 +13,7 @@ module ActiveFedora
           when :has_many, :belongs_to, :has_and_belongs_to_many, :contains
             AssociationReflection
           when :rdf, :singular_rdf
-            RdfPropertyReflection
+            RDFPropertyReflection
         end
         reflection = klass.new(macro, name, options, active_fedora)
         add_reflection name, reflection
@@ -37,7 +37,7 @@ module ActiveFedora
       end
 
       def outgoing_reflections
-        reflections.select { |_, reflection| reflection.kind_of? RdfPropertyReflection }
+        reflections.select { |_, reflection| reflection.kind_of? RDFPropertyReflection }
       end
 
       def child_resource_reflections
@@ -190,7 +190,7 @@ module ActiveFedora
       # TODO this is dupliacate code from Associations::Builder::Association
       def predicate
         predicate = options[:predicate] || options[:property]
-        return predicate if predicate.kind_of? RDF::URI
+        return predicate if predicate.kind_of? ::RDF::URI
         ActiveFedora::Predicates.find_graph_predicate(predicate)
       end
 
@@ -253,9 +253,9 @@ module ActiveFedora
         when :has_many
           Associations::HasManyAssociation
         when :singular_rdf
-          Associations::SingularRdf
+          Associations::SingularRDF
         when :rdf
-          Associations::Rdf
+          Associations::RDF
         end
       end
 
@@ -328,7 +328,7 @@ module ActiveFedora
       end
     end
 
-    class RdfPropertyReflection < AssociationReflection
+    class RDFPropertyReflection < AssociationReflection
 
       def derive_foreign_key
         name

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -204,7 +204,7 @@ module ActiveFedora
 
     # TODO just use has_model
     def has_model_value(resource)
-      Ldp::Orm.new(resource).value(RDF::URI.new("http://fedora.info/definitions/v4/rels-ext#hasModel")).first.to_s
+      Ldp::Orm.new(resource).value(::RDF::URI.new("http://fedora.info/definitions/v4/rels-ext#hasModel")).first.to_s
     end
 
     def find_with_ids(ids, cast)

--- a/lib/active_fedora/sparql_insert.rb
+++ b/lib/active_fedora/sparql_insert.rb
@@ -3,7 +3,7 @@ module ActiveFedora
 
     attr_reader :changes, :subject
 
-    def initialize(changes, subject = RDF::URI.new(nil))
+    def initialize(changes, subject = ::RDF::URI.new(nil))
       @changes = changes
       @subject = subject
     end
@@ -20,7 +20,7 @@ module ActiveFedora
       query +=
         changes.map do |_, result|
           result.map do |statement|
-            RDF::Query::Pattern.new(subject: subject, predicate: statement.predicate, object: statement.object).to_s
+            ::RDF::Query::Pattern.new(subject: subject, predicate: statement.predicate, object: statement.object).to_s
           end.join("\n")
         end.join("\n")
 
@@ -38,7 +38,7 @@ module ActiveFedora
 
     def patterns(subject)
       changes.map do |key, _|
-        RDF::Query::Pattern.new(subject, key, :change).to_s
+        ::RDF::Query::Pattern.new(subject, key, :change).to_s
       end
     end
   end

--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -16,19 +16,19 @@ module ActiveFedora
     # under fcr:metadata
     def model_type
       if self.respond_to?(:metadata)
-        metadata.ldp_source.graph.query(predicate: RDF.type).objects
+        metadata.ldp_source.graph.query(predicate: ::RDF.type).objects
       else
-        resource.query(subject: resource.rdf_subject, predicate: RDF.type).objects
+        resource.query(subject: resource.rdf_subject, predicate: ::RDF.type).objects
       end
     end
 
     def versions
-      results = versions_graph.query([nil, RDF::URI.new('http://fedora.info/definitions/v4/repository#hasVersionLabel'), nil])
+      results = versions_graph.query([nil, ::RDF::URI.new('http://fedora.info/definitions/v4/repository#hasVersionLabel'), nil])
       results.map(&:object)
     end
 
     def versions_graph
-      @versions_graph ||= RDF::Graph.new << RDF::Reader.for(:ttl).new(versions_request)
+      @versions_graph ||= ::RDF::Graph.new << ::RDF::Reader.for(:ttl).new(versions_request)
     end
 
     def versions_url

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -15,7 +15,7 @@ module ActiveFedora
 
       def metadata_uri
         @metadata_uri ||= if file.new_record?
-          RDF::URI.new nil
+          ::RDF::URI.new nil
         else
           raise "#{file} must respond_to described_by" unless file.respond_to? :described_by
           file.described_by
@@ -38,7 +38,7 @@ module ActiveFedora
       def save
         raise "Save the file first" if file.new_record?
         change_set = ChangeSet.new(self, self, changed_attributes.keys)
-        SparqlInsert.new(change_set.changes, RDF::URI.new(file.uri)).execute(metadata_uri)
+        SparqlInsert.new(change_set.changes, ::RDF::URI.new(file.uri)).execute(metadata_uri)
         @ldp_source = nil
         true
       end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -4,7 +4,7 @@ describe ActiveFedora::Base do
   describe "use a URI as the property" do
     before do
       class Book < ActiveFedora::Base
-        belongs_to :author, predicate: RDF::DC.creator, class_name: 'Person'
+        belongs_to :author, predicate: ::RDF::DC.creator, class_name: 'Person'
       end
 
       class Person < ActiveFedora::Base
@@ -28,13 +28,13 @@ describe ActiveFedora::Base do
   describe "complex example" do
     before do
       class Library < ActiveFedora::Base
-        has_many :books, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
+        has_many :books, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
-        belongs_to :author, predicate: ActiveFedora::Rdf::RelsExt.hasMember, class_name: 'Person'
-        belongs_to :publisher, predicate: ActiveFedora::Rdf::RelsExt.hasMember
+        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        belongs_to :author, predicate: ActiveFedora::RDF::RelsExt.hasMember, class_name: 'Person'
+        belongs_to :publisher, predicate: ActiveFedora::RDF::RelsExt.hasMember
       end
 
       class Person < ActiveFedora::Base
@@ -335,10 +335,10 @@ describe ActiveFedora::Base do
   describe "single direction habtm" do
     before :all do
       class Course < ActiveFedora::Base
-        has_and_belongs_to_many :textbooks, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+        has_and_belongs_to_many :textbooks, predicate: ActiveFedora::RDF::RelsExt.isPartOf
       end
       class Textbook < ActiveFedora::Base
-        has_many :courses, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+        has_many :courses, predicate: ActiveFedora::RDF::RelsExt.isPartOf
       end
 
     end
@@ -395,7 +395,7 @@ describe ActiveFedora::Base do
     describe "for habtm" do
       before :all do
         class LibraryBook < ActiveFedora::Base
-          has_and_belongs_to_many :pages, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, after_remove: :after_hook, before_remove: :before_hook
+          has_and_belongs_to_many :pages, predicate: ActiveFedora::RDF::RelsExt.isPartOf, after_remove: :after_hook, before_remove: :before_hook
 
           def before_hook(m)
             say_hi(m)
@@ -413,7 +413,7 @@ describe ActiveFedora::Base do
 
         end
         class Page < ActiveFedora::Base
-          has_many :library_books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          has_many :library_books, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
 
       end
@@ -441,11 +441,11 @@ describe ActiveFedora::Base do
     describe "for has_many" do
       before :all do
         class LibraryBook < ActiveFedora::Base
-          has_many :pages, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, after_remove: :say_hi
+          has_many :pages, predicate: ActiveFedora::RDF::RelsExt.isPartOf, after_remove: :say_hi
 
         end
         class Page < ActiveFedora::Base
-          belongs_to :library_book, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          belongs_to :library_book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
       end
 
@@ -472,7 +472,7 @@ describe ActiveFedora::Base do
     describe "when an object doesn't have a property, and the class_name is predictable" do
       before (:all) do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
           has_many :baubles
@@ -491,7 +491,7 @@ describe ActiveFedora::Base do
     describe "when an object doesn't have a property, but has a class_name" do
       before :all do
         class MasterFile < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
           has_many :parts, class_name: 'MasterFile'
@@ -511,10 +511,10 @@ describe ActiveFedora::Base do
     describe "an object has an explicity property" do
       before :all do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
-          has_many :baubles, predicate: ActiveFedora::Rdf::RelsExt.hasEquivalent
+          has_many :baubles, predicate: ActiveFedora::RDF::RelsExt.hasEquivalent
         end
       end
 
@@ -531,7 +531,7 @@ describe ActiveFedora::Base do
     describe "an object doesn't have a property" do
       before :all do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         end
 
         class MediaObject < ActiveFedora::Base
@@ -554,16 +554,16 @@ describe ActiveFedora::Base do
     describe "for habtm" do
       before :all do
         class Novel < ActiveFedora::Base
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class TextBook < ActiveFedora::Base
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Text < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Image < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
       end
 

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -17,7 +17,7 @@ describe "delegating attributes" do
     class RdfObject < ActiveFedora::Base
       contains 'foo', class_name: 'PropertiesDatastream'
       has_attributes :depositor, datastream: :foo, multiple: false
-      property :resource_type, predicate: RDF::DC.type do |index|
+      property :resource_type, predicate: ::RDF::DC.type do |index|
         index.as :stored_searchable, :facetable
       end
     end

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -82,7 +82,7 @@ describe ActiveFedora::Base do
   describe "a saved object" do
     before do
       class Book < ActiveFedora::Base
-        property :title, predicate: RDF::DC.title
+        property :title, predicate: ::RDF::DC.title
       end
     end
 
@@ -103,11 +103,9 @@ describe ActiveFedora::Base do
       it { should_not be_nil }
     end
 
-    describe "that is updated" do
+    context "when updated with changes after one second" do
       before do
-        # Give something to save
-        obj.title = ['sample']#resource.insert([obj.rdf_subject, RDF::DC.title, 'sample'])
-        # Make sure the modification time changes by at least 1 second
+        obj.title = ['sample']
         sleep 1
       end
 

--- a/spec/integration/belongs_to_association_spec.rb
+++ b/spec/integration/belongs_to_association_spec.rb
@@ -7,7 +7,7 @@ describe ActiveFedora::Base do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
     end
     class SpecialInheritedBook < Book
     end
@@ -86,23 +86,23 @@ describe ActiveFedora::Base do
   describe "casting inheritance detailed test cases" do
     before :all do
       class SimpleObject < ActiveFedora::Base
-        belongs_to :simple_collection, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'SimpleCollection'
-        belongs_to :complex_collection, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ComplexCollection'
+        belongs_to :simple_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleCollection'
+        belongs_to :complex_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexCollection'
       end
 
       class ComplexObject < SimpleObject
-        belongs_to :simple_collection, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'SimpleCollection'
-        belongs_to :complex_collection, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ComplexCollection'
+        belongs_to :simple_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleCollection'
+        belongs_to :complex_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexCollection'
       end
 
       class SimpleCollection < ActiveFedora::Base
-        has_many :objects, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
-        has_many :complex_objects, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
+        has_many :objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
+        has_many :complex_objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
       end
 
       class ComplexCollection < SimpleCollection
-        has_many :objects, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
-        has_many :complex_objects, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
+        has_many :objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
+        has_many :complex_objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
       end
 
     end

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -6,7 +6,7 @@ describe ActiveFedora::Base do
       has_many :books
     end
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasMember
+      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasMember
     end
   end
   let(:library) { Library.create! }

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -4,10 +4,10 @@ describe "Nested Rdf Objects" do
   describe "without type" do
     before do
       class SpecDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :parts, predicate: RDF::DC.hasPart, class_name: 'Component'
+        property :parts, predicate: ::RDF::DC.hasPart, class_name: 'Component'
 
         class Component < ActiveTriples::Resource
-          property :label, predicate: RDF::DC.title
+          property :label, predicate: ::RDF::DC.title
         end
       end
 
@@ -131,11 +131,11 @@ END
     describe "one class per assertion" do
       before(:each) do
         class SpecDatastream < ActiveFedora::NtriplesRDFDatastream
-          property :mediator, predicate: RDF::DC.mediator, class_name: 'MediatorUser'
+          property :mediator, predicate: ::RDF::DC.mediator, class_name: 'MediatorUser'
 
           class MediatorUser < ActiveTriples::Resource
-            configure type: RDF::DC.AgentClass
-            property :title, predicate: RDF::DC.title
+            configure type: ::RDF::DC.AgentClass
+            property :title, predicate: ::RDF::DC.title
           end
         end
       end
@@ -150,7 +150,7 @@ END
         comp = SpecDatastream::MediatorUser.new ds.graph
         comp.title = ["Doctor"]
         ds.mediator = comp
-        expect(ds.mediator.first.type.first).to be_instance_of RDF::URI
+        expect(ds.mediator.first.type.first).to be_instance_of ::RDF::URI
         expect(ds.mediator.first.type.first.to_s).to eq "http://purl.org/dc/terms/AgentClass"
         expect(ds.mediator.first.title.first).to eq 'Doctor'
       end

--- a/spec/integration/fedora_solr_sync_spec.rb
+++ b/spec/integration/fedora_solr_sync_spec.rb
@@ -4,11 +4,11 @@ require 'timeout'
 describe "fedora_solr_sync_issues" do
   before :all do
     class ParentThing < ActiveFedora::Base
-      has_many :things, :class_name=>'ChildThing', predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      has_many :things, :class_name=>'ChildThing', predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
 
     class ChildThing < ActiveFedora::Base
-      belongs_to :parent, :class_name=>'ParentThing', predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :parent, :class_name=>'ParentThing', predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
   end
 

--- a/spec/integration/field_to_solr_name_spec.rb
+++ b/spec/integration/field_to_solr_name_spec.rb
@@ -5,10 +5,10 @@ describe "An object with RDF backed attributes" do
   before do
     class TestOne < ActiveFedora::Base
       class MyMetadata < ActiveFedora::NtriplesRDFDatastream
-        property :title, predicate: RDF::DC.title do |index|
+        property :title, predicate: ::RDF::DC.title do |index|
           index.as :stored_searchable
         end
-        property :date_uploaded, predicate: RDF::DC.dateSubmitted do |index|
+        property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
           index.type :date
           index.as :stored_searchable, :sortable
         end

--- a/spec/integration/has_and_belongs_to_many_associations_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_associations_spec.rb
@@ -306,7 +306,7 @@ describe "create" do
     end
 
     class Collection < ActiveFedora::Base
-      property :title, predicate: RDF::DC.title
+      property :title, predicate: ::RDF::DC.title
     end
   end
 

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -7,7 +7,7 @@ describe "Collection members" do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
     end
   end
   after :all do
@@ -69,7 +69,7 @@ describe "After save callbacks" do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
       after_save :find_self
       attr_accessor :library_books
 
@@ -101,11 +101,11 @@ describe "When two or more relationships share the same property" do
     end
 
     class Person < ActiveFedora::Base
-      belongs_to :book, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
 
     class Collection < ActiveFedora::Base
-      belongs_to :book, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
 
     @book = Book.create!
@@ -128,14 +128,14 @@ end
 describe "with an polymorphic association" do
   before do
     class Permissionable1 < ActiveFedora::Base
-      has_many :permissions, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, inverse_of: :access_to
+      has_many :permissions, predicate: ActiveFedora::RDF::RelsExt.isPartOf, inverse_of: :access_to
     end
     class Permissionable2 < ActiveFedora::Base
-      has_many :permissions, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, inverse_of: :access_to
+      has_many :permissions, predicate: ActiveFedora::RDF::RelsExt.isPartOf, inverse_of: :access_to
     end
 
     class Permission < ActiveFedora::Base
-      belongs_to :access_to, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      belongs_to :access_to, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
     end
   end
 
@@ -155,15 +155,15 @@ end
 describe "When relationship is restricted to AF::Base" do
   before do
     class Email < ActiveFedora::Base
-      has_many :attachments, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, :class_name=>'ActiveFedora::Base'
+      has_many :attachments, predicate: ActiveFedora::RDF::RelsExt.isPartOf, :class_name=>'ActiveFedora::Base'
     end
 
     class Image < ActiveFedora::Base
-      belongs_to :email, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :email, predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
 
     class PDF < ActiveFedora::Base
-      belongs_to :email, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :email, predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
   end
 
@@ -211,7 +211,7 @@ describe "Deleting a dependent relationship" do
       has_many :components
     end
     class Component < ActiveFedora::Base
-      belongs_to :item, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+      belongs_to :item, predicate: ActiveFedora::RDF::RelsExt.isPartOf
     end
   end
 
@@ -279,7 +279,7 @@ describe "Autosave" do
         has_attributes :title, datastream: 'foo'
       end
       class Component < ActiveFedora::Base
-        belongs_to :item, predicate: ActiveFedora::Rdf::RelsExt.isPartOf
+        belongs_to :item, predicate: ActiveFedora::RDF::RelsExt.isPartOf
         has_metadata "foo", type: ActiveFedora::SimpleDatastream do |m|
           m.field "description", :string
         end
@@ -315,11 +315,11 @@ describe "Autosave" do
     context "with ActiveFedora::Base as classes" do
       before do
         class Novel < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Text < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
       end
       let(:text) { Text.create}

--- a/spec/integration/json_serialization_spec.rb
+++ b/spec/integration/json_serialization_spec.rb
@@ -14,7 +14,7 @@ describe "Objects should be serialized to JSON" do
         end
         has_attributes :foo, datastream: 'descMetadata', multiple: true
         has_attributes :bar, datastream: 'descMetadata', multiple: false
-        property :title, predicate: RDF::DC.title
+        property :title, predicate: ::RDF::DC.title
       end
     end
 
@@ -39,11 +39,11 @@ describe "Objects should be serialized to JSON" do
   context "with nested nodes" do
     before do
       class DummySubnode < ActiveTriples::Resource
-        property :relation, predicate:  RDF::DC[:relation]
+        property :relation, predicate: ::RDF::DC[:relation]
       end
 
       class DummyResource < ActiveFedora::RDFDatastream
-        property :license, predicate:  RDF::DC[:license], class_name: DummySubnode do |index|
+        property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
           index.as :searchable, :displayable
         end
         def serialization_format

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "NestedAttribute behavior" do
   before do
     class Bar < ActiveFedora::Base
-      belongs_to :car, predicate: ActiveFedora::Rdf::RelsExt.hasMember
+      belongs_to :car, predicate: ActiveFedora::RDF::RelsExt.hasMember
       has_metadata :type=>ActiveFedora::SimpleDatastream, :name=>"someData" do |m|
         m.field "uno", :string
         m.field "dos", :string
@@ -13,7 +13,7 @@ describe "NestedAttribute behavior" do
 
     # base Car class, used in test for association updates and :allow_destroy flag
     class Car < ActiveFedora::Base
-      has_many :bars, predicate: ActiveFedora::Rdf::RelsExt.hasMember
+      has_many :bars, predicate: ActiveFedora::RDF::RelsExt.hasMember
       accepts_nested_attributes_for :bars, :allow_destroy=>true
     end
 

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -8,10 +8,10 @@ describe ActiveFedora::NtriplesRDFDatastream do
     end
 
     class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-      property :title, predicate: RDF::DC.title do |index|
+      property :title, predicate: ::RDF::DC.title do |index|
         index.as :stored_searchable, :facetable
       end
-      property :date_uploaded, predicate: RDF::DC.dateSubmitted do |index|
+      property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
         index.type :date
         index.as :stored_searchable, :sortable
       end
@@ -19,9 +19,9 @@ describe ActiveFedora::NtriplesRDFDatastream do
         index.type :integer
         index.as :stored_sortable
       end
-      property :part, predicate: RDF::DC.hasPart
-      property :based_near, predicate: RDF::FOAF.based_near
-      property :related_url, predicate: RDF::RDFS.seeAlso
+      property :part, predicate: ::RDF::DC.hasPart
+      property :based_near, predicate: ::RDF::FOAF.based_near
+      property :related_url, predicate: ::RDF::RDFS.seeAlso
     end
 
     class RdfTest < ActiveFedora::Base
@@ -156,7 +156,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
       # reopening existing class
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
         rdf_subject { |ds| RDF::URI.new("http://oregondigital.org/ns/#{parent_uri(ds).split('/')[-1].split(':')[1]}") }
-        property :dctype, predicate: RDF::DC.type
+        property :dctype, predicate: ::RDF::DC.type
       end
       subject.rdf.dctype = "Frog"
       subject.save!
@@ -212,7 +212,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "term proxy methods" do
     before(:each) do
       class TitleDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :title, predicate: RDF::DC.title
+        property :title, predicate: ::RDF::DC.title
       end
       class Foobar < ActiveFedora::Base 
         has_metadata 'rdf', type: TitleDatastream

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -29,7 +29,7 @@ describe "Nesting attribute behavior of RDFDatastream" do
         class ComplexRDFDatastream < ActiveFedora::NtriplesRDFDatastream
           property :topic, predicate: DummyMADS.Topic, class_name: "Topic"
           property :personalName, predicate: DummyMADS.PersonalName, class_name: "PersonalName"
-          property :title, predicate: RDF::DC.title
+          property :title, predicate: ::RDF::DC.title
 
 
           accepts_nested_attributes_for :topic, :personalName
@@ -146,11 +146,11 @@ describe "Nesting attribute behavior of RDFDatastream" do
     describe "with an existing object" do
       before(:each) do
         class SpecDatastream < ActiveFedora::NtriplesRDFDatastream
-          property :parts, predicate: RDF::DC.hasPart, :class_name=>'Component'
+          property :parts, predicate: ::RDF::DC.hasPart, :class_name=>'Component'
           accepts_nested_attributes_for :parts, allow_destroy: true
 
           class Component < ActiveTriples::Resource
-            property :label, predicate: RDF::DC.title
+            property :label, predicate: ::RDF::DC.title
           end
         end
 

--- a/spec/integration/solr_instance_loader_spec.rb
+++ b/spec/integration/solr_instance_loader_spec.rb
@@ -9,9 +9,9 @@ describe ActiveFedora::SolrInstanceLoader do
       end
       has_attributes :foo, datastream: 'descMetadata', multiple: true
       has_attributes :bar, datastream: 'descMetadata', multiple: false
-      property :title, predicate: RDF::DC.title
-      property :description, predicate: RDF::DC.description
-      belongs_to :another, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'Foo'
+      property :title, predicate: ::RDF::DC.title
+      property :description, predicate: ::RDF::DC.description
+      belongs_to :another, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'Foo'
 
       def title
         super.first

--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -4,7 +4,7 @@ describe "a versionable class" do
   before do
     class WithVersions < ActiveFedora::Base
       has_many_versions
-      property :title, predicate: RDF::DC.title
+      property :title, predicate: ::RDF::DC.title
     end
   end
 
@@ -24,12 +24,12 @@ describe "a versionable class" do
     end
 
     it "should set model_type to versionable" do
-      expect(subject.reload.model_type).to include RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
+      expect(subject.reload.model_type).to include ::RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
     end
 
     it "should have one version" do
       expect(subject.versions.size).to eq 1
-      expect(subject.versions.first).to be_kind_of RDF::Literal
+      expect(subject.versions.first).to be_kind_of ::RDF::Literal
     end
 
     context "two times" do
@@ -42,7 +42,7 @@ describe "a versionable class" do
       it "should have two versions" do
         expect(subject.versions.size).to eq 2
         subject.versions.each do |version|
-          expect(version).to be_kind_of RDF::Literal
+          expect(version).to be_kind_of ::RDF::Literal
         end
       end
 
@@ -78,7 +78,7 @@ describe "a versionable rdf datastream" do
   before(:all) do
     class VersionableDatastream < ActiveFedora::NtriplesRDFDatastream
       has_many_versions
-      property :title, predicate: RDF::DC.title
+      property :title, predicate: ::RDF::DC.title
     end
 
     class MockAFBase < ActiveFedora::Base
@@ -126,7 +126,7 @@ describe "a versionable rdf datastream" do
       end
 
       it "should have one version" do
-        expect(subject.versions.first).to be_kind_of RDF::Literal
+        expect(subject.versions.first).to be_kind_of ::RDF::Literal
       end
 
       it "should have a title" do
@@ -147,7 +147,7 @@ describe "a versionable rdf datastream" do
         it "should have two versions" do
           expect(subject.versions.size).to eq 2
           subject.versions.each do |version|
-            expect(version).to be_kind_of RDF::Literal
+            expect(version).to be_kind_of ::RDF::Literal
           end
         end
 
@@ -256,7 +256,7 @@ describe "a versionable OM datastream" do
 
       it "should have one version" do
         expect(subject.versions.size).to eq 1
-        expect(subject.versions.first).to be_kind_of RDF::Literal
+        expect(subject.versions.first).to be_kind_of ::RDF::Literal
       end
 
       it "should have a title" do
@@ -278,7 +278,7 @@ describe "a versionable OM datastream" do
         it "should have two unique versions" do
           expect(subject.versions.size).to eq 2
           subject.versions.each do |version|
-            expect(version).to be_kind_of RDF::Literal
+            expect(version).to be_kind_of ::RDF::Literal
           end
         end
 
@@ -384,7 +384,7 @@ describe "a versionable binary datastream" do
         expect(subject.versions.size).to eq 1
         expect(subject.original_name).to eql(first_name)
         expect(subject.content.size).to eq first_file.size
-        expect(subject.versions.first).to be_kind_of RDF::Literal
+        expect(subject.versions.first).to be_kind_of ::RDF::Literal
       end
 
       context "two times" do
@@ -402,7 +402,7 @@ describe "a versionable binary datastream" do
           expect(subject.original_name).to eql(second_name)
           expect(subject.content.size).to eq second_file.size
           subject.versions.each do |version|
-            expect(version).to be_kind_of RDF::Literal
+            expect(version).to be_kind_of ::RDF::Literal
           end
         end
 
@@ -436,7 +436,7 @@ describe "a versionable binary datastream" do
               expect(subject.versions.size).to eq 3
               expect(subject.original_name).to eql(first_name)
               expect(subject.content.size).to eq first_file.size
-              expect(subject.versions.first).to be_kind_of RDF::Literal
+              expect(subject.versions.first).to be_kind_of ::RDF::Literal
             end
 
           end
@@ -450,7 +450,7 @@ describe "a non-versionable resource" do
   before(:all) do
     class NotVersionableWithVersions < ActiveFedora::Base
       # explicitly don't call has_many_versions 
-      property :title, predicate: RDF::DC.title
+      property :title, predicate: ::RDF::DC.title
     end
   end
 

--- a/spec/integration/with_metadata_spec.rb
+++ b/spec/integration/with_metadata_spec.rb
@@ -10,7 +10,7 @@ describe ActiveFedora::WithMetadata do
       include ActiveFedora::WithMetadata
 
       metadata do
-        property :title, predicate: RDF::DC.title
+        property :title, predicate: ::RDF::DC.title
       end
     end
   end

--- a/spec/samples/special_thing.rb
+++ b/spec/samples/special_thing.rb
@@ -37,8 +37,8 @@ class SpecialThing < ActiveFedora::Base
 
   # This is an example of how you can add a custom relationship to a model
   # This will allow you to call .derivation on instances of the model to get the _outbound_ "hasDerivation" relationship in the RELS-EXT datastream
-  belongs_to :derivation, predicate: ActiveFedora::Rdf::RelsExt.hasDerivation, class_name: 'SpecialThing'
+  belongs_to :derivation, predicate: ActiveFedora::RDF::RelsExt.hasDerivation, class_name: 'SpecialThing'
 
   # This will allow you to call .inspirations on instances of the model to get a list of all of the objects that assert "hasDerivation" relationships pointing at this object
-  has_many :inspirations, predicate: ActiveFedora::Rdf::RelsExt.hasDerivation, class_name: 'SpecialThing'
+  has_many :inspirations, predicate: ActiveFedora::RDF::RelsExt.hasDerivation, class_name: 'SpecialThing'
 end

--- a/spec/unit/active_fedora_spec.rb
+++ b/spec/unit/active_fedora_spec.rb
@@ -115,8 +115,8 @@ describe ActiveFedora do
     end
     it "should return class constants based on strings" do
       expect(ActiveFedora.class_from_string("Om")).to eq Om
-      expect(ActiveFedora.class_from_string("ActiveFedora::Rdf::Indexing")).to eq ActiveFedora::Rdf::Indexing
-      expect(ActiveFedora.class_from_string("Indexing", ActiveFedora::Rdf)).to eq ActiveFedora::Rdf::Indexing
+      expect(ActiveFedora.class_from_string("ActiveFedora::RDF::Indexing")).to eq ActiveFedora::RDF::Indexing
+      expect(ActiveFedora.class_from_string("Indexing", ActiveFedora::RDF)).to eq ActiveFedora::RDF::Indexing
     end
 
     it "should find sibling classes" do

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -57,7 +57,7 @@ describe ActiveFedora::Base do
           has_attributes :duck, datastream: 'xmlish', :at=>[:waterfowl, :ducks, :duck], multiple: true
           has_attributes :animal_id, datastream: 'someData', multiple: false
 
-          property :goose, predicate: RDF::URI.new('http://example.com#hasGoose')
+          property :goose, predicate: ::RDF::URI.new('http://example.com#hasGoose')
 
         end
       end
@@ -105,7 +105,7 @@ describe ActiveFedora::Base do
         describe "with relationships" do
           before do
             class BarHistory3 < BarHistory2
-              belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent, class_name: 'BarHistory2'
+              belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent, class_name: 'BarHistory2'
             end
             subject.library = library
           end
@@ -282,8 +282,8 @@ describe ActiveFedora::Base do
   context "with a RDF datastream" do
     before :all do
       class BarRdfDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :title, :predicate => RDF::DC.title
-        property :description, :predicate => RDF::DC.description
+        property :title, predicate: ::RDF::DC.title
+        property :description, predicate: ::RDF::DC.description
       end
       class BarHistory4 < ActiveFedora::Base
         has_metadata 'rdfish', :type=>BarRdfDatastream
@@ -367,8 +367,8 @@ describe ActiveFedora::Base do
   context "when a datastream is specified as a symbol" do
     before :all do
       class BarRdfDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :title, :predicate => RDF::DC.title
-        property :description, :predicate => RDF::DC.description
+        property :title, predicate: ::RDF::DC.title
+        property :description, predicate: ::RDF::DC.description
       end
       class BarHistory4 < ActiveFedora::Base
         has_metadata 'rdfish', :type=>BarRdfDatastream
@@ -391,7 +391,7 @@ describe ActiveFedora::Base do
   context "when properties are defined on an object" do
     before :all do
       class BarHistory4 < ActiveFedora::Base
-        property :title, predicate: RDF::DC.title do |index|
+        property :title, predicate: ::RDF::DC.title do |index|
           index.as :symbol
         end
       end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -216,7 +216,7 @@ describe ActiveFedora::Base do
             let(:test_object) { WithProperty.new(title: 'foo') }
             before do
               class WithProperty < ActiveFedora::Base
-                property :title, predicate: RDF::DC.title
+                property :title, predicate: ::RDF::DC.title
               end
               allow(test_object).to receive(:assign_id).and_return(@this_id)
               test_object.save
@@ -226,7 +226,7 @@ describe ActiveFedora::Base do
             end
 
             it "should update the resource" do
-              expect(test_object.resource.rdf_subject).to eq RDF::URI.new("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{@this_id}")
+              expect(test_object.resource.rdf_subject).to eq ::RDF::URI.new("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{@this_id}")
               expect(test_object.title).to eq ['foo']
             end
           end

--- a/spec/unit/change_set_spec.rb
+++ b/spec/unit/change_set_spec.rb
@@ -16,8 +16,8 @@ describe ActiveFedora::ChangeSet do
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
-        property :title, predicate: RDF::DC.title
+        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        property :title, predicate: ::RDF::DC.title
       end
 
       base.library_id = 'foo'

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe ActiveFedora::Base do
   before do
     class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-      property :publisher, predicate: RDF::DC.publisher
+      property :publisher, predicate: ::RDF::DC.publisher
     end
     class Library < ActiveFedora::Base
     end
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
       has_metadata "foo", type: ActiveFedora::SimpleDatastream do |m|
         m.field "title", :string
       end

--- a/spec/unit/has_many_association_spec.rb
+++ b/spec/unit/has_many_association_spec.rb
@@ -22,7 +22,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
       allow(ActiveFedora::SolrService).to receive(:query).and_return([])
     end
 
-    let(:reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::Rdf::RelsExt.isPartOf }, Book) }
+    let(:reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::RelsExt.isPartOf }, Book) }
     let(:association) { ActiveFedora::Associations::HasManyAssociation.new(book, reflection) }
 
     it "should set the book_id attribute" do
@@ -36,10 +36,10 @@ describe ActiveFedora::Associations::HasManyAssociation do
 
     before do
       # :books must come first, so that we can test that is being passed over in favor of :contents
-      Page.has_many :books, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
-      Page.has_and_belongs_to_many :contents, predicate: ActiveFedora::Rdf::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      Page.has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      Page.has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
     end
-    let(:book_reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::Rdf::RelsExt.isPartOf }, Book) }
+    let(:book_reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::RelsExt.isPartOf }, Book) }
     let(:association) { ActiveFedora::Associations::HasManyAssociation.new(book, book_reflection) }
 
     subject { association.send(:find_polymorphic_inverse, page) }

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -4,13 +4,13 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "an instance with content" do
     before do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :created, predicate: RDF::DC.created
-        property :title, predicate: RDF::DC.title
-        property :publisher, predicate: RDF::DC.publisher
-        property :creator, predicate: RDF::DC.creator
-        property :educationLevel, predicate: RDF::DC.educationLevel
-        property :based_near, predicate: RDF::FOAF.based_near
-        property :related_url, predicate: RDF::RDFS.seeAlso
+        property :created, predicate: ::RDF::DC.created
+        property :title, predicate: ::RDF::DC.title
+        property :publisher, predicate: ::RDF::DC.publisher
+        property :creator, predicate: ::RDF::DC.creator
+        property :educationLevel, predicate: ::RDF::DC.educationLevel
+        property :based_near, predicate: ::RDF::FOAF.based_near
+        property :related_url, predicate: ::RDF::RDFS.seeAlso
       end
       @subject = MyDatastream.new(ActiveFedora::Base.id_to_uri '/test:1/descMetadata')
       @subject.content = File.new('spec/fixtures/mixed_rdf_descMetadata.nt').read
@@ -84,11 +84,11 @@ describe ActiveFedora::NtriplesRDFDatastream do
     before do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
         rdf_subject { |ds| "http://localhost:8983/fedora/rest/test/#{ds.id}/content" }
-        property :created, predicate: RDF::DC.created
-        property :title, predicate: RDF::DC.title
-        property :publisher, predicate: RDF::DC.publisher
-        property :based_near, predicate: RDF::FOAF.based_near
-        property :related_url, predicate: RDF::RDFS.seeAlso
+        property :created, predicate: ::RDF::DC.created
+        property :title, predicate: ::RDF::DC.title
+        property :publisher, predicate: ::RDF::DC.publisher
+        property :based_near, predicate: ::RDF::FOAF.based_near
+        property :related_url, predicate: ::RDF::RDFS.seeAlso
       end
       @subject = MyDatastream.new
       allow(@subject).to receive(:id).and_return 'test:1'
@@ -116,7 +116,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "a new instance" do
     before(:each) do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :publisher, predicate: RDF::DC.publisher
+        property :publisher, predicate: ::RDF::DC.publisher
       end
       @subject = MyDatastream.new
     end
@@ -135,25 +135,25 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "solr integration" do
     before(:all) do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :created, predicate: RDF::DC.created do |index|
+        property :created, predicate: ::RDF::DC.created do |index|
           index.as :sortable, :displayable
           index.type :date
         end
-        property :title, predicate: RDF::DC.title do |index|
+        property :title, predicate: ::RDF::DC.title do |index|
           index.as :stored_searchable, :sortable
           index.type :text
         end
-        property :publisher, predicate: RDF::DC.publisher do |index|
+        property :publisher, predicate: ::RDF::DC.publisher do |index|
           index.as :facetable, :sortable, :stored_searchable
         end
-        property :based_near, predicate: RDF::FOAF.based_near do |index|
+        property :based_near, predicate: ::RDF::FOAF.based_near do |index|
           index.as :facetable, :stored_searchable
           index.type :text
         end
-        property :related_url, predicate: RDF::RDFS.seeAlso do |index|
+        property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
           index.as :stored_searchable
         end
-        property :rights, predicate: RDF::DC.rights
+        property :rights, predicate: ::RDF::DC.rights
       end
     end
 

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -11,8 +11,8 @@ describe ActiveFedora::RDFDatastream do
   describe "an instance that exists in the datastore, but hasn't been loaded" do
     before do
       class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :title, :predicate => RDF::DC.title
-        property :description, :predicate => RDF::DC.description, :multivalue => false
+        property :title, predicate: ::RDF::DC.title
+        property :description, predicate: ::RDF::DC.description, :multivalue => false
       end
       class MyObj < ActiveFedora::Base
         has_metadata 'descMetadata', type: MyDatastream
@@ -49,7 +49,7 @@ describe ActiveFedora::RDFDatastream do
     it "should clear stuff" do
       subject.title = ['one', 'two', 'three']
       subject.title.clear
-      expect(subject.graph.query([subject.rdf_subject,  RDF::DC.title, nil]).first).to be_nil
+      expect(subject.graph.query([subject.rdf_subject,  ::RDF::DC.title, nil]).first).to be_nil
     end
 
     it "should have a list of fields" do

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 describe ActiveFedora::RDFDatastream do
   before do
     class DummySubnode < ActiveTriples::Resource
-      property :title, predicate:  RDF::DC[:title], class_name: RDF::Literal
-      property :relation, predicate:  RDF::DC[:relation]
+      property :title, predicate: ::RDF::DC[:title], class_name: ::RDF::Literal
+      property :relation, predicate: ::RDF::DC[:relation]
     end
 
     class DummyResource < ActiveFedora::RDFDatastream
-      property :title, predicate:  RDF::DC[:title], class_name: RDF::Literal do |index|
+      property :title, predicate: ::RDF::DC[:title], class_name: ::RDF::Literal do |index|
         index.as :searchable, :displayable
       end
-      property :license, predicate:  RDF::DC[:license], class_name: DummySubnode do |index|
+      property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
         index.as :searchable, :displayable
       end
-      property :creator, predicate: RDF::DC[:creator], class_name: 'DummyAsset' do |index|
+      property :creator, predicate: ::RDF::DC[:creator], class_name: 'DummyAsset' do |index|
         index.as :searchable
       end
       def serialization_format

--- a/spec/unit/rdfxml_datastream_spec.rb
+++ b/spec/unit/rdfxml_datastream_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe ActiveFedora::RdfxmlRDFDatastream do
+describe ActiveFedora::RDFXMLDatastream do
   describe "a new instance" do
     before(:each) do
-      class MyRdfxmlDatastream < ActiveFedora::RdfxmlRDFDatastream
-        property :publisher, :predicate => RDF::DC.publisher
+      class MyRdfxmlDatastream < ActiveFedora::RDFXMLDatastream
+        property :publisher, predicate: ::RDF::DC.publisher
       end
       @subject = MyRdfxmlDatastream.new
       allow(@subject).to receive(:id).and_return('test:1')
@@ -51,9 +51,9 @@ describe ActiveFedora::RdfxmlRDFDatastream do
         end
       end
 
-      class MyDatastream < ActiveFedora::RdfxmlRDFDatastream
-        property :resource_type, :predicate => DAMS.typeOfResource
-        property :title, :predicate => DAMS.title, :class_name => 'Description'
+      class MyDatastream < ActiveFedora::RDFXMLDatastream
+        property :resource_type, predicate: DAMS.typeOfResource
+        property :title, predicate: DAMS.title, :class_name => 'Description'
 
         rdf_subject { |ds| RDF::URI.new(ds.about) }
 
@@ -66,7 +66,7 @@ describe ActiveFedora::RdfxmlRDFDatastream do
 
         class Description < ActiveTriples::Resource
           configure :type => DAMS.Description
-          property :value, :predicate => RDF.value do |index|
+          property :value, predicate: ::RDF.value do |index|
               index.as :searchable
           end
         end

--- a/spec/unit/sparql_insert_spec.rb
+++ b/spec/unit/sparql_insert_spec.rb
@@ -10,8 +10,8 @@ describe ActiveFedora::SparqlInsert do
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::Rdf::RelsExt.hasConstituent
-        property :title, predicate: RDF::DC.title
+        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        property :title, predicate: ::RDF::DC.title
       end
 
       base.library_id = 'foo'


### PR DESCRIPTION
Renames instances of "Rdf" to "RDF" to keep it consistent with other classes.
