### PR TITLE
Treat resources as allowable single valued properties

### DIFF
--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -13,10 +13,9 @@ module ActiveFedora::Attributes
     end
 
     def self.define_writers(mixin, name)
-      # RDF Terms are singular, even if they respond to `#each`
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          unless value.nil? || (value.respond_to?(:each) && !(value.respond_to?(:term?) && value.term?))
+          if value.present? && !value.respond_to?(:each)
             raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to a scalar value. However, this property is declared as being multivalued."
           end
           set_value(:#{name}, value)
@@ -44,10 +43,9 @@ module ActiveFedora::Attributes
     end
 
     def self.define_singular_writers(mixin, name)
-      # RDF Terms are singular, even if they respond to `#each`
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          if value.respond_to?(:each) && !(value.respond_to?(:term?) && value.term?)
+          if value.respond_to?(:each) # singular
             raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to an enumerable value. However, this property is declared as singular."
           end
           set_value(:#{name}, value)

--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -45,7 +45,7 @@ module ActiveFedora::Attributes
     def self.define_singular_writers(mixin, name)
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          if value.respond_to?(:each) # singular
+          if value.respond_to?(:each) && !(value.respond_to?(:term?) && value.term?)
             raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to an enumerable value. However, this property is declared as singular."
           end
           set_value(:#{name}, value)

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -138,6 +138,7 @@ describe ActiveFedora::Base do
         expect { history.abstract = ["Low"]
         }.to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
         expect { history.abstract = nil }.not_to raise_error
+        expect { history.abstract = ActiveTriples::Resource.new }.not_to raise_error
       end
     end
   end

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -131,15 +131,13 @@ describe ActiveFedora::Base do
         expect { history.title = "Quack" }.to raise_error ArgumentError
         expect { history.title = ["Quack"] }.not_to raise_error
         expect { history.title = nil }.not_to raise_error
-        expect { history.title = ActiveTriples::Resource.new }.to raise_error
       end
 
       it "does not allow an enumerable to a unique attribute writer" do
         expect { history.abstract = "Low" }.not_to raise_error
-        expect { history.abstract = ["Low"] }
-          .to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
+        expect { history.abstract = ["Low"]
+        }.to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
         expect { history.abstract = nil }.not_to raise_error
-        expect { history.abstract = ActiveTriples::Resource.new }.not_to raise_error
       end
     end
   end

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -133,6 +133,11 @@ describe ActiveFedora::Base do
         expect { history.title = nil }.not_to raise_error
       end
 
+      it "allow setting to multiple properties with unintended legacy behavior" do
+        expect { history.title = '' }.not_to raise_error
+        expect { history.title = ActiveTriples::Resource.new }.not_to raise_error
+      end
+
       it "does not allow an enumerable to a unique attribute writer" do
         expect { history.abstract = "Low" }.not_to raise_error
         expect { history.abstract = ["Low"]


### PR DESCRIPTION
This is a minimal replacement for the more comprehensive fix in the reverted
3c21a7d.

Some `RDF::Term` objects implement `#each`, including
`ActiveTriples::RDFSources`. The old checks for singular fail on simple cases
like `work.single = RDF::Node.new; work.single = work.single`. The new check has
a special case allowing terms as single valued properties. Checking for
multivalued fields remains broken to support legacy code that accidentally takes
advantage of the bug.

Presently, both `work.my_property = ''` and `work.my_property = RDF::Node.new`
are allowable sets for multivalued fields.