### PR TITLE
Add a service object for indexing profile json documents

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -69,8 +69,9 @@ module ActiveFedora #:nodoc:
     autoload :NomDatastream
     autoload :NullRelation
     autoload :OmDatastream
-    autoload :Property
     autoload :Persistence
+    autoload :ProfileIndexingService
+    autoload :Property
     autoload :QualifiedDublinCoreDatastream
     autoload :Querying
     autoload :QueryResultBuilder

--- a/lib/active_fedora/indexing_service.rb
+++ b/lib/active_fedora/indexing_service.rb
@@ -20,6 +20,10 @@ module ActiveFedora
       @profile_solr_name ||= ActiveFedora::SolrQueryBuilder.solr_name("object_profile", :displayable)
     end
 
+    def profile_service
+      ProfileIndexingService
+    end
+
 
     def generate_solr_document
       solr_doc = {}
@@ -28,7 +32,7 @@ module ActiveFedora
       Solrizer.set_field(solr_doc, 'active_fedora_model', object.class.inspect, :stored_sortable)
       solr_doc.merge!(QueryResultBuilder::HAS_MODEL_SOLR_FIELD => object.has_model)
       solr_doc.merge!(SOLR_DOCUMENT_ID.to_sym => object.id)
-      solr_doc.merge!(self.class.profile_solr_name => object.to_json)
+      solr_doc.merge!(self.class.profile_solr_name => profile_service.new(object).export)
       object.attached_files.each do |name, file|
         solr_doc.merge! file.to_solr(solr_doc, name: name.to_s)
       end

--- a/lib/active_fedora/profile_indexing_service.rb
+++ b/lib/active_fedora/profile_indexing_service.rb
@@ -1,0 +1,11 @@
+module ActiveFedora
+  class ProfileIndexingService
+    def initialize(object)
+      @object = object
+    end
+
+    def export
+      @object.serializable_hash.to_json
+    end
+  end
+end


### PR DESCRIPTION
Fixes #654
This allows implementers to override to_json without impacting the
structure of how the profile is stored in solr.
