### PR TITLE
Always rewind IO content even when the file is new.

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -191,9 +191,7 @@ module ActiveFedora
       end
 
       def local_or_remote_content(ensure_fetch = true)
-        return @content if new_record?
-
-        @content ||= ensure_fetch ? remote_content : @ds_content
+        @content ||= ensure_fetch ? remote_content : @ds_content unless new_record?
         @content.rewind if behaves_like_io?(@content)
         @content
       end

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -192,6 +192,23 @@ describe ActiveFedora::File do
     end
   end
 
+  context 'when file is new and content behaves like io' do
+    let(:file_content) { "hello world" }
+
+    before do
+      af_file.uri = "http://localhost:8983/fedora/rest/test/1234/abcd"
+      af_file.content = StringIO.new(file_content)
+      allow(af_file).to receive(:new_record?).and_return(true)
+    end
+
+    describe "#content" do
+      it 'can be re-read' do
+        expect(af_file.content.read).to eq file_content
+        expect(af_file.content.read).to eq file_content
+      end
+    end
+  end
+
   describe "#mime_type" do
     let(:parent) { ActiveFedora::Base.create }
     before do


### PR DESCRIPTION
This bug was causing https://github.com/samvera/hyrax/issues/4018 but could also be the source of many more issues.

In the issue above this manifested with the extracted text file being read by indexing prior to the actual persisting to fedora at which point it was already consumed and an empty file was sent to fedora.

BE KIND, REWIND!