### PR TITLE
Deprecate `#clear_changed_attributes`

### DIFF
--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -15,6 +15,8 @@ module ActiveFedora
       # Overriding so that we don't track previously_changed, which was
       # rather expensive.
       def clear_changed_attributes
+        Deprecation.warn self.class, "#clear_changed_attributes is deprecated, use ActiveModel::Dirty#changes_applied instead."
+
         clear_changes_information
       end
 

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -9,10 +9,23 @@ module ActiveFedora
       include Serializers
       include PrimaryKey
 
-      after_save :clear_changed_attributes
+      after_save :clear_changed_attributes_or_changes_applied
       def clear_changed_attributes
+        Deprecation.warn ActiveFedora::Attributes, "#clear_changed_attributes is deprecated, use ActiveModel::Dirty#changes_applied instead."
         @previously_changed = changes
         clear_attribute_changes(changes.keys)
+      end
+
+      ##
+      # Call the deprecated method
+      def clear_changed_attributes_or_changes_applied
+        return changes_applied if
+          method(:clear_changed_attributes).super_method.nil? ||
+          method(:clear_changed_attributes).owner == ActiveFedora::Aggregation::ListSource
+
+        Deprecation.warn self.class, "after_save callbacks to #clear_changed_attributes are deprecated." /
+                                     "These calls will be removed in 14.0.0."
+        clear_changed_attributes
       end
     end
 


### PR DESCRIPTION
This method can be replaced by `ActiveModel::Dirty#changes_applied`, which is
more resiliant to changing `ActiveModel` and `Rails` behavior.

However, since we call it in a callback, and downstream users may be relying on
that fact to trigger calls to their overrides, we can't avoid calling it
locally until a 14.0.0 release.