### PR TITLE
Upgrades the dependency for faraday-encoding in order to ensure that FrozenError is not raised for HTTP request body content; Releases 13.1.1

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ldp", '>= 0.7.0', '< 2'
   s.add_dependency "ruby-progressbar", '~> 1.0'
   s.add_dependency 'faraday', '~> 0.12'
-  s.add_dependency 'faraday-encoding', '0.0.4'
+  s.add_dependency 'faraday-encoding', '>= 0.0.5'
 
   s.add_development_dependency "rails"
   s.add_development_dependency "rdoc"

--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,3 +1,3 @@
 module ActiveFedora
-  VERSION = '13.1.0'.freeze
+  VERSION = '13.1.1'.freeze
 end


### PR DESCRIPTION
This currently blocks https://github.com/samvera/hydra-editor/pull/180 due to https://github.com/ma2gedev/faraday-encoding/commit/dc749230d4dd71dedc4b2703a7bb62ac1ea8f7c9 being introduced in `faraday-encoding` release 0.0.5.