### PR TITLE
Add an IO like object for Fedora files

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -67,6 +67,7 @@ module ActiveFedora #:nodoc:
     autoload :FedoraAttributes
     autoload :File
     autoload :FileConfigurator
+    autoload :FileIO
     autoload :FilePathBuilder
     autoload :FilePersistence
     autoload :FileRelation

--- a/lib/active_fedora/file_io.rb
+++ b/lib/active_fedora/file_io.rb
@@ -1,0 +1,120 @@
+module ActiveFedora
+  ##
+  # IO like object for reading Fedora files.
+  # Use ActiveFedora::FileIO.new(fedora_file) to create one. You can then call
+  # read on it or use it with IO.copy_stream and the like.
+  #
+  # @Note The stream will always be in binmode and return ASCII-8BIT content.
+  class FileIO
+    attr_reader :pos
+
+    ##
+    # @param [ActiveFedora::File] the file which is wrapped in this IO object.
+    def initialize(fedora_file)
+      @fedora_file = fedora_file
+      @closed = false
+      rewind # this initialises various variables
+    end
+
+    def size
+      @fedora_file.size
+    end
+
+    alias length size
+
+    def binmode
+      # Do nothing, just return self. The stream is essentially always in binmode.
+      self
+    end
+
+    def binmode?
+      true
+    end
+
+    ##
+    # Read bytes from the file. See IO.read for more information.
+    # @param [Integer] the number of bytes to read. If nil or omitted, the
+    #                  entire contents will be read.
+    # @param [String] a string in which the contents are read. Can be omitted.
+    # @return [String] the read bytes. If number of bytes to read was not
+    #                  specified then always returns a String, possibly an empty
+    #                  one. If number of bytes was specified then the returned
+    #                  string will always be at least one byte long. If no bytes
+    #                  are left in the file returns nil instead.
+    def read(amount = nil, buf = nil)
+      raise(IOError, "closed stream") if @closed
+
+      buf ||= ''.force_encoding("ASCII-8BIT")
+      buf.clear
+
+      if amount.nil?
+        read_to_buf(nil, buf) # read the entire file, returns buf
+      elsif amount < 0
+        raise(ArgumentError, "negative length #{amount} given")
+      elsif amount.zero?
+        ''
+      else
+        read_to_buf(amount, buf)
+        # if amount was specified but we reached eof before reading anything
+        # then we must return nil
+        buf.empty? ? nil : buf
+      end
+    end
+
+    ##
+    # Rewinds the io object to the beginning. Read will return bytes from the
+    # start of the file again.
+    def rewind
+      raise(IOError, "closed stream") if @closed
+      @pos = 0
+      @buffer = nil
+      @stream_fiber = Fiber.new do
+        @fedora_file.stream.each do |chunk|
+          Fiber.yield chunk
+        end
+        @stream_fiber = nil
+        # last value from Fiber is the return value of the block which should be nil
+      end
+      0
+    end
+
+    ##
+    # Closes the file. No further action can be taken on the file.
+    def close
+      @closed = true
+      @stream_fiber = nil
+      nil
+    end
+
+    private
+
+      def read_to_buf(amount, buf)
+        while (amount.nil? || buf.length < amount) && fill_buffer
+          buf << consume_buffer(amount.nil? ? nil : (amount - buf.length))
+        end
+        buf
+      end
+
+      def consume_buffer(count = nil)
+        if count.nil? || count >= @buffer.length
+          @pos += @buffer.length
+          @buffer .tap do
+            @buffer = nil
+          end
+        else
+          @buffer.slice!(0, count) .tap do |slice|
+            @pos += slice.length
+          end
+        end
+      end
+
+      def fill_buffer
+        return true if @buffer.present?
+        # Ruby Net library doesn't seem to like it if we modify the returned
+        # chunk in any way, hence dup.
+        @buffer = @stream_fiber.try(:resume).try(:dup)
+        @buffer.try(:force_encoding, 'ASCII-8BIT')
+        !@buffer.nil?
+      end
+  end
+end

--- a/spec/unit/file_io_spec.rb
+++ b/spec/unit/file_io_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe ActiveFedora::FileIO do
+  # 300,000 byte test string
+  test_file = (0..300_000).reduce('') do |s, c| s << (c % 256).chr end
+
+  let(:file_contents) { test_file }
+  let(:fedora_file) {
+    ActiveFedora::File.new .tap do |file|
+      file.content = file_contents
+      file.save
+    end
+  }
+  let(:io) { described_class.new(fedora_file) }
+
+  describe "#read" do
+    it "reads the entire file when called without parameters" do
+      expect(io.read).to eql(file_contents)
+    end
+
+    it "returns nil at end of file when requested with length" do
+      io.read
+      expect(io.read(10)).to be_nil
+    end
+
+    it "returns only requested amount of bytes" do
+      expect(io.read(5)).to eql(file_contents[0..4])
+      expect(io.read(5)).to eql(file_contents[5..9])
+      expect(io.read(100_000)).to eql(file_contents[10..100_009])
+      expect(io.read(200_000)).to eql(file_contents[100_010..-1])
+    end
+
+    it "returns an empty string if 0 bytes is requested" do
+      expect(io.read(0)).to eql('')
+    end
+
+    it "raises an error with negative length parameter" do
+      expect { io.read(-1) }.to raise_error(ArgumentError)
+    end
+
+    it "returns ASCII-8BIT strings" do
+      expect(io.read(10).encoding.to_s).to eql("ASCII-8BIT")
+      expect(io.read.encoding.to_s).to eql("ASCII-8BIT")
+    end
+
+    it "can take a buffer parameter" do
+      buffer = ''
+      expect(io.read(100, buffer)).to eql(file_contents[0..99])
+      expect(buffer).to eql(file_contents[0..99])
+      # IO.read will clear the buffer if it's not empty
+      expect(io.read(100, buffer)).to eql(file_contents[100..199])
+      expect(buffer).to eql(file_contents[100..199])
+    end
+
+    context "with empty file" do
+      let(:file_contents) { '' }
+      it "returns an empty string when called without parameters" do
+        expect(io.read).to eql('')
+      end
+
+      it "returns nil when called with length parameter" do
+        expect(io.read(10)).to be_nil
+      end
+    end
+
+    context "edge cases" do
+      let(:stream) {
+        instance_double(ActiveFedora::File::Streaming::FileBody).tap do |stream|
+          allow(stream).to receive(:each) do |&block|
+            ['abcd', 'efghijkl', 'mnopqrst', 'uvwxy', 'z'].each(&block)
+          end
+        end
+      }
+      before {
+        allow(fedora_file).to receive(:stream).and_return(stream)
+      }
+      let(:file_contents) { 'abcdefghijklmnopqrstuvwxyz' }
+      it "are handled correctly" do
+        expect(io.read(4)).to eql('abcd')
+        expect(io.read(7)).to eql('efghijk')
+        expect(io.read(9)).to eql('lmnopqrst')
+        expect(io.read(6)).to eql('uvwxyz')
+        expect(io.read(4)).to be_nil
+      end
+    end
+  end
+
+  describe "#pos" do
+    it "returns current position" do
+      expect(io.pos).to be(0)
+      io.read(5)
+      expect(io.pos).to be(5)
+      io.read(100_000)
+      expect(io.pos).to be(100_005)
+      io.read
+      expect(io.pos).to be(file_contents.length)
+      io.rewind
+      expect(io.pos).to be(0)
+    end
+  end
+
+  describe "#rewind" do
+    it "restarts the stream" do
+      io.read(10)
+      io.rewind
+      expect(io.read(10)).to eql(file_contents[0..9])
+    end
+  end
+
+  describe "#close" do
+    it "closes the stream" do
+      io.read(10)
+      io.close
+      expect { io.read(10) } .to raise_error(IOError)
+    end
+  end
+
+  describe "#binmode" do
+    it "responds to binmode" do
+      expect { io.binmode } .not_to raise_error
+    end
+  end
+
+  describe "#binmode?" do
+    it "returns true" do
+      expect(io.binmode?).to be(true)
+    end
+  end
+
+  describe "working with IO.copy_stream" do
+    let(:output_stream) { StringIO.new .tap(&:binmode) }
+    it "copies the stream" do
+      IO.copy_stream(io, output_stream)
+      expect(output_stream.string).to eql(file_contents)
+    end
+  end
+end


### PR DESCRIPTION
This adds an IO like way to use ActiveFedora::Files. This will make it easier to handle files as streams rather than loading the entire contents in memory, which should always be avoided for obvious reasons. file.stream.each offers a similar mechanism (and this PR is based on that) but since it's not IO-like, it's not as simple to use with other tools.

For example in here https://github.com/samvera/hyrax/blob/master/app/services/hyrax/working_directory.rb#L36 the StringIO could immediately be replaced with this IO like object to avoid loading the contents in memory. 