### PR TITLE
Pin the version of rails that is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - rvm: 2.3
       env: RAILS_VERSION=4.2.10
+           BUNDLER_VERSION=1.17.3
     - env: RAILS_VERSION=5.0.7
     - env: RAILS_VERSION=5.1.6
     - rvm: 2.5
@@ -14,6 +15,6 @@ global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:
   - gem update --system
-  - gem install bundler
+  - if [ ! -z $BUNDLER_VERSION ]; then gem install bundler -v $BUNDLER_VERSION; else gem install bundler; fi
 before_script:
   - jdk_switcher use oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec path: File.expand_path('..', __FILE__)
 gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 
-gem 'activemodel', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
 group :test do
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec path: File.expand_path('..', __FILE__)
 gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 
-gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+gem 'activemodel', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
 group :test do
   gem 'simplecov', require: false


### PR DESCRIPTION
rather than the version of activemodel.

This prevents the tests from installing rails 0.9.5, and not finding the generator code we depend on.