### PR TITLE
Deprecate `#clear_changed_attributes`

### DIFF
--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -12,6 +12,14 @@ module ActiveFedora
         super
       end
 
+      ##
+      # @deprecated use #changes_applied instead
+      def clear_changed_attributes
+        Deprecation.warn self.class, "#clear_changed_attributes is deprecated, use ActiveModel::Dirty#changes_applied instead."
+
+        clear_changes_information
+      end
+
       def changed?
         super || ordered_self.changed?
       end


### PR DESCRIPTION
This method can be replaced by `ActiveModel::Dirty#changes_applied`, which is
more resiliant to changing `ActiveModel` and `Rails` behavior.

However, since we call it in a callback, and downstream users may be relying on
that fact to trigger calls to their overrides, we continue calling it in the
case that it is both: not the base definition, and not the version overridden in
`ListSource`.

Callers to those two versions will see deprecation warnings, and users of the
callback will also see deprecation warnings. Their local behavior may be in
conflict with Rails 6.0.