### PR TITLE
Request options allow for setting timeout of Fedora client

### DIFF
--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -49,6 +49,10 @@ module ActiveFedora
       @config[:ssl]
     end
 
+    def request_options
+      @config[:request]
+    end
+
     def connection
       @connection ||= begin
         build_connection
@@ -86,6 +90,7 @@ module ActiveFedora
     def authorized_connection
       options = {}
       options[:ssl] = ssl_options if ssl_options
+      options[:request] = request_options if request_options
       Faraday.new(host, options) do |conn|
         conn.response :encoding # use Faraday::Encoding middleware
         conn.adapter Faraday.default_adapter # net/http

--- a/spec/unit/fedora_spec.rb
+++ b/spec/unit/fedora_spec.rb
@@ -15,5 +15,17 @@ describe ActiveFedora::Fedora do
         fedora.authorized_connection
       }
     end
+    describe "with request options" do
+      let(:config) {
+        { url: "https://example.com",
+          user: "fedoraAdmin",
+          password: "fedoraAdmin",
+          request: { timeout: 600, open_timeout: 60 } }
+      }
+      specify {
+        expect(Faraday).to receive(:new).with("https://example.com", request: { timeout: 600, open_timeout: 60 }).and_call_original
+        fedora.authorized_connection
+      }
+    end
   end
 end


### PR DESCRIPTION
When attempting to run reindex_everything, my Fedora instance sits in silence for 10+ minutes before returning the first bytes of a response to a get request of the base path.  Faraday throws a timeout after a few seconds so I need to be able to configure it to allow for these abnormally long periods of waiting.