### PR TITLE
Allow the descendant fetcher to be more flexible by grouping uris by model

### DIFF
--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -49,10 +49,9 @@ module ActiveFedora
 
       # returns a hash where keys are model names
       def descendant_and_self_uris_partitioned_by_model
-        resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
         # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
         # but this causes more requests to Fedora.
-        return partitioned_uris unless resource.head.rdf_source?
+        return partitioned_uris unless rdf_resource.head.rdf_source?
 
         add_self_to_partitioned_uris unless @exclude_self
 

--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -7,7 +7,7 @@ module ActiveFedora
     #
     # The DescendantFetcher is also capable of partitioning the URIs into "priority" URIs
     # that will be first in the returned list. These prioritized URIs belong to objects
-    # with certain hasModel models. This feature is used in some hydra apps that need to
+    # with certain hasModel models. This feature is used in some samvera apps that need to
     # index 'permissions' objects before other objects to have the solr indexing work right.
     # And so by default, the prioritized class names are the ones form Hydra::AccessControls,
     # but you can alter the prioritized model name list, or set it to the empty array.
@@ -34,6 +34,7 @@ module ActiveFedora
         @exclude_self = exclude_self
       end
 
+      # @return [Array<String>] uris starting with priority models
       def descendant_and_self_uris
         partitioned = descendant_and_self_uris_partitioned
         partitioned[:priority] + partitioned[:other]
@@ -41,13 +42,16 @@ module ActiveFedora
 
       # returns a hash where key :priority is an array of all prioritized
       # type objects, key :other is an array of the rest.
+      # @return [Hash<String, Array<String>>] uris sorted into :priority and :other
       def descendant_and_self_uris_partitioned
         model_partitioned = descendant_and_self_uris_partitioned_by_model
         { priority: model_partitioned.slice(*priority_models).values.flatten,
           other: model_partitioned.slice(*(model_partitioned.keys - priority_models)).values.flatten }
       end
 
-      # returns a hash where keys are model names
+      # Returns a hash where keys are model names
+      # This is useful if you need to action on certain models and want finer grainularity than priority/other
+      # @return [Hash<String, Array<String>>] uris sorted by model names
       def descendant_and_self_uris_partitioned_by_model
         # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
         # but this causes more requests to Fedora.

--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -91,10 +91,6 @@ module ActiveFedora
           end.compact
         end
 
-        def prioritized_object?
-          priority_models.present? && (rdf_graph_models & priority_models).count > 0
-        end
-
         def add_self_to_partitioned_uris
           rdf_graph_models.each do |model|
             partitioned_uris[model] ||= []

--- a/spec/integration/indexing/descendant_fetcher_spec.rb
+++ b/spec/integration/indexing/descendant_fetcher_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Indexing::DescendantFetcher do
+  before do
+    class Thing < ActiveFedora::Base
+      property :title, predicate: ::RDF::Vocab::DC.title
+    end
+    class Source < ActiveFedora::Base
+      is_a_container class_name: 'Thing'
+    end
+  end
+  after do
+    Object.send(:remove_const, :Source)
+    Object.send(:remove_const, :Thing)
+  end
+
+  let(:parent) { Source.create }
+  let(:child) { parent.contains.create(title: ['my title']) }
+  let(:other_parent) { Source.create }
+  let!(:source_uris) { [parent, other_parent].map(&:uri).map(&:to_s) }
+  let!(:thing_uris) { [child].map(&:uri).map(&:to_s) }
+  let(:uri) { ActiveFedora.fedora.base_uri }
+  let(:fetcher) { described_class.new(uri) }
+
+  describe '.descendant_and_self_uris' do
+    context 'with default priority models' do
+      it 'returns uris for all objects by walking tree' do
+        expect(fetcher.descendant_and_self_uris).to match_array(source_uris + thing_uris)
+      end
+    end
+    context 'when supplying priority models' do
+      let(:priority_models) { ['Thing'] }
+      let(:fetcher) { described_class.new(uri, priority_models: priority_models) }
+      it 'returns priority model uris first' do
+        expect(fetcher.descendant_and_self_uris.slice(0..(thing_uris.count - 1))).to match_array(thing_uris)
+      end
+    end
+  end
+  describe '.descendant_and_self_uris_partitioned' do
+    context 'with default priority models' do
+      it 'returns' do
+        expect(fetcher.descendant_and_self_uris_partitioned.to_a).to match_array([[:priority, []], [:other, match_array(source_uris + thing_uris)]])
+      end
+    end
+    context 'when supplying priority models' do
+      let(:priority_models) { ['Thing'] }
+      let(:fetcher) { described_class.new(uri, priority_models: priority_models) }
+      it 'returns' do
+        expect(fetcher.descendant_and_self_uris_partitioned.to_a).to match_array([[:priority, match_array(thing_uris)], [:other, match_array(source_uris)]])
+      end
+    end
+  end
+  describe '.descendant_and_self_uris_partitioned_by_model' do
+    it 'returns' do
+      expect(fetcher.descendant_and_self_uris_partitioned_by_model.to_a).to match_array([['Source', match_array(source_uris)], ['Thing', match_array(thing_uris)]])
+    end
+    context 'excluding self' do
+      let(:fetcher) { described_class.new(parent.uri, exclude_self: true) }
+      it 'returns' do
+        expect(fetcher.descendant_and_self_uris_partitioned_by_model.to_a).to match_array([['Thing', [child.uri.to_s]]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR preserves previous functionality for grouping uris by priority/other but also adds the capability to get the uris grouped by model if you call `descendant_and_self_uris_partitioned_by_model` directly.