### PR TITLE
Implement enumeration for `Relation#each`

### DIFF
--- a/lib/active_fedora/associations/collection_proxy.rb
+++ b/lib/active_fedora/associations/collection_proxy.rb
@@ -41,6 +41,8 @@ module ActiveFedora
         merge! association.scope(nullify: false)
       end
 
+      delegate :each, to: :to_a
+
       def target
         @association.target
       end

--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -144,6 +144,16 @@ module ActiveFedora
       @scope_for_create ||= where_values_hash.merge(create_with_value)
     end
 
+    def each
+      if loaded?
+        @records.each { |item| yield item } if block_given?
+        @records.to_enum
+      else
+        find_each(where_values) { |item| yield item } if block_given?
+        enum_for(:find_each, where_values)
+      end
+    end
+
     private
 
       VALID_FIND_OPTIONS = [:order, :limit, :start, :conditions, :cast].freeze

--- a/lib/active_fedora/relation/delegation.rb
+++ b/lib/active_fedora/relation/delegation.rb
@@ -13,7 +13,8 @@ module ActiveFedora
       :keep_if, :pop, :shift, :delete_at, :select!
     ].to_set
 
-    delegate :length, :collect, :map, :each, :all?, :include?, :to_ary, to: :to_a
+    delegate :length, :map, :to_ary, to: :to_a
+    delegate :all?, :blank?, :collect, :include?, :present?, to: :each
 
     protected
 

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -41,6 +41,40 @@ describe ActiveFedora::Base do
         expect_any_instance_of(ActiveFedora::Relation).to_not receive :find_each
         libraries[0]
       end
+
+      it "does not reload" do
+        expect_any_instance_of(ActiveFedora::Relation).to_not receive :find_each
+        libraries.each { |l| l.id }
+      end
+    end
+
+    describe '#each' do
+      before { Book.create }
+
+      it 'returns an enumerator' do
+        expect(libraries.each).to be_a Enumerator
+      end
+
+      it 'yields the items' do
+        expect { |b| libraries.each(&b) }
+          .to yield_successive_args(*Library.all.to_a)
+      end
+
+      it 'when called from Base yields all items' do
+        expect { |b| ActiveFedora::Base.all.each(&b) }
+          .to yield_successive_args(*(Library.all.to_a + Book.all.to_a))
+      end
+
+      context 'when cached' do
+        it 'returns an enumerator' do
+          expect(libraries.each).to be_a Enumerator
+        end
+
+        it 'yields the items' do
+          expect { |b| libraries.each(&b) }
+            .to yield_successive_args(*Library.all.to_a)
+        end
+      end
     end
 
     describe "#find" do


### PR DESCRIPTION
`Relation#each` had previously delegated to `Relation#to_a`, which sends
N requests to Fedora (plus one to Solr) and loads all the objects into memory
before beginning work.

This introduces an `Enumerator` based implementation, using `#find_each`. When
`#to_a` has already been called, we take advantage of the existing caching;
otherwise we yield items individually.

We also delegate certain other methods to `#each` instead of `#to_a`,
extending the same benefits to `#collect`, and getting massively
better performance from `#blank?`, `#present?`, `#include?` and `#any?`. There
are probably other optimizations to be explored based on this.

`#map` is kept as is, since delegating it to `#each` breaks ordering code. Since
it would be rasonable to assume that `#map` would have effient access
properties and not cast to an Array, this should be investigated.