### PR TITLE
Remove deprecated Solr StandardFilter

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
@@ -172,7 +172,6 @@
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>


### PR DESCRIPTION
I'm re-submitting this PR from @jcoyne 

This filter is deprecated and according to the solr docs it is
inoperative if "luceneMatchVersion (in solrconfig.xml) is higher than
3.1."  The luceneMatchVersion in active_fedora is currently 5.0.0

See https://lucene.apache.org/solr/guide/7_0/filter-descriptions.html#FilterDescriptions-StandardFilter