### PR TITLE
Allow SolrService to submit queries via HTTP POST

### DIFF
--- a/spec/unit/solr_service_spec.rb
+++ b/spec/unit/solr_service_spec.rb
@@ -65,12 +65,46 @@ describe ActiveFedora::SolrService do
     end
   end
 
+  describe "#post" do
+    it "calls solr" do
+      stub_result = double("Result")
+      expect(mock_conn).to receive(:post).with('select', data: { q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      allow(described_class).to receive(:instance).and_return(double("instance", conn: mock_conn))
+      expect(described_class.post('querytext')).to eq stub_result
+    end
+    it "uses select_path" do
+      stub_result = double("Result")
+      expect(mock_conn).to receive(:post).with('select_test', data: { q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      expect(described_class).to receive(:select_path).and_return('select_test')
+      allow(described_class).to receive(:instance).and_return(double("instance", conn: mock_conn))
+      expect(described_class.post('querytext')).to eq stub_result
+    end
+  end
+
   describe "#query" do
     let(:doc) { { 'id' => 'x' } }
     let(:docs) { [doc] }
     let(:stub_result) { { 'response' => { 'docs' => docs } } }
+
     before do
       allow(described_class).to receive(:instance).and_return(double("instance", conn: mock_conn))
+    end
+
+    it "defaults to HTTP GET method" do
+      expect(mock_conn).to receive(:get).with('select', params: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      described_class.query('querytext', rows: 2)
+    end
+
+    it "allows callers to specify HTTP POST method" do
+      expect(mock_conn).to receive(:post).with('select', data: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      described_class.query('querytext', rows: 2, method: :post)
+    end
+
+    it "raises if method not GET or POST" do
+      expect(mock_conn).not_to receive(:head).with('select', data: { rows: 2, q: 'querytext', qt: 'standard' })
+      expect {
+        described_class.query('querytext', rows: 2, method: :head)
+      }.to raise_error(RuntimeError, "Unsupported HTTP method for querying SolrService (:head)")
     end
 
     it "wraps the solr response documents in Solr hits" do


### PR DESCRIPTION
Backports #1283 to the 11.x series.