### PR TITLE
Separate Fedora and Hydra rels-ext terms

### DIFF
--- a/lib/active_fedora/errors.rb
+++ b/lib/active_fedora/errors.rb
@@ -27,7 +27,7 @@ module ActiveFedora #:nodoc:
   #   end
   #
   #   class Patch < ActiveFedora::Base
-  #     belongs_to :ticket, predicate: ActiveFedora::RDF::RelsExt.isComponentOf
+  #     belongs_to :ticket, predicate: ActiveFedora::RDF::FedoraRelsExt.isComponentOf
   #   end
   #
   #   # Comments are not patches, this assignment raises AssociationTypeMismatch.

--- a/lib/active_fedora/rdf.rb
+++ b/lib/active_fedora/rdf.rb
@@ -3,11 +3,12 @@ module ActiveFedora
     extend ActiveSupport::Autoload
     autoload :DatastreamIndexing
     autoload :Fcrepo
-    autoload :Ldp
-    autoload :Indexing
+    autoload :FedoraRelsExt
+    autoload :HydraRelsExt
     autoload :Identifiable
+    autoload :Indexing
+    autoload :Ldp
     autoload :ObjectResource
     autoload :Persistence
-    autoload :RelsExt
   end
 end

--- a/lib/active_fedora/rdf/fedora_rels_ext.rb
+++ b/lib/active_fedora/rdf/fedora_rels_ext.rb
@@ -1,5 +1,5 @@
 require 'rdf'
-class ActiveFedora::RDF::RelsExt < RDF::StrictVocabulary("http://fedora.info/definitions/v4/rels-ext#")
+class ActiveFedora::RDF::FedoraRelsExt < RDF::StrictVocabulary("http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#")
   property :hasAnnotation
   property :hasCollectionMember
   property :hasConstituent

--- a/lib/active_fedora/rdf/hydra_rels_ext.rb
+++ b/lib/active_fedora/rdf/hydra_rels_ext.rb
@@ -1,0 +1,5 @@
+require 'rdf'
+class ActiveFedora::RDF::HydraRelsExt < RDF::StrictVocabulary("http://projecthydra.org/ns/relations#")
+  property :hasProfile
+  property :isGovernedBy
+end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -28,13 +28,13 @@ describe ActiveFedora::Base do
   describe "complex example" do
     before do
       class Library < ActiveFedora::Base
-        has_many :books, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
-        belongs_to :author, predicate: ActiveFedora::RDF::RelsExt.hasMember, class_name: 'Person'
-        belongs_to :publisher, predicate: ActiveFedora::RDF::RelsExt.hasMember
+        belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
+        belongs_to :author, predicate: ActiveFedora::RDF::FedoraRelsExt.hasMember, class_name: 'Person'
+        belongs_to :publisher, predicate: ActiveFedora::RDF::FedoraRelsExt.hasMember
       end
 
       class Person < ActiveFedora::Base
@@ -335,10 +335,10 @@ describe ActiveFedora::Base do
   describe "single direction habtm" do
     before :all do
       class Course < ActiveFedora::Base
-        has_and_belongs_to_many :textbooks, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+        has_and_belongs_to_many :textbooks, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
       end
       class Textbook < ActiveFedora::Base
-        has_many :courses, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+        has_many :courses, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
       end
 
     end
@@ -395,7 +395,7 @@ describe ActiveFedora::Base do
     describe "for habtm" do
       before :all do
         class LibraryBook < ActiveFedora::Base
-          has_and_belongs_to_many :pages, predicate: ActiveFedora::RDF::RelsExt.isPartOf, after_remove: :after_hook, before_remove: :before_hook
+          has_and_belongs_to_many :pages, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, after_remove: :after_hook, before_remove: :before_hook
 
           def before_hook(m)
             say_hi(m)
@@ -413,7 +413,7 @@ describe ActiveFedora::Base do
 
         end
         class Page < ActiveFedora::Base
-          has_many :library_books, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          has_many :library_books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
 
       end
@@ -441,11 +441,11 @@ describe ActiveFedora::Base do
     describe "for has_many" do
       before :all do
         class LibraryBook < ActiveFedora::Base
-          has_many :pages, predicate: ActiveFedora::RDF::RelsExt.isPartOf, after_remove: :say_hi
+          has_many :pages, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, after_remove: :say_hi
 
         end
         class Page < ActiveFedora::Base
-          belongs_to :library_book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          belongs_to :library_book, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
       end
 
@@ -472,7 +472,7 @@ describe ActiveFedora::Base do
     describe "when an object doesn't have a property, and the class_name is predictable" do
       before (:all) do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
           has_many :baubles
@@ -484,14 +484,14 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq 'http://fedora.info/definitions/v4/rels-ext#isPartOf'
+        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq 'http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#isPartOf'
       end
     end
 
     describe "when an object doesn't have a property, but has a class_name" do
       before :all do
         class MasterFile < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
           has_many :parts, class_name: 'MasterFile'
@@ -504,17 +504,17 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        expect(MediaObject.new.association(:parts).send(:find_predicate)).to eq 'http://fedora.info/definitions/v4/rels-ext#isPartOf'
+        expect(MediaObject.new.association(:parts).send(:find_predicate)).to eq 'http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#isPartOf'
       end
     end
 
     describe "an object has an explicity property" do
       before :all do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
         class MediaObject < ActiveFedora::Base
-          has_many :baubles, predicate: ActiveFedora::RDF::RelsExt.hasEquivalent
+          has_many :baubles, predicate: ActiveFedora::RDF::FedoraRelsExt.hasEquivalent
         end
       end
 
@@ -524,14 +524,14 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq 'http://fedora.info/definitions/v4/rels-ext#hasEquivalent'
+        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq 'http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#hasEquivalent'
       end
     end
 
     describe "an object doesn't have a property" do
       before :all do
         class Bauble < ActiveFedora::Base
-          belongs_to :media_object, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+          belongs_to :media_object, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         end
 
         class MediaObject < ActiveFedora::Base
@@ -550,20 +550,40 @@ describe ActiveFedora::Base do
     end
   end
 
+  describe "is_governed_by" do
+    before :all do
+      class ControlledObject < ActiveFedora::Base
+        belongs_to :policy_object, predicate: ActiveFedora::RDF::HydraRelsExt.isGovernedBy
+      end
+      class PolicyObject < ActiveFedora::Base
+        has_many :parts, class_name: 'ControlledObject'
+      end
+    end
+
+    after :all do
+      Object.send(:remove_const, :ControlledObject)
+      Object.send(:remove_const, :PolicyObject)
+    end
+
+    it "it should find the predicate" do
+      expect(PolicyObject.new.association(:parts).send(:find_predicate)).to eq 'http://projecthydra.org/ns/relations#isGovernedBy'
+    end
+  end
+
   describe "casting when the class name is ActiveFedora::Base" do
     describe "for habtm" do
       before :all do
         class Novel < ActiveFedora::Base
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class TextBook < ActiveFedora::Base
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Text < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Image < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
       end
 

--- a/spec/integration/belongs_to_association_spec.rb
+++ b/spec/integration/belongs_to_association_spec.rb
@@ -7,7 +7,7 @@ describe ActiveFedora::Base do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
     end
     class SpecialInheritedBook < Book
     end
@@ -86,23 +86,23 @@ describe ActiveFedora::Base do
   describe "casting inheritance detailed test cases" do
     before :all do
       class SimpleObject < ActiveFedora::Base
-        belongs_to :simple_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleCollection'
-        belongs_to :complex_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexCollection'
+        belongs_to :simple_collection, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'SimpleCollection'
+        belongs_to :complex_collection, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ComplexCollection'
       end
 
       class ComplexObject < SimpleObject
-        belongs_to :simple_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleCollection'
-        belongs_to :complex_collection, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexCollection'
+        belongs_to :simple_collection, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'SimpleCollection'
+        belongs_to :complex_collection, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ComplexCollection'
       end
 
       class SimpleCollection < ActiveFedora::Base
-        has_many :objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
-        has_many :complex_objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
+        has_many :objects, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
+        has_many :complex_objects, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
       end
 
       class ComplexCollection < SimpleCollection
-        has_many :objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
-        has_many :complex_objects, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
+        has_many :objects, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'SimpleObject', autosave: true
+        has_many :complex_objects, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ComplexObject', autosave: true
       end
 
     end

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -6,7 +6,7 @@ describe ActiveFedora::Base do
       has_many :books
     end
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasMember
+      belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasMember
     end
   end
   let(:library) { Library.create! }

--- a/spec/integration/fedora_solr_sync_spec.rb
+++ b/spec/integration/fedora_solr_sync_spec.rb
@@ -4,11 +4,11 @@ require 'timeout'
 describe "fedora_solr_sync_issues" do
   before :all do
     class ParentThing < ActiveFedora::Base
-      has_many :things, :class_name=>'ChildThing', predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      has_many :things, :class_name=>'ChildThing', predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
 
     class ChildThing < ActiveFedora::Base
-      belongs_to :parent, :class_name=>'ParentThing', predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :parent, :class_name=>'ParentThing', predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
   end
 

--- a/spec/integration/has_and_belongs_to_many_associations_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_associations_spec.rb
@@ -5,7 +5,7 @@ describe ActiveFedora::Base do
     before do
       class Book < ActiveFedora::Base
         has_and_belongs_to_many :topics, predicate: ::RDF::FOAF.primaryTopic, inverse_of: :books
-        has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection
+        has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection
       end
 
       class SpecialInheritedBook < Book
@@ -113,11 +113,11 @@ describe ActiveFedora::Base do
   describe "when inverse is not specified" do
     before do
       class Book < ActiveFedora::Base
-        has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection
+        has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection
       end
 
       class Collection < ActiveFedora::Base
-        has_and_belongs_to_many :books, predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection
+        has_and_belongs_to_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection
       end
     end
 
@@ -166,7 +166,7 @@ describe ActiveFedora::Base do
     describe "without callbacks" do
       before do
         class Book < ActiveFedora::Base
-          has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection
+          has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection
         end
 
         class Collection < ActiveFedora::Base
@@ -211,7 +211,7 @@ describe ActiveFedora::Base do
       before do
         class Book < ActiveFedora::Base
           has_and_belongs_to_many :collections,
-                                  predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection,
+                                  predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection,
                                   before_remove: :foo, after_remove: :bar
         end
 
@@ -258,7 +258,7 @@ describe ActiveFedora::Base do
       before do
         class Book < ActiveFedora::Base
           has_and_belongs_to_many :collections,
-                                  predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection,
+                                  predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection,
                                   before_add: :foo, after_add: :bar
         end
 
@@ -302,7 +302,7 @@ end
 describe "create" do
   before do
     class Book < ActiveFedora::Base
-      has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection
+      has_and_belongs_to_many :collections, predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection
     end
 
     class Collection < ActiveFedora::Base
@@ -338,7 +338,7 @@ describe "Autosave" do
     end
 
     class Component < ActiveFedora::Base
-      has_and_belongs_to_many :items, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      has_and_belongs_to_many :items, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
       has_metadata "foo", type: ActiveFedora::SimpleDatastream do |m|
         m.field "description", :string
       end

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -7,7 +7,7 @@ describe "Collection members" do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
     end
   end
   after :all do
@@ -69,7 +69,7 @@ describe "After save callbacks" do
     end
 
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
       after_save :find_self
       attr_accessor :library_books
 
@@ -101,11 +101,11 @@ describe "When two or more relationships share the same property" do
     end
 
     class Person < ActiveFedora::Base
-      belongs_to :book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :book, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
 
     class Collection < ActiveFedora::Base
-      belongs_to :book, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :book, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
 
     @book = Book.create!
@@ -128,14 +128,14 @@ end
 describe "with an polymorphic association" do
   before do
     class Permissionable1 < ActiveFedora::Base
-      has_many :permissions, predicate: ActiveFedora::RDF::RelsExt.isPartOf, inverse_of: :access_to
+      has_many :permissions, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, inverse_of: :access_to
     end
     class Permissionable2 < ActiveFedora::Base
-      has_many :permissions, predicate: ActiveFedora::RDF::RelsExt.isPartOf, inverse_of: :access_to
+      has_many :permissions, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, inverse_of: :access_to
     end
 
     class Permission < ActiveFedora::Base
-      belongs_to :access_to, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      belongs_to :access_to, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
     end
   end
 
@@ -155,15 +155,15 @@ end
 describe "When relationship is restricted to AF::Base" do
   before do
     class Email < ActiveFedora::Base
-      has_many :attachments, predicate: ActiveFedora::RDF::RelsExt.isPartOf, :class_name=>'ActiveFedora::Base'
+      has_many :attachments, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, :class_name=>'ActiveFedora::Base'
     end
 
     class Image < ActiveFedora::Base
-      belongs_to :email, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :email, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
 
     class PDF < ActiveFedora::Base
-      belongs_to :email, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :email, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
   end
 
@@ -211,7 +211,7 @@ describe "Deleting a dependent relationship" do
       has_many :components
     end
     class Component < ActiveFedora::Base
-      belongs_to :item, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      belongs_to :item, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
   end
 
@@ -279,7 +279,7 @@ describe "Autosave" do
         has_attributes :title, datastream: 'foo'
       end
       class Component < ActiveFedora::Base
-        belongs_to :item, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+        belongs_to :item, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
         has_metadata "foo", type: ActiveFedora::SimpleDatastream do |m|
           m.field "description", :string
         end
@@ -315,11 +315,11 @@ describe "Autosave" do
     context "with ActiveFedora::Base as classes" do
       before do
         class Novel < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
-          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
         class Text < ActiveFedora::Base
-          has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+          has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
       end
       let(:text) { Text.create}

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "NestedAttribute behavior" do
   before do
     class Bar < ActiveFedora::Base
-      belongs_to :car, predicate: ActiveFedora::RDF::RelsExt.hasMember
+      belongs_to :car, predicate: ActiveFedora::RDF::FedoraRelsExt.hasMember
       has_metadata :type=>ActiveFedora::SimpleDatastream, :name=>"someData" do |m|
         m.field "uno", :string
         m.field "dos", :string
@@ -13,7 +13,7 @@ describe "NestedAttribute behavior" do
 
     # base Car class, used in test for association updates and :allow_destroy flag
     class Car < ActiveFedora::Base
-      has_many :bars, predicate: ActiveFedora::RDF::RelsExt.hasMember
+      has_many :bars, predicate: ActiveFedora::RDF::FedoraRelsExt.hasMember
       accepts_nested_attributes_for :bars, :allow_destroy=>true
     end
 

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ActiveFedora::Base do
   before :all do
     class Library < ActiveFedora::Base
-      has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf
+      has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf
     end
     class Book < ActiveFedora::Base; end
   end

--- a/spec/integration/solr_instance_loader_spec.rb
+++ b/spec/integration/solr_instance_loader_spec.rb
@@ -11,7 +11,7 @@ describe ActiveFedora::SolrInstanceLoader do
       has_attributes :bar, datastream: 'descMetadata', multiple: false
       property :title, predicate: ::RDF::DC.title
       property :description, predicate: ::RDF::DC.description
-      belongs_to :another, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'Foo'
+      belongs_to :another, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'Foo'
 
       def title
         super.first

--- a/spec/samples/special_thing.rb
+++ b/spec/samples/special_thing.rb
@@ -37,8 +37,8 @@ class SpecialThing < ActiveFedora::Base
 
   # This is an example of how you can add a custom relationship to a model
   # This will allow you to call .derivation on instances of the model to get the _outbound_ "hasDerivation" relationship in the RELS-EXT datastream
-  belongs_to :derivation, predicate: ActiveFedora::RDF::RelsExt.hasDerivation, class_name: 'SpecialThing'
+  belongs_to :derivation, predicate: ActiveFedora::RDF::FedoraRelsExt.hasDerivation, class_name: 'SpecialThing'
 
   # This will allow you to call .inspirations on instances of the model to get a list of all of the objects that assert "hasDerivation" relationships pointing at this object
-  has_many :inspirations, predicate: ActiveFedora::RDF::RelsExt.hasDerivation, class_name: 'SpecialThing'
+  has_many :inspirations, predicate: ActiveFedora::RDF::FedoraRelsExt.hasDerivation, class_name: 'SpecialThing'
 end

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -105,7 +105,7 @@ describe ActiveFedora::Base do
         describe "with relationships" do
           before do
             class BarHistory3 < BarHistory2
-              belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent, class_name: 'BarHistory2'
+              belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent, class_name: 'BarHistory2'
             end
             subject.library = library
           end

--- a/spec/unit/change_set_spec.rb
+++ b/spec/unit/change_set_spec.rb
@@ -16,7 +16,7 @@ describe ActiveFedora::ChangeSet do
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
         property :title, predicate: ::RDF::DC.title
       end
 

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -8,7 +8,7 @@ describe ActiveFedora::Base do
     class Library < ActiveFedora::Base
     end
     class Book < ActiveFedora::Base
-      belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+      belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
       has_metadata "foo", type: ActiveFedora::SimpleDatastream do |m|
         m.field "title", :string
       end

--- a/spec/unit/has_and_belongs_to_many_association_spec.rb
+++ b/spec/unit/has_and_belongs_to_many_association_spec.rb
@@ -24,7 +24,7 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
     context "a one way relationship " do
       describe "adding memeber" do
         it "should set the relationship attribute" do
-          reflection = Book.create_reflection(:has_and_belongs_to_many, :pages, {predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection}, Book)
+          reflection = Book.create_reflection(:has_and_belongs_to_many, :pages, {predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection}, Book)
           allow(ActiveFedora::SolrService).to receive(:query).and_return([])
           ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, reflection)
           expect(ac).to receive(:callback).twice
@@ -46,7 +46,7 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
         let(:query2) { ids.slice(10,10).map {|i| "_query_:\"{!raw f=id}#{i}\""}.join(" OR ") }
 
         it "should call solr query multiple times" do
-          reflection = Book.create_reflection(:has_and_belongs_to_many, :pages, { predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection, solr_page_size: 10}, Book)
+          reflection = Book.create_reflection(:has_and_belongs_to_many, :pages, { predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection, solr_page_size: 10}, Book)
           expect(subject).to receive(:[]).with('page_ids').and_return(ids)
           expect(ActiveFedora::SolrService).to receive(:query).with(query1, rows: 10).and_return([])
           expect(ActiveFedora::SolrService).to receive(:query).with(query2, rows: 10).and_return([])
@@ -58,8 +58,8 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
     end
 
     context "with an inverse reflection" do
-      let!(:inverse) { Page.create_reflection(:has_and_belongs_to_many, :books, { predicate: ActiveFedora::RDF::RelsExt.isMemberOfCollection }, Page) }
-      let(:reflection) { Book.create_reflection(:has_and_belongs_to_many, :pages, { predicate: ActiveFedora::RDF::RelsExt.hasCollectionMember, inverse_of: 'books'}, Book) }
+      let!(:inverse) { Page.create_reflection(:has_and_belongs_to_many, :books, { predicate: ActiveFedora::RDF::FedoraRelsExt.isMemberOfCollection }, Page) }
+      let(:reflection) { Book.create_reflection(:has_and_belongs_to_many, :pages, { predicate: ActiveFedora::RDF::FedoraRelsExt.hasCollectionMember, inverse_of: 'books'}, Book) }
       let(:ac) { ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, reflection) }
       let(:object) { Page.new }
 
@@ -84,13 +84,13 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
   context "class with association" do
     before do
       class Collection < ActiveFedora::Base
-        has_and_belongs_to_many :members, predicate: ActiveFedora::RDF::RelsExt.hasCollectionMember, class_name: "ActiveFedora::Base", after_remove: :remove_member
+        has_and_belongs_to_many :members, predicate: ActiveFedora::RDF::FedoraRelsExt.hasCollectionMember, class_name: "ActiveFedora::Base", after_remove: :remove_member
         def remove_member (m)
         end
       end
 
       class Thing < ActiveFedora::Base
-        has_many :collections, predicate: ActiveFedora::RDF::RelsExt.hasCollectionMember, class_name: "ActiveFedora::Base"
+        has_many :collections, predicate: ActiveFedora::RDF::FedoraRelsExt.hasCollectionMember, class_name: "ActiveFedora::Base"
       end
     end
 

--- a/spec/unit/has_many_association_spec.rb
+++ b/spec/unit/has_many_association_spec.rb
@@ -22,7 +22,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
       allow(ActiveFedora::SolrService).to receive(:query).and_return([])
     end
 
-    let(:reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::RelsExt.isPartOf }, Book) }
+    let(:reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf }, Book) }
     let(:association) { ActiveFedora::Associations::HasManyAssociation.new(book, reflection) }
 
     it "should set the book_id attribute" do
@@ -36,10 +36,10 @@ describe ActiveFedora::Associations::HasManyAssociation do
 
     before do
       # :books must come first, so that we can test that is being passed over in favor of :contents
-      Page.has_many :books, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
-      Page.has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      Page.has_many :books, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
+      Page.has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf, class_name: 'ActiveFedora::Base'
     end
-    let(:book_reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::RelsExt.isPartOf }, Book) }
+    let(:book_reflection) { Book.create_reflection(:has_many, 'pages', { predicate: ActiveFedora::RDF::FedoraRelsExt.isPartOf }, Book) }
     let(:association) { ActiveFedora::Associations::HasManyAssociation.new(book, book_reflection) }
 
     subject { association.send(:find_polymorphic_inverse, page) }

--- a/spec/unit/sparql_insert_spec.rb
+++ b/spec/unit/sparql_insert_spec.rb
@@ -10,7 +10,7 @@ describe ActiveFedora::SparqlInsert do
       end
 
       class Book < ActiveFedora::Base
-        belongs_to :library, predicate: ActiveFedora::RDF::RelsExt.hasConstituent
+        belongs_to :library, predicate: ActiveFedora::RDF::FedoraRelsExt.hasConstituent
         property :title, predicate: ::RDF::DC.title
       end
 
@@ -26,7 +26,7 @@ describe ActiveFedora::SparqlInsert do
 
 
     it "should return the string" do
-      expect(subject.build).to eq "DELETE { <> <http://fedora.info/definitions/v4/rels-ext#hasConstituent> ?change . }\n  WHERE { <> <http://fedora.info/definitions/v4/rels-ext#hasConstituent> ?change . } ;\nDELETE { <> <http://purl.org/dc/terms/title> ?change . }\n  WHERE { <> <http://purl.org/dc/terms/title> ?change . } ;\nINSERT { \n<> <http://fedora.info/definitions/v4/rels-ext#hasConstituent> <http://localhost:8983/fedora/rest/test/foo> .\n<> <http://purl.org/dc/terms/title> \"bar\" .\n}\n WHERE { }"
+      expect(subject.build).to eq "DELETE { <> <http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#hasConstituent> ?change . }\n  WHERE { <> <http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#hasConstituent> ?change . } ;\nDELETE { <> <http://purl.org/dc/terms/title> ?change . }\n  WHERE { <> <http://purl.org/dc/terms/title> ?change . } ;\nINSERT { \n<> <http://www.fedora.info/definitions/1/0/fedora-relsext-ontology.rdfs#hasConstituent> <http://localhost:8983/fedora/rest/test/foo> .\n<> <http://purl.org/dc/terms/title> \"bar\" .\n}\n WHERE { }"
     end
   end
 end


### PR DESCRIPTION
This moves the Fedora rels-ext terms to a new class with a new url that resolves to their new location. Hydra rels-ext terms are given their own class for clarity.

We should explore opportunities for parity with #616 . @barmintor suggested keeping class names the same in both AF8 and AF9 releases which would make migrating less painful.
