### PR TITLE
Run and test validation callbacks

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency "yard"
   s.add_development_dependency "rake"
-  s.add_development_dependency "solr_wrapper", "~> 1.0"
+  s.add_development_dependency "solr_wrapper", "~> 2.0"
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"

--- a/lib/active_fedora/validations.rb
+++ b/lib/active_fedora/validations.rb
@@ -92,5 +92,12 @@ module ActiveFedora
       def perform_validations(options = {}) # :nodoc:
         options[:validate] == false || valid?(options[:context])
       end
+
+    private
+
+      # Overwrite run validations to include callbacks.
+      def run_validations!
+        _run_validation_callbacks { super }
+      end
   end
 end

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -8,6 +8,16 @@ describe ActiveFedora::Base do
 
       validates_presence_of :fubar
       validates_length_of :swank, minimum: 5
+
+      before_validation :before_validation_callback
+      after_validation :after_validation_callback
+
+      def before_validation_callback
+        # no-op
+      end
+      def after_validation_callback
+        # no-op
+      end
     end
   end
 
@@ -69,6 +79,14 @@ describe ActiveFedora::Base do
         expect { validation_stub.update!(fubar: ['here'], swank: 'long enough') }.to raise_error ActiveFedora::RecordInvalid
         expect(validation_stub.fubar).to eq ['here']
       end
+    end
+  end
+
+  describe 'validation callbacks' do
+    it 'calls callbacks' do
+      expect(validation_stub).to receive(:before_validation_callback)
+      expect(validation_stub).to receive(:after_validation_callback)
+      validation_stub.validate
     end
   end
 end


### PR DESCRIPTION
As reported various times (https://github.com/samvera/active_fedora/issues/914, https://github.com/samvera/active_fedora/pull/797, https://github.com/avalonmediasystem/avalon/pull/2984), it looks like validation callbacks aren't running.  

This PR adds a test case for before and after validation callbacks and then copies the code used in ActiveModel: https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validations/callbacks.rb#L114-L119