### PR TITLE
Limit support to Rails 5.2; add support for `ldp` 1.0

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
   s.add_dependency 'solrizer', '>= 3.4', '< 5'
-  s.add_dependency "activesupport", '>= 4.2.4', '< 6'
-  s.add_dependency "activemodel", '>= 4.2.10', '< 6'
+  s.add_dependency "activesupport", '>= 4.2.4', '< 5.3'
+  s.add_dependency "activemodel", '>= 4.2.10', '< 5.3'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
   s.add_dependency "deprecation"
-  s.add_dependency "ldp", '~> 0.7.0'
+  s.add_dependency "ldp", '>= 0.7.0', '< 2'
   s.add_dependency "ruby-progressbar", '~> 1.0'
   s.add_dependency 'faraday', '~> 0.12'
   s.add_dependency 'faraday-encoding', '0.0.4'


### PR DESCRIPTION
Rails can break on minor changes. Supporting `< 6` is optimistic and leads to
version problems.

`ldp` has recently released 1.0.0; supporting this will help adopters ensure
stability.