### PR TITLE
Reload and sort versions

### DIFF
--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -22,8 +22,12 @@ module ActiveFedora
 
     # Returns an array of ActiveFedora::VersionsGraph::ResourceVersion objects.
     # Excludes auto-snapshot versions from Fedora.
-    def versions
-      @versions ||= ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)
+    def versions(reload=false)
+      if reload
+        @versions = ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)
+      else
+        @versions ||= ActiveFedora::VersionsGraph.new << ::RDF::Reader.for(:ttl).new(versions_request)     
+      end
     end
 
     def create_version

--- a/lib/active_fedora/versions_graph.rb
+++ b/lib/active_fedora/versions_graph.rb
@@ -50,7 +50,8 @@ module ActiveFedora
       end
 
       def fedora_versions
-        resources.map { |statement| version_from_resource(statement) }
+        list = resources.map { |statement| version_from_resource(statement) }
+        list.sort_by(&:created)
       end
 
   end


### PR DESCRIPTION
Adds an option to force the reloading of VersionsGraph and ensures that all versions are sorted according to their creation date.

This duplicates #642 which was accidentally deleted.
