### PR TITLE
Reload and sort versions

### DIFF
--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -22,8 +22,12 @@ module ActiveFedora
 
     # Returns an array of ActiveFedora::VersionsGraph::ResourceVersion objects.
     # Excludes auto-snapshot versions from Fedora.
-    def versions
-      @versions ||= ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)
+    def versions(reload=false)
+      if reload
+        @versions ||= ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)
+      else
+        @versions = ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)
+      end
     end
 
     def create_version

--- a/lib/active_fedora/versions_graph.rb
+++ b/lib/active_fedora/versions_graph.rb
@@ -50,7 +50,8 @@ module ActiveFedora
       end
 
       def fedora_versions
-        resources.map { |statement| version_from_resource(statement) }
+        list = resources.map { |statement| version_from_resource(statement) }
+        list.sort { |a,b| a.created <=> b.created }
       end
 
   end


### PR DESCRIPTION
Enables force-reloading of versions from Fedora (#641) and ensures that versions are returned in the order they were created (#640).
