### PR TITLE
Removing spec files from gem distribution

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -39,8 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-rspec", '~> 1.12.0'
 
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {spec}/*`.split("\n")
+  s.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec\/?} }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.extra_rdoc_files = [
     "LICENSE",


### PR DESCRIPTION
Removing the test_files from the gemspec ensures that consumers of the Gem are not required to download any fixture files with the Gem (please see https://github.com/samvera/hyrax/pull/4245 for the origin discussion).