### PR TITLE
Force overwrite of `solr/conf` files if they have changes

### DIFF
--- a/lib/generators/active_fedora/config/solr/solr_generator.rb
+++ b/lib/generators/active_fedora/config/solr/solr_generator.rb
@@ -7,7 +7,7 @@ module ActiveFedora
     def generate
       # Overwrite the configuration files that Blacklight has installed
       copy_file 'solr.yml', 'config/solr.yml', force: true
-      directory 'solr', 'solr'
+      directory 'solr', 'solr', force: true
     end
 
     def solr_wrapper_config


### PR DESCRIPTION
Blacklight generates Solr configuration into `solr/conf`. Since ActiveFedora now
generates its configurations into the same directory, any differing files will
be treated as conflicts by `Rails::Generators::Base`. Adding `force: true` to
the step that copies these files ensures that the AF versions of these files are
installed without requiring confusing user feedback at generation time.