### PR TITLE
Fixing the 10.3.x Solr schema to work with Solr 7.x releases

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
@@ -337,9 +337,6 @@
  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
  <!--  <defaultSearchField>text</defaultSearchField> -->
 
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
Otherwise one will encounter errors when attempting to create cores for Solr 7.x installations using the CircleCI test commands such as `install_solr_core` (https://github.com/samvera-labs/samvera-circleci-orb/blob/master/src/commands/install_solr_core.yml).  Please see https://github.com/samvera/hydra-head/pull/488#issuecomment-522774361 for further context.

I would propose that we please follow this by either a 10.3.1 or 10.4.0 release.