### PR TITLE
Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: ruby
 cache: bundler
+dist: trusty
 sudo: false
-rvm: 2.4.1
+
+rvm:
+  - 2.3
+  - 2.3.4
+  - 2.4
+  - ruby-head
+
 matrix:
+  allow_failures: ruby-head
   include:
-    - rvm: 2.3.4
-      env: "RAILS_VERSION=4.2.8"
     - env: "RAILS_VERSION=5.1.1"
+
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:


### PR DESCRIPTION
The proposed updates are:

  - Build latest of Ruby 2.3, 2.4, and ruby-head.
  - Keep Ruby 2.3.4.
  - Allow failure on ruby-head (this is a canary).
  - Use `trusty` explicitly (this provides stability for the default).

In addition to these changes, I would suggest adding a weekly cron job to the travis configuration to build `master` if a build has not occurred in the last 24 hours.