### PR TITLE
Prefer om_term_values to send when solrizing within SimpleDatastream

### DIFF
--- a/lib/active_fedora/simple_datastream.rb
+++ b/lib/active_fedora/simple_datastream.rb
@@ -1,12 +1,12 @@
 module ActiveFedora
-  #This class represents a simple xml datastream. 
+  #This class represents a simple xml datastream.
   class SimpleDatastream < OmDatastream
 
     class_attribute :class_fields
     attr_accessor :fields
     self.class_fields = []
-    
-    
+
+
      set_terminology do |t|
        t.root(:path=>"fields", :xmlns=>nil)
      end
@@ -16,7 +16,7 @@ module ActiveFedora
         xml.text(name)
       end
     end
-    
+
 
     #Constructor. this class will call self.field for each DCTERM. In short, all DCTERMS fields will already exist
     #when this method returns. Each term is marked as a multivalue string.
@@ -27,15 +27,15 @@ module ActiveFedora
 
     # This method generates the various accessor and mutator methods on self for the datastream metadata attributes.
     # each field will have the 2 magic methods:
-    #   name=(arg) 
-    #   name 
+    #   name=(arg)
+    #   name
     #
     #
     # 'datatype' is a datatype, currently :string, :integer and :date are supported.
     #
     # opts is an options hash, which  will affect the generation of the xml representation of this datastream.
     #
-    # Currently supported modifiers: 
+    # Currently supported modifiers:
     # For +SimpleDatastream+:
     #   :element_attrs =>{:foo=>:bar} -  hash of xml element attributes
     #   :xml_node => :nodename  - The xml node to be used to represent this object (in dcterms namespace)
@@ -45,8 +45,8 @@ module ActiveFedora
     #
     #There is quite a good example of this class in use in spec/examples/oral_history.rb
     #
-    #!! Careful: If you declare two fields that correspond to the same xml node without any qualifiers to differentiate them, 
-    #you will end up replicating the values in the underlying datastream, resulting in mysterious dubling, quadrupling, etc. 
+    #!! Careful: If you declare two fields that correspond to the same xml node without any qualifiers to differentiate them,
+    #you will end up replicating the values in the underlying datastream, resulting in mysterious dubling, quadrupling, etc.
     #whenever you edit the field's values.
     def field(name, datatype=:string, opts={})
       fields ||= {}
@@ -59,9 +59,9 @@ module ActiveFedora
         self.class.terminology.add_term(term)
         term.generate_xpath_queries!
       end
-      
+
     end
-    
+
     def update_indexed_attributes(params={}, opts={})
       raise "can't modify frozen #{self.class}" if frozen?
       # if the params are just keys, not an array, make then into an array.
@@ -75,25 +75,20 @@ module ActiveFedora
       end
       super(new_params, opts)
     end
-    
 
     def self.xml_template
-       Nokogiri::XML::Document.parse("<fields/>")
+      Nokogiri::XML::Document.parse("<fields/>")
     end
 
     def to_solr(solr_doc = Hash.new) # :nodoc:
       @fields.each do |field_key, field_info|
         next if field_key == :location ## FIXME HYDRA-825
-        things = send(field_key)
-        if things 
-          field_symbol = ActiveFedora::SolrService.solr_name(field_key, type: field_info[:type])
-          things.val.each do |val|    
-            ::Solrizer::Extractor.insert_solr_field_value(solr_doc, field_symbol, val.to_s )         
-          end
+        field_symbol = ActiveFedora::SolrService.solr_name(field_key, type: field_info[:type])
+        om_term_values(field_key).each do |val|
+          ::Solrizer::Extractor.insert_solr_field_value(solr_doc, field_symbol, val.to_s)
         end
       end
-      return solr_doc
+      solr_doc
     end
-
   end
 end

--- a/spec/unit/simple_datastream_spec.rb
+++ b/spec/unit/simple_datastream_spec.rb
@@ -3,26 +3,40 @@ require 'spec_helper'
 describe ActiveFedora::SimpleDatastream do
 
   before do
-    @sample_xml =  "<fields><coverage>coverage1</coverage><coverage>coverage2</coverage><creation_date>2012-01-15</creation_date><mydate>fake-date</mydate><publisher>publisher1</publisher></fields>"
+    @sample_xml =  "<fields><coverage>coverage1</coverage><coverage>coverage2</coverage><creation_date>2012-01-15</creation_date><mydate>fake-date</mydate><prefix>foobar</prefix><publisher>publisher1</publisher></fields>"
     @test_ds = ActiveFedora::SimpleDatastream.from_xml(@sample_xml )
     @test_ds.field :coverage
     @test_ds.field :creation_date, :date
     @test_ds.field :mydate
+    @test_ds.field :prefix
     @test_ds.field :publisher
-
   end
+
   it "from_xml should parse everything correctly" do
     expect(@test_ds.ng_xml).to be_equivalent_to @sample_xml
   end
 
-  
+  describe "#to_solr" do
+    it "should work as expected" do
+      expect(@test_ds.to_solr).to eq(
+        {
+          'coverage_tesim' => ['coverage1', 'coverage2'],
+          'creation_date_dtsim' => '2012-01-15',
+          'mydate_tesim' => 'fake-date',
+          'prefix_tesim' => 'foobar',
+          'publisher_tesim' => 'publisher1'
+        }
+      )
+    end
+  end
+
   describe '#new' do
-    describe "model methods" do 
+    describe "model methods" do
 
       [:coverage, :mydate, :publisher].each do |el|
         it "should respond to getters and setters for the string typed #{el} element" do
           value = "Hey #{el}"
-          @test_ds.send("#{el.to_s}=", value) 
+          @test_ds.send("#{el.to_s}=", value)
           expect(@test_ds.send(el).first).to eq(value)  #Looking at first because creator has 2 nodes
         end
       end
@@ -34,7 +48,7 @@ describe ActiveFedora::SimpleDatastream do
       end
     end
   end
-  
+
   describe '.to_xml' do
     it 'should output the fields hash as Qualified Dublin Core XML' do
       @test_ds.publisher= "charlie"
@@ -46,6 +60,7 @@ describe ActiveFedora::SimpleDatastream do
           <coverage>20%</coverage>
           <creation_date>2012-01-15</creation_date>
           <mydate>fake-date</mydate>
+          <prefix>foobar</prefix>
           <publisher>charlie</publisher>
         </fields>')
     end


### PR DESCRIPTION
This allows downstream users to use fields that conflict with public AF methods. Case in point: I need to support a field named "prefix" which entered the public API around AF 7.0.0.