### PR TITLE
Removes the dependency for solrizer

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.0'
 
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
-  s.add_dependency 'solrizer', '>= 3.4', '< 5'
   s.add_dependency "activesupport", '>= 4.2.4', '< 5.3'
   s.add_dependency "activemodel", '>= 4.2.10', '< 5.3'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -7,7 +7,6 @@ require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/except'
 require 'active_triples'
-require 'solrizer'
 
 # Monkey patching RDF::Literal::DateTime to support fractional seconds.
 # See https://github.com/samvera/active_fedora/issues/497
@@ -31,10 +30,6 @@ module RDF
     end
   end
 end
-
-# This is in place until Solrizer is updated
-class Solrizer::SolrizerError < RuntimeError; end
-class Solrizer::InvalidIndexDescriptor < Solrizer::SolrizerError; end
 
 module ActiveFedora #:nodoc:
   extend ActiveSupport::Autoload

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -21,6 +21,9 @@ module ActiveFedora
       autoload :Suffix
     end
 
+    # Error to be raised for encountering unsupported field types
+    class InvalidIndexDescriptor < RuntimeError; end
+
     included do
       # Because the previous method of setting indexer was to override
       # the class method, we must ensure that we aren't using the instance

--- a/lib/active_fedora/indexing/descriptor.rb
+++ b/lib/active_fedora/indexing/descriptor.rb
@@ -9,7 +9,7 @@ module ActiveFedora
           @type_required = opts[:requires_type]
         end
         @index_type = args
-        raise Solrizer::InvalidIndexDescriptor, "Invalid index type passed to Sorizer.solr_name.  It should be an array like [:string, :indexed, :stored, :multivalued]. You provided: `#{@index_type}'" unless index_type.is_a? Array
+        raise InvalidIndexDescriptor, "Invalid index type passed.  It should be an array like [:string, :indexed, :stored, :multivalued]. You provided: `#{@index_type}'" unless index_type.is_a? Array
       end
 
       def name_and_converter(field_name, args = nil)

--- a/lib/active_fedora/indexing/field_mapper.rb
+++ b/lib/active_fedora/indexing/field_mapper.rb
@@ -89,7 +89,7 @@ module ActiveFedora
               values = (results[name] ||= [])
               values << value unless value.nil? || values.include?(value)
             else
-              Solrizer.logger.warn "Setting #{name} to `#{value}', but it already had `#{results[name]}'" if results[name] && Solrizer.logger
+              Rails.logger.warn "Setting #{name} to `#{value}', but it already had `#{results[name]}'" if results[name]
               results[name] = value
             end
           end
@@ -111,7 +111,7 @@ module ActiveFedora
                        when Descriptor
                          index_type
                        else
-                         raise Solrizer::InvalidIndexDescriptor, "#{index_type.class} is not a valid indexer_type. Use a String, Symbol or Descriptor."
+                         raise InvalidIndexDescriptor, "#{index_type.class} is not a valid indexer_type. Use a String, Symbol or Descriptor."
                        end
 
           raise InvalidIndexDescriptor, "index type should be an Descriptor, you passed: #{index_type.class}" unless index_type.is_a? Descriptor

--- a/lib/active_fedora/indexing/suffix.rb
+++ b/lib/active_fedora/indexing/suffix.rb
@@ -28,7 +28,7 @@ module ActiveFedora
       end
 
       def to_s
-        raise Solrizer::InvalidIndexDescriptor, "Missing datatype for #{@fields}" unless data_type
+        raise InvalidIndexDescriptor, "Missing datatype for #{@fields}" unless data_type
 
         field_suffix = [config.suffix_delimiter]
 
@@ -69,7 +69,7 @@ module ActiveFedora
                                                    when :float, :big_decimal
                                                      'f'
                                                    else
-                                                     raise Solrizer::InvalidIndexDescriptor, "Invalid datatype `#{type.inspect}'. Must be one of: :date, :time, :text, :text_en, :string, :symbol, :integer, :boolean"
+                                                     raise InvalidIndexDescriptor, "Invalid datatype `#{type.inspect}'. Must be one of: :date, :time, :text, :text_en, :string, :symbol, :integer, :boolean"
                                                    end
                                                  end),
                                    stored_suffix: 's',


### PR DESCRIPTION
The community decided to proceed with deprecating the Solrizer Gem on April 26th, 2018 (please see https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/samvera-tech/gjN6DjjnaEA/oGWoVtHFAAAJ)