### PR TITLE
Restore equivalent_class? method

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -194,11 +194,15 @@ module ActiveFedora
           ActiveFedora::Base
         else
           resource_class = ActiveFedora.model_mapper.classifier(resource).best_model
-          unless resource_class <= @klass
+          unless equivalent_class?(resource_class)
             raise ActiveFedora::ModelMismatch, "Expected #{@klass}. Got: #{resource_class}"
           end
           resource_class
         end
+      end
+
+      def equivalent_class?(other_class)
+        other_class <= @klass
       end
 
       def find_with_ids(ids, cast)


### PR DESCRIPTION
It was in use by Hyrax (see
https://github.com/samvera/hyrax/issues/2482)  This was removed in https://github.com/samvera/active_fedora/pull/1277