### PR TITLE
suggest searchComponent and requestHandler disabled by default

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
@@ -284,6 +284,8 @@
       -->
   </searchComponent>
 
+<!-- suggest searchComponent and requestHandler disabled by default due to performance penalties -->
+<!--
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
@@ -304,7 +306,8 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
-
+-->
+ 
   <requestHandler name="/update/extract" class="org.apache.solr.handler.extraction.ExtractingRequestHandler">
     <lst name="defaults">
       <str name="fmap.Last-Modified">last_modified</str>


### PR DESCRIPTION
Due to performance penalties documented by @awead and replicated by others.