### PR TITLE
Validation callback

### DIFF
--- a/spec/unit/callback_spec.rb
+++ b/spec/unit/callback_spec.rb
@@ -70,7 +70,7 @@ describe ActiveFedora::Base do
 
   end
 
-  describe 'validations bug' do
+  describe 'before_validation callback' do
     module SpecModel
       class Book < ActiveFedora::Base
         property :title, predicate: ::RDF::DC.title, multiple: false
@@ -83,8 +83,13 @@ describe ActiveFedora::Base do
     end
     let(:book) { SpecModel::Book.new}
 
-    it 'should run the before_validation callback on valid? check' do
+    it 'should be called by the valid? check' do
       book.valid?
+      expect(book.title).to eql 'Some title'
+    end
+
+    it 'should be called before save' do
+      book.save
       expect(book.title).to eql 'Some title'
     end
   end

--- a/spec/unit/callback_spec.rb
+++ b/spec/unit/callback_spec.rb
@@ -69,4 +69,23 @@ describe ActiveFedora::Base do
     @cb.destroy
 
   end
+
+  describe 'validations bug' do
+    module SpecModel
+      class Book < ActiveFedora::Base
+        property :title, predicate: ::RDF::DC.title, multiple: false
+
+        before_validation do
+          self.title = "Some title" if title.blank?
+        end
+
+      end
+    end
+    let(:book) { SpecModel::Book.new}
+
+    it 'should run the before_validation callback on valid? check' do
+      book.valid?
+      expect(book.title).to eql 'Some title'
+    end
+  end
 end


### PR DESCRIPTION
As I understand it, the `before_validation` callback should be called before the `save` event and the `valid?` check. As far as I can see, this doesn't happen with `ActiveFedora::Base`. My apologies if I'm misunderstanding something. 
