### PR TITLE
Use cached download of Solr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - "dep_cache"
 sudo: false
 rvm: 2.4.1
 matrix:
@@ -11,5 +14,8 @@ global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:
   - gem update --system
+  - mkdir -p dep_cache
+  - ls -l dep_cache
+  - cp config/travis/.solr_wrapper .solr_wrapper
 before_script:
   - jdk_switcher use oraclejdk8

--- a/config/travis/.solr_wrapper
+++ b/config/travis/.solr_wrapper
@@ -1,0 +1,7 @@
+# Place any default configuration for solr_wrapper here
+# version: 6.1.0
+port: 8985
+download_dir: dep_cache
+collection:
+  dir: lib/generators/active_fedora/config/solr/templates/solr/config/
+  name: hydra-test


### PR DESCRIPTION
Apache will eventually stop allowing multiple downloads of Solr over a
given 24-hour period. Here we can cache the download on Travis to
prevent from happening and run an unlimited number of builds per day.

This should fix the issue that @jrochkind and others were having with running multiple AF builds and Solr not getting downloaded.