### PR TITLE
[backport] Fix `#blank?` and `#present?`

### DIFF
--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -154,6 +154,10 @@ module ActiveFedora
       end
     end
 
+    def empty?
+      !any?
+    end
+
     private
 
       VALID_FIND_OPTIONS = [:order, :limit, :start, :conditions, :cast].freeze

--- a/lib/active_fedora/relation/delegation.rb
+++ b/lib/active_fedora/relation/delegation.rb
@@ -14,7 +14,7 @@ module ActiveFedora
     ].to_set
 
     delegate :length, :map, :to_ary, to: :to_a
-    delegate :all?, :blank?, :collect, :include?, :present?, to: :each
+    delegate :any?, :all?, :collect, :include?, to: :each
 
     protected
 

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -22,6 +22,10 @@ describe ActiveFedora::Base do
   end
 
   it { is_expected.to respond_to(:each_with_index) }
+  it { expect(libraries.any?).to eq false }
+  it { is_expected.to be_blank }
+  it { is_expected.to be_empty }
+  it { is_expected.not_to be_present }
 
   context "when some records exist" do
     before do
@@ -42,6 +46,11 @@ describe ActiveFedora::Base do
         libraries.each(&:id)
       end
     end
+
+    it { expect(libraries.any?).to eq true }
+    it { is_expected.not_to be_blank }
+    it { is_expected.not_to be_empty }
+    it { is_expected.to be_present }
 
     describe '#each' do
       before { Book.create }


### PR DESCRIPTION
Rails' `Object#blank?` and `Object#present?` return `true` for empty
`Enumerable` objects. This is because they don't implement `#empty?`.

Our prior effort to optimize these methods for `Relation` by delegating them to
`#each` broke them for this reason, always returning `true`. Instead, we
delegate `#any?` which does exist, and implement `Relation#empty?` directly as
its inverse. Rails provides the `#blank?` and `#present?` implementations.