### PR TITLE
Jruby travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 sudo: false
 rvm:
   - 2.3.0
+  - jruby-head
 
 notifications:
   irc: "irc.freenode.org#projecthydra"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 sudo: false
 rvm:
   - 2.3.0
-  - jruby-head
+  - jruby-9.0.5.0
 
 notifications:
   irc: "irc.freenode.org#projecthydra"
@@ -15,3 +15,7 @@ global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_script:
   - jdk_switcher use oraclejdk8
+before_install:
+  - gem install bundler
+  - gem install bundler
+# jruby env doesn't have bundler by default


### PR DESCRIPTION
Old jruby branch was old.  Can't do just `jruby` because that gets **1.x** version of Ruby. We require **2.x**.   

Travis has jruby build issues w/ RVM images not including bundler (and Travis failing to backfill where bundler is expected).  Workaround allows app testing to happen, but we get:

```
1065 examples, 475 failures, 1 pending
```

Unclear how much is due to CI environment vs. actual jruby compatibility issues.  But there's a lot to look at.
