### PR TITLE
Add key to changed attributes if type is changed, fixes #1165

### DIFF
--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -190,9 +190,17 @@ module ActiveFedora
       end
 
       def execute_sparql_update
-        change_set = ChangeSet.new(self, resource, changed_attributes.keys)
+        changed_attributes_keys = changed_attributes.keys
+        changed_attributes_keys << "type" if type_changed?
+        change_set = ChangeSet.new(self, resource, changed_attributes_keys)
         return true if change_set.empty?
         ActiveFedora.fedora.ldp_resource_service.update(change_set, self.class, id)
+      end
+
+      def type_changed?
+        current = build_ldp_resource(id)
+        current_types = self.class.resource_class.new(current.graph.rdf_subject, data: current.graph.graph.data).type
+        (type.map(&:to_s) - current_types.map(&:to_s)).any?
       end
 
       # Override to tie in an ID minting service

--- a/spec/integration/rdf_types_spec.rb
+++ b/spec/integration/rdf_types_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+  let(:type1) { ::RDF::URI("http://my.types.com/TypeOne") }
+  let(:type2) { ::RDF::URI("http://my.types.com/TypeTwo") }
+
+  before(:all) do
+    class TypedSample < ActiveFedora::Base
+      type [::RDF::URI("http://my.types.com/TypeOne")]
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :TypedSample)
+  end
+
+  let(:sample) { TypedSample.new }
+
+  subject { sample }
+
+  context "before saving" do
+    its(:type) { is_expected.to include(type1) }
+  end
+
+  context "after saving" do
+    before do
+      sample.save
+      sample.reload
+    end
+    its(:type) { is_expected.to include(type1) }
+  end
+
+  context "when adding additional types after save" do
+    before do
+      sample.save
+      sample.type << type2
+    end
+    its(:type) { is_expected.to include(type1, type2) }
+
+    context "and then reloading" do
+      before do
+        sample.save
+        sample.reload
+      end
+      its(:type) { is_expected.to include(type1, type2) }
+    end
+  end
+
+  context "adding additional types at creation" do
+    before do
+      sample.type << type2
+      sample.save
+    end
+    its(:type) { is_expected.to include(type1, type2) }
+  end
+end


### PR DESCRIPTION
Note: I really don't like this solution, but I need to be able to do this.

Ideally, `type` needs to be added to the list of `changed_attributes.keys` but it's buried within ActiveModel and I can't figure out how ActiveFedora is wielding in order to make that happen.

My solution is to "re-query" the resource and compare the existing types with the ones that have been changed in the AF::Base instance.
