### PR TITLE
Return array of version uris

### DIFF
--- a/lib/active_fedora/fixity_service.rb
+++ b/lib/active_fedora/fixity_service.rb
@@ -25,7 +25,7 @@ module ActiveFedora
 
     def get_fixity_response_from_fedora
       uri = target + "/fcr:fixity"
-      ActiveFedora.fedora.connection.get(uri)
+      ActiveFedora.fedora.connection.get(encoded_url(uri))
     end
 
     def fixity_graph
@@ -34,6 +34,14 @@ module ActiveFedora
 
     def status_url
       ::RDF::URI("http://fedora.info/definitions/v4/repository#status")
+    end
+
+    def encoded_url uri
+      if uri.match("fcr:versions")
+        uri.gsub(/fcr:versions/,"fcr%3aversions")
+      else
+        uri
+      end
     end
 
   end

--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -29,7 +29,8 @@ describe "a versionable class" do
 
     it "should have one version" do
       expect(subject.versions.size).to eq 1
-      expect(subject.versions.first).to be_kind_of ::RDF::Literal
+      expect(subject.versions.first).to be_kind_of String
+      expect(subject.versions.first).to end_with "version1"
     end
 
     context "two times" do
@@ -41,8 +42,8 @@ describe "a versionable class" do
 
       it "should have two versions" do
         expect(subject.versions.size).to eq 2
-        subject.versions.each do |version|
-          expect(version).to be_kind_of ::RDF::Literal
+        subject.versions.each_index do |index|
+          expect(subject.versions[index]).to end_with "version"+(index+1).to_s
         end
       end
 
@@ -126,7 +127,7 @@ describe "a versionable rdf datastream" do
       end
 
       it "should have one version" do
-        expect(subject.versions.first).to be_kind_of ::RDF::Literal
+        expect(subject.versions.first).to end_with "version1"
       end
 
       it "should have a title" do
@@ -146,8 +147,8 @@ describe "a versionable rdf datastream" do
 
         it "should have two versions" do
           expect(subject.versions.size).to eq 2
-          subject.versions.each do |version|
-            expect(version).to be_kind_of ::RDF::Literal
+          subject.versions.each_index do |index|
+            expect(subject.versions[index]).to end_with "version"+(index+1).to_s
           end
         end
 
@@ -255,8 +256,7 @@ describe "a versionable OM datastream" do
       end
 
       it "should have one version" do
-        expect(subject.versions.size).to eq 1
-        expect(subject.versions.first).to be_kind_of ::RDF::Literal
+        expect(subject.versions.first).to end_with "version1"
       end
 
       it "should have a title" do
@@ -277,8 +277,8 @@ describe "a versionable OM datastream" do
 
         it "should have two unique versions" do
           expect(subject.versions.size).to eq 2
-          subject.versions.each do |version|
-            expect(version).to be_kind_of ::RDF::Literal
+          subject.versions.each_index do |index|
+            expect(subject.versions[index]).to end_with "version"+(index+1).to_s
           end
         end
 
@@ -384,7 +384,7 @@ describe "a versionable binary datastream" do
         expect(subject.versions.size).to eq 1
         expect(subject.original_name).to eql(first_name)
         expect(subject.content.size).to eq first_file.size
-        expect(subject.versions.first).to be_kind_of ::RDF::Literal
+        expect(subject.versions.first).to end_with "version1"
       end
 
       context "two times" do
@@ -401,8 +401,24 @@ describe "a versionable binary datastream" do
           expect(subject.versions.size).to eq 2
           expect(subject.original_name).to eql(second_name)
           expect(subject.content.size).to eq second_file.size
-          subject.versions.each do |version|
-            expect(version).to be_kind_of ::RDF::Literal
+          subject.versions.each_index do |index|
+            expect(subject.versions[index]).to end_with "version"+(index+1).to_s
+          end
+        end
+
+        context "with fixity checking" do
+          let(:results) do
+            results = Array.new
+            subject.versions.each do |uri|
+              results << ActiveFedora::FixityService.new(uri).check
+            end
+            return results
+          end
+
+          it "should report on the fixity of each version" do
+            results.each do |result|
+              expect(result).to be true
+            end
           end
         end
 
@@ -436,7 +452,9 @@ describe "a versionable binary datastream" do
               expect(subject.versions.size).to eq 3
               expect(subject.original_name).to eql(first_name)
               expect(subject.content.size).to eq first_file.size
-              expect(subject.versions.first).to be_kind_of ::RDF::Literal
+              subject.versions.each_index do |index|
+                expect(subject.versions[index]).to end_with "version"+(index+1).to_s
+              end
             end
 
           end


### PR DESCRIPTION
Fixes #625 and #627. Returns array of uris for every version. This also addresses issues with fixity checking in Sufia where you can now check the fixity of a specific version:

```
object.versions.each do |uri|
  ActiveFedora::FixityService.new(uri).check
end
```
