### PR TITLE
[WIP] Add support for external files via RFC2017 mime types

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -146,8 +146,7 @@ module ActiveFedora
 
     def external_url
       return nil unless mime_type.start_with? "message/external-body"
-      url = mime_type.split(';').at(2)
-      url.nil? ? nil : url[/\"(.*?)\"/, 1]
+      mime_type[/url=['"](.+?)['"]/i, 1]
     end
 
     def external_url=(external_file_url)

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -107,6 +107,11 @@ module ActiveFedora
       @ds_content ||= retrieve_content
     end
 
+    def external_content
+      return nil unless external_url.start_with?("http")
+      Faraday.get(external_url).body
+    end
+
     def metadata
       @metadata ||= ActiveFedora::WithMetadata::MetadataNode.new(self)
     end
@@ -116,6 +121,7 @@ module ActiveFedora
     end
 
     def content_changed?
+      return false if external_content?
       return true if new_record? && !local_or_remote_content(false).blank?
       local_or_remote_content(false) != @ds_content
     end
@@ -139,6 +145,20 @@ module ActiveFedora
       false
     end
 
+    def external_content?
+      external_url.present?
+    end
+
+    def external_url
+      return nil unless mime_type.start_with? "message/external-body"
+      url = mime_type.split(';').at(2)
+      url.nil? ? nil : url[/\"(.*?)\"/, 1]
+    end
+
+    def external_url=(external_file_url)
+      self.mime_type = "message/external-body; access-type=URL; URL=\"#{external_file_url}\""
+    end
+
     # serializes any changed data into the content field
     def serialize!; end
 
@@ -147,12 +167,13 @@ module ActiveFedora
     end
 
     def content=(string_or_io)
+      raise "This file has external content.  First call external_url=nil if you want to use content=." if external_content?
       content_will_change! unless @content == string_or_io
       @content = string_or_io
     end
 
     def content
-      local_or_remote_content(true)
+      external_content? ? external_content : local_or_remote_content(true)
     end
 
     def self.relation

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -1,31 +1,6 @@
 require 'spec_helper'
 
 describe ActiveFedora::AttachedFiles do
-  describe "#has_subresource" do
-    before do
-      class FooHistory < ActiveFedora::Base
-        has_subresource 'child'
-      end
-    end
-    after do
-      Object.send(:remove_const, :FooHistory)
-    end
-
-    context "when the object exists" do
-      let!(:o) { FooHistory.create }
-      before do
-        o.child.content = "HMMM"
-        o.save
-      end
-
-      it "does not need to do a head on the children" do
-        f = FooHistory.find(o.id)
-        expect(f.ldp_source.client).not_to receive(:head)
-        f.child.content
-      end
-    end
-  end
-
   describe "Datastreams synched together" do
     before do
       class DSTest < ActiveFedora::Base

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -1,6 +1,31 @@
 require 'spec_helper'
 
 describe ActiveFedora::AttachedFiles do
+  describe "#has_subresource" do
+    before do
+      class FooHistory < ActiveFedora::Base
+        has_subresource 'child'
+      end
+    end
+    after do
+      Object.send(:remove_const, :FooHistory)
+    end
+
+    context "when the object exists" do
+      let!(:o) { FooHistory.create }
+      before do
+        o.child.content = "HMMM"
+        o.save
+      end
+
+      it "does not need to do a head on the children" do
+        f = FooHistory.find(o.id)
+        expect(f.ldp_source.client).not_to receive(:head)
+        f.child.content
+      end
+    end
+  end
+
   describe "Datastreams synched together" do
     before do
       class DSTest < ActiveFedora::Base

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -192,7 +192,7 @@ describe ActiveFedora::File do
 
     describe ".content" do
       it "returns external content" do
-        expect(af_file.content).to eq af_file.external_content
+        expect(af_file.content).to eq "This is external content!"
       end
     end
 
@@ -211,12 +211,6 @@ describe ActiveFedora::File do
     describe ".external_content?" do
       it "returns true" do
         expect(af_file.external_content?).to be_truthy
-      end
-    end
-
-    describe ".external_content" do
-      it "returns the content of the external url" do
-        expect(af_file.external_content).to eq 'This is external content!'
       end
     end
 


### PR DESCRIPTION
This PR takes the pattern used by Fedora and some Hydra implementors (see related links below) and enables it at the ActiveFedora::File level.  The use case for Avalon is that we want to store technical metadata and track derivative files that do not live in our repository but somewhere external, possibly a streaming server.  

~~Since the only way to determine if there is external content is to inspect the mime type, a request to fcr:metadata is required to get the file's content.  You can see I had to remove the test in spec/integration/attached_files_spec.rb due to this additional request.~~ Certain calls now require requesting fcr:metadata to get the mime type to check if there is external content. 

I'm guess there are things I've overlooked or edge cases that aren't handled so please give feedback on improvements!

~~The last failing test is related to #1233 and should disappear if I rebase once that is merged.~~

Related tickets and code:
https://github.com/projecthydra/active_fedora/issues/1156
https://github.com/projecthydra/ldp/pull/71
https://github.com/projecthydra/hydra-works/blob/master/lib/hydra/works/services/add_external_file_to_file_set.rb
https://github.com/lbiedinger/ldp/tree/redirects
https://github.com/pulibrary/plum/blob/master/app/jobs/ingest_file_job.rb