### PR TITLE
Remove deprecated defaultOperator and defaultSearchField solr configs

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
@@ -334,12 +334,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <!--  <defaultSearchField>text</defaultSearchField> -->
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
As per same fix in blacklight: https://github.com/projectblacklight/blacklight/commit/b88b93ab7cfffb03117f47b6cd92a9bde5426d6d
and hyrax:
https://github.com/samvera/hyrax/pull/1711