### PR TITLE
Request ntriples when fetching descendants to avoid timeout issues

### DIFF
--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -103,5 +103,13 @@ module ActiveFedora
         ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
       end
     end
+
+    def ntriples_connection
+      authorized_connection.tap { |conn| conn.headers['Accept'] = 'application/n-triples' }
+    end
+
+    def build_ntriples_connection
+      ActiveFedora::InitializingConnection.new(ActiveFedora::CachingConnection.new(ntriples_connection, omit_ldpr_interaction_model: true), root_resource_path)
+    end
   end
 end

--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -77,7 +77,7 @@ module ActiveFedora
       protected
 
         def rdf_resource
-          @rdf_resource ||= Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+          @rdf_resource ||= Ldp::Resource::RdfSource.new(ActiveFedora.fedora.build_ntriples_connection, uri)
         end
 
         def rdf_graph


### PR DESCRIPTION
This PR proposes to request ntriples when gathering the descendants for reindexing.  

Due to the number of child nodes on the base path requesting it can take a really long time to return the whole rdf document.  If the default turtle serialization is used the entire document has to be prepared prior to returning anything to the client (AF) leading to timeouts.  Switching to ntriples allows the document to stream back avoiding the timeout issues.

Related discussion:
https://jira.duraspace.org/browse/FCREPO-2544
https://groups.google.com/d/topic/samvera-tech/FPSFJubcPn8/discussion