### PR TITLE
[backport] Call get instead of HEAD + GET

### DIFF
--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -4,9 +4,13 @@ module ActiveFedora
     extend ActiveSupport::Concern
 
     def new_record?
-      @ldp_source.new?
+      return true if @ldp_source.subject.nil?
+      @ldp_source.get
+      false
     rescue Ldp::Gone
       false
+    rescue Ldp::NotFound
+      true
     end
 
     def persisted?


### PR DESCRIPTION
We almost always follow up a HEAD request with a GET request, so don't
bother with the HEAD request. The GET gives us all the information we
need.