### PR TITLE
Treat `RDF::Term` implementers as singular values

### DIFF
--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -13,9 +13,10 @@ module ActiveFedora::Attributes
     end
 
     def self.define_writers(mixin, name)
+      # RDF Terms are singular, even if they respond to `#each`
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          if value.present? && !value.respond_to?(:each)
+          unless value.nil? || (value.respond_to?(:each) && !(value.respond_to?(:term?) && value.term?))
             raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to a scalar value. However, this property is declared as being multivalued."
           end
           set_value(:#{name}, value)
@@ -43,9 +44,10 @@ module ActiveFedora::Attributes
     end
 
     def self.define_singular_writers(mixin, name)
+      # RDF Terms are singular, even if they respond to `#each`
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          if value.respond_to?(:each) # singular
+          if value.respond_to?(:each) && !(value.respond_to?(:term?) && value.term?)
             raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to an enumerable value. However, this property is declared as singular."
           end
           set_value(:#{name}, value)

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -131,13 +131,15 @@ describe ActiveFedora::Base do
         expect { history.title = "Quack" }.to raise_error ArgumentError
         expect { history.title = ["Quack"] }.not_to raise_error
         expect { history.title = nil }.not_to raise_error
+        expect { history.title = ActiveTriples::Resource.new }.to raise_error
       end
 
       it "does not allow an enumerable to a unique attribute writer" do
         expect { history.abstract = "Low" }.not_to raise_error
-        expect { history.abstract = ["Low"]
-        }.to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
+        expect { history.abstract = ["Low"] }
+          .to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
         expect { history.abstract = nil }.not_to raise_error
+        expect { history.abstract = ActiveTriples::Resource.new }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Some `RDF::Term` objects implement `#each`, including `ActiveTriples::RDFSources`. The old checks for singular fail on simple cases like `work.single = RDF::Node.new; work.single = work.single`. The new check has a special case for terms.

Ideally, we could check something like `#to_ary`, but behavior is not consistent across the relevant dependency libraries. E.g. `ActiveTriples::Relation#to_ary` is unimplemented, while `RDF::Queryable#to_ary` is (the opposite would be better for our use).