### PR TITLE
Readd support for Ruby 2.4.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,7 @@ workflows:
           name: ruby2-5_rails6.0
           ruby_version: 2.5.5
           rails_version: 6.0.0
+      - bundle_lint_test:
+          name: ruby2-4_rails5-2
+          ruby_version: 2.4.7
+          rails_version: 5.2.3

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A convenience libary for manipulating documents in the Fedora Repository.}
   s.description = %q{ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.}
   s.license = "Apache-2.0"
-  s.required_ruby_version = '~> 2.5'
+  s.required_ruby_version = '~> 2.4'
 
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
   s.add_dependency "activesupport", '>= 5.2'


### PR DESCRIPTION
The CCWG says we have to support Ruby 2.4, so we're readding, but without the
tests for Rails 6.0 (which won't bundle).