### PR TITLE
core reload rescue edge case

### DIFF
--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -62,6 +62,9 @@ module ActiveFedora
       refresh
       load_attached_files
       self
+    rescue Ldp::Gone => err
+      logger.error("Tried to reload an object that has been destroyed.\n\t#{err.message}")
+      raise ActiveFedora::ObjectNotFoundError
     end
 
     # Initialize an empty model object and set its +resource+

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -18,6 +18,15 @@ describe ActiveFedora::Base do
         object.reload
         expect(object.person).to eq ['dave']
       end
+
+      context "when object is destroyed but flag is not set on copy" do
+        before { object2.destroy! }
+
+        it 'causes the correct error' do
+          expect(object.destroyed?).to be(nil)
+          expect { object.reload }.to raise_error(ActiveFedora::ObjectNotFoundError)
+        end
+      end
     end
 
     context "when not persisted" do


### PR DESCRIPTION
Fixes #1388 
This adds a rescue block to the reload method in core; it handles the case where two copies of an object are live, one is destroyed, but reload is called the other which will not have the destroyed flag set, resulting in uncaught Ldp::Gone, rather than the expected ActiveFedora::ObjectNotFoundError.
This scenario can occur in Hyrax when the wings module is in use; a monkey patch by @no-reply to temporarily handle this in Hyrax is in progress.