### PR TITLE
Avoid private `ActiveModel::Dirty#attributes_changed_by_setter`

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -97,11 +97,6 @@ module ActiveFedora
       attribute_will_change! :ldp_source
     end
 
-    def attribute_will_change!(attr)
-      return super unless attr == 'content'
-      attributes_changed_by_setter[:content] = true
-    end
-
     def remote_content
       return if new_record?
       @ds_content ||= retrieve_content

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -15,7 +15,7 @@ module ActiveFedora
         @file = file
         super(file.uri, ldp_source.graph)
         return unless self.class.type && !type.include?(self.class.type)
-        attributes_changed_by_setter[:type] = true if type.present?
+        attribute_will_change!(:type) if type.present?
         # Workaround for https://github.com/ActiveTriples/ActiveTriples/issues/123
         get_values(:type) << self.class.type
       end

--- a/spec/unit/with_metadata/metadata_node_spec.rb
+++ b/spec/unit/with_metadata/metadata_node_spec.rb
@@ -19,7 +19,7 @@ describe ActiveFedora::WithMetadata::MetadataNode do
         generated_schema.configure type: book
       end
 
-      it { is_expected.to eq('type' => true) }
+      it { is_expected.to match('type' => be_truthy) }
     end
   end
 


### PR DESCRIPTION
This method is removed in ActiveModel 6.0, and is private anyway. Avoid calling
it for upgradability.