### PR TITLE
Fix to make sure all values are handled as arrays

### DIFF
--- a/lib/active_fedora/solr_digital_object.rb
+++ b/lib/active_fedora/solr_digital_object.rb
@@ -47,10 +47,10 @@ module ActiveFedora
       attribute = original_class.defined_attributes[field]
       field_name = attribute.primary_solr_name
       raise KeyError, "Tried to fetch `#{field}' from solr, but it isn't indexed." unless field_name
-      val = solr_doc.fetch field_name, default
+      val = Array(solr_doc.fetch(field_name, default))
       case attribute.type
       when :date
-        val.is_a?(Array) ? val.map{|v| Date.parse v} : Date.parse(val)
+        val.map{|v| Date.parse v}
       else
         val
       end

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -63,7 +63,6 @@ module ActiveFedora
           model_value = Model.from_class_uri(value)
 
           if model_value
-
             # Set as the first model in case opts[:class] was nil
             best_model_match ||= model_value
 

--- a/spec/integration/load_from_solr_spec.rb
+++ b/spec/integration/load_from_solr_spec.rb
@@ -10,6 +10,10 @@ describe "Loading from solr" do
         index.type :date
         index.as :stored_searchable, :sortable
       end
+      property :date_modified, predicate: RDF::DC.date do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
       property :identifier, predicate: RDF::DC.identifier do |index|
         index.type :integer
         index.as :stored_searchable, :sortable
@@ -28,6 +32,7 @@ describe "Loading from solr" do
       has_metadata 'rdf', type: MyRdfDatastream
       has_metadata 'om', type: MyOmDatastream
       has_attributes :based_near, :related_url, :part, :date_uploaded, datastream: 'rdf', multiple: true
+      has_attributes :date_modified, datastream: 'rdf', multiple: false
       has_attributes :title, :identifier, datastream: 'rdf', multiple: false
       has_attributes :duck, datastream: 'om', multiple: false
     end
@@ -35,6 +40,7 @@ describe "Loading from solr" do
 
   let!(:original) { RdfTest.create!(title: "PLAN 9 FROM OUTER SPACE",
                                     date_uploaded: Date.parse('1959-01-01'),
+                                    date_modified: Date.parse('1999-01-01'),
                                     duck: "quack",
                                    identifier: 12345) }
 
@@ -50,6 +56,7 @@ describe "Loading from solr" do
     obj = RdfTest.load_instance_from_solr original.pid
     expect(obj.title).to eq "PLAN 9 FROM OUTER SPACE"
     expect(obj.date_uploaded).to eq [Date.parse('1959-01-01')]
+    expect(obj.date_modified).to eq Date.parse('1999-01-01')
     expect(obj.identifier).to eq 12345
     expect{obj.part}.to raise_error KeyError, "Tried to fetch `part' from solr, but it isn't indexed."
     expect(ActiveFedora::Base.logger).to receive(:info).with "Couldn't get duck out of solr, because the datastream 'MyOmDatastream' doesn't respond to 'primary_solr_name'. Trying another way."

--- a/spec/unit/solr_digital_object_spec.rb
+++ b/spec/unit/solr_digital_object_spec.rb
@@ -47,10 +47,10 @@ describe ActiveFedora::SolrDigitalObject do
       expect(subject.fetch('author')).to be_empty
     end
     it "should grab values" do
-      expect(subject.fetch('title')).to eq 'foo'
+      expect(subject.fetch('title')).to eq ['foo']
     end
     it "should grab values" do
-      expect(subject.fetch('title')).to eq 'foo'
+      expect(subject.fetch('title')).to eq ['foo']
     end
 
     it "should raise an error if the field isn't indexed" do


### PR DESCRIPTION
@jcoyne this is an alternative way to handle the PR that @cam156 submitted before (https://github.com/projecthydra/active_fedora/pull/486) 

I am updating solr_digital_object to return all values as arrays which I believe was the original intention. The change will affect all types (dates and others)
