### PR TITLE
No need to set RSolr 2.0 explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - rvm: 2.3.4
       env: "RAILS_VERSION=4.2.8"
-    - env: "RSOLR_VERSION=2.0.1"
+    - env: "RAILS_VERSION=5.1.1"
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 
 gem 'activemodel', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
-gem 'rsolr', ENV['RSOLR_VERSION'] if ENV['RSOLR_VERSION']
 
 group :test do
   gem 'simplecov', require: false


### PR DESCRIPTION
2.0.2 is the latest and will be installed by default.