### PR TITLE
Leverage callback in ActiveTriples to mark attributes as dirty

### DIFF
--- a/lib/active_fedora/attribute_methods/dirty.rb
+++ b/lib/active_fedora/attribute_methods/dirty.rb
@@ -3,12 +3,10 @@ module ActiveFedora
     module Dirty
       extend ActiveSupport::Concern
 
-      def set_value(*val)
-        attribute = val.first
+      def dirty_attribute(attribute, values)
         unless [:has_model, :modified_date].include? attribute
-          attribute_will_change!(attribute) unless Array(self[val.first]).to_set == Array(val.last).to_set
+          attribute_will_change!(attribute) unless Array(self[attribute]).to_set == Array(values).to_set
         end
-        super
       end
     end
   end

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -43,7 +43,9 @@ module ActiveFedora
       # Appending the graph at the end is necessary because adding it as the
       # parent leaves behind triples not related to the ldp_source's rdf
       # subject.
-      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject, data: @ldp_source.graph.graph.data)
+      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject,
+                                                  data: @ldp_source.graph.graph.data,
+                                                  callback: ->(attrib, values) { dirty_attribute(attrib, values) })
     end
 
     # You can set the URI to use for the rdf_label on ClassMethods.rdf_label, then on

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -45,7 +45,7 @@ module ActiveFedora
       # subject.
       @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject,
                                                   data: @ldp_source.graph.graph.data,
-                                                  callback: ->(attrib, values) { dirty_attribute(attrib, values) })
+                                                  on_property_change: ->(attrib, values) { dirty_attribute(attrib, values) })
     end
 
     # You can set the URI to use for the rdf_label on ClassMethods.rdf_label, then on

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -69,5 +69,10 @@ describe "delegating attributes" do
       expect(titled_object).to_not be_title_changed
       expect(titled_object.changes).to be_empty
     end
+
+    it "changes when the shift operator is used" do
+      titled_object.title << "Another Title"
+      expect(titled_object.changes).to have_key :title
+    end
   end
 end


### PR DESCRIPTION
Resolves #540,  #768, and possibly other duplicates.

This works hand-in-hand with a separate PR against ActiveTriples (https://github.com/ActiveTriples/ActiveTriples/pull/258). The net result is that ActiveFedora objects have properties properly marked as dirty in circumstances when they previously weren't (most notably, when using `<<` to append to a multi-valued property), so that those changes get persisted instead of silently dropped.