### PR TITLE
[backport] Allow access to ETag with `AF::Common#etag`

### DIFF
--- a/lib/active_fedora/common.rb
+++ b/lib/active_fedora/common.rb
@@ -17,6 +17,16 @@ module ActiveFedora
       end
     end
 
+    ##
+    # @return [String] the etag from the response headers
+    #
+    # @raise [RuntimeError] when the resource is new and has no etag
+    # @raise [Ldp::Gone]    when the resource is deleted
+    def etag
+      raise 'Unable to produce an etag for a unsaved object' if ldp_source.new?
+      ldp_source.head.etag
+    end
+
     def ldp_source
       @ldp_source
     end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -43,6 +43,28 @@ describe ActiveFedora::Base do
     end
   end
 
+  describe '#etag' do
+    let(:attributes) { { id: '1234' } }
+
+    it 'before save raises an error' do
+      expect { book.etag }
+        .to raise_error 'Unable to produce an etag for a unsaved object'
+    end
+
+    context 'after save' do
+      before { book.save! }
+
+      it 'has the etag from the ldp_source' do
+        expect(book.etag).to eq book.ldp_source.head.etag
+      end
+
+      it 'after delete raises Ldp::Gone' do
+        book.destroy!
+        expect { book.etag }.to raise_error Ldp::Gone
+      end
+    end
+  end
+
   describe "#freeze" do
     before { book.freeze }
 


### PR DESCRIPTION
The specs guarantee that the ETag will be the one returned by the base
object's `#ldp_source`.

This allows a fix for a [to do item in
`Hyrax::WorkBehavior`](https://github.com/samvera/hyrax/blob/bf1ba8057da3212a32e3c30d070ba6d85cb8128a/app/models/concerns/hyrax/work_behavior.rb). The
implementation is slightly different from the one there, to avoid
reaching outside of `ActiveFedora::Common`. The functional difference is
that deleted objects will raise `Ldp::Gone` instead of `RuntimeError`;
this error is more informative and `Ldp::Gone` is a subclass of
`RuntimeError`.