### PR TITLE
File metadata should have a modified_date

### DIFF
--- a/lib/active_fedora/file/attributes.rb
+++ b/lib/active_fedora/file/attributes.rb
@@ -49,6 +49,11 @@ module ActiveFedora::File::Attributes
     created && created.first
   end
 
+  def modified_date
+    modified = metadata.attributes["http://fedora.info/definitions/v4/repository#lastModified"]
+    modified && modified.first
+  end
+
   private
 
     # Fcrepo4.digest was used by Fedora < 4.3, but it was removed

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -319,6 +319,20 @@ describe ActiveFedora::File do
     end
   end
 
+  describe "#modified_date" do
+    subject { af_file.modified_date }
+    describe "when new record" do
+      it { is_expected.to be_nil }
+    end
+    describe "when persisted" do
+      before do
+        af_file.content = "foo"
+        af_file.save!
+      end
+      it { is_expected.to be_a(DateTime) }
+    end
+  end
+
   describe "callbacks" do
     before do
       class MyFile < ActiveFedora::File


### PR DESCRIPTION
ActiveFedora::Base objects have `.modified_date` alongside a `.create_date`, but ActiveFedora::File objects only have a `.create_date`.  This PR adds a `.modified_date` to match and make it easier to get the last modified date for a NonRdfSource.