### PR TITLE
Fix support for Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ rvm: 2.4.1
 matrix:
   include:
     - rvm: 2.3.4
-      env: "RAILS_VERSION=4.2.8"
+      env: "RAILS_VERSION=4.2.10"
     - env: "RAILS_VERSION=5.1.1"
+    - rvm: 2.5.1
+      env: RAILS_VERSION=5.2.0
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:
   - gem update --system
+  - gem install bundler
 before_script:
   - jdk_switcher use oraclejdk8

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
   s.add_dependency 'solrizer', '>= 3.4', '< 5'
   s.add_dependency "activesupport", '>= 4.2.4', '< 6'
-  s.add_dependency "activemodel", '>= 4.2', '< 6'
+  s.add_dependency "activemodel", '>= 4.2.10', '< 6'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '~> 0.7.0'

--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -15,7 +15,7 @@ module ActiveFedora
       # Overriding so that we don't track previously_changed, which was
       # rather expensive.
       def clear_changed_attributes
-        @changed_attributes.clear
+        clear_changes_information
       end
 
       def changed?

--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -136,7 +136,7 @@ module ActiveFedora
     #   person.attribute_names
     #   # => ["id", "created_at", "updated_at", "name", "age"]
     def attribute_names
-      @attributes.keys
+      @local_attributes.keys
     end
 
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.

--- a/lib/active_fedora/attribute_methods/read.rb
+++ b/lib/active_fedora/attribute_methods/read.rb
@@ -36,7 +36,7 @@ module ActiveFedora
       end
 
       def _read_attribute(attr_name) # :nodoc:
-        @attributes.fetch(attr_name.to_s) { |n| yield n if block_given? }
+        attributes.fetch(attr_name.to_s) { |n| yield n if block_given? }
       end
 
       alias attribute _read_attribute

--- a/lib/active_fedora/attribute_methods/write.rb
+++ b/lib/active_fedora/attribute_methods/write.rb
@@ -28,7 +28,7 @@ module ActiveFedora
 
       def write_attribute(attribute_name, value)
         if self.class.properties.key?(attribute_name)
-          @attributes[attribute_name] = value
+          attributes[attribute_name] = value
         else
           raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attribute_name}'"
         end

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -12,7 +12,7 @@ module ActiveFedora
       after_save :clear_changed_attributes
       def clear_changed_attributes
         @previously_changed = changes
-        @changed_attributes.clear
+        clear_attribute_changes(changes.keys)
       end
     end
 

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -43,7 +43,7 @@ module ActiveFedora
           raise "The first argument to #{self} must be a Hash, String or RDF::URI. You provided a #{identifier.class}"
         end
 
-        @attributes = {}.with_indifferent_access
+        @local_attributes = {}.with_indifferent_access
         @readonly = false
         yield self if block_given?
       end
@@ -86,7 +86,7 @@ module ActiveFedora
       @content = nil
       @metadata = nil
       @ds_content = nil
-      changed_attributes.clear
+      clear_attribute_changes(changes.keys)
     end
 
     def check_fixity
@@ -94,12 +94,12 @@ module ActiveFedora
     end
 
     def datastream_will_change!
-      attribute_will_change! :profile
+      attribute_will_change! :ldp_source
     end
 
     def attribute_will_change!(attr)
       return super unless attr == 'content'
-      changed_attributes['content'] = true
+      attributes_changed_by_setter[:content] = true
     end
 
     def remote_content

--- a/lib/active_fedora/inheritable_accessors.rb
+++ b/lib/active_fedora/inheritable_accessors.rb
@@ -1,5 +1,6 @@
 # Similar to ActiveSupport.class_attribute but with a setter that doesn't use the #{name}= syntax
 # This preserves backward compatibility with the API in ActiveTriples
+require "active_support/core_ext/module/remove_method"
 
 module ActiveFedora
   module InheritableAccessors

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -15,6 +15,7 @@ module ActiveFedora
         @file = file
         super(file.uri, ldp_source.graph)
         return unless self.class.type && !type.include?(self.class.type)
+        attributes_changed_by_setter[:type] = true if type.present?
         # Workaround for https://github.com/ActiveTriples/ActiveTriples/issues/123
         get_values(:type) << self.class.type
       end
@@ -54,7 +55,7 @@ module ActiveFedora
 
       def changed_attributes
         super.tap do |changed|
-          changed['type'] = true if type.present? && new_record?
+          changed.merge('type' => true) if type.present? && new_record?
         end
       end
 

--- a/spec/integration/file_spec.rb
+++ b/spec/integration/file_spec.rb
@@ -74,7 +74,7 @@ describe ActiveFedora::File do
 
     describe "changed attributes are set" do
       it "marks profile as changed" do
-        expect_any_instance_of(SampleResource).to receive(:attribute_will_change!).with(:profile)
+        expect_any_instance_of(SampleResource).to receive(:attribute_will_change!).with(:ldp_source)
         test_object
       end
     end

--- a/spec/support/an_active_model.rb
+++ b/spec/support/an_active_model.rb
@@ -11,6 +11,10 @@ shared_examples_for "An ActiveModel" do
     expect(one).to eq the_other
   end
 
+  def assert_respond_to(obj, meth, _msg = nil)
+    expect(obj).to respond_to meth
+  end
+
   include ActiveModel::Lint::Tests
 
   ActiveModel::Lint::Tests.public_instance_methods.map(&:to_s).grep(/^test/).each do |m|


### PR DESCRIPTION
This PR takes pieces of #1310 and https://github.com/samvera/rubydora/pull/110 and attempts to build on them to do the rest necessary to fix support for Rails 5.2.  I have to admit that I'm not certain these changes are correct but the test suite passes.  These changes are needed to fix the builds of downstream gems (hydra-pcdm, hydra-works, and potentially others) which are currently broken if they don't pin to older versions of rails.

Fixes https://github.com/samvera/hydra-pcdm/issues/248