### PR TITLE
Updating the EBUCore term for `RDF::Vocab::EBUCore.filename`

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -14,30 +14,29 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
   s.required_ruby_version = '~> 2.4'
 
-  s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
-  s.add_dependency "activesupport", '>= 5.2'
   s.add_dependency "activemodel", '>= 5.2'
+  s.add_dependency "activesupport", '>= 5.2'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
   s.add_dependency "deprecation"
-  s.add_dependency "ldp", '>= 0.7.0', '< 2'
-  s.add_dependency "ruby-progressbar", '~> 1.0'
   s.add_dependency 'faraday', '~> 0.12'
   s.add_dependency 'faraday-encoding', '>= 0.0.5'
+  s.add_dependency "ldp", '>= 0.7.0', '< 2'
+  s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
+  s.add_dependency "ruby-progressbar", '~> 1.0'
 
-  s.add_development_dependency "github_changelog_generator"
-  s.add_development_dependency "rails"
-  s.add_development_dependency "rdoc"
-  s.add_development_dependency "yard"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "solr_wrapper", "~> 2.0"
+  s.add_development_dependency "equivalent-xml"
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
+  s.add_development_dependency "github_changelog_generator"
+  s.add_development_dependency "rdoc"
+  s.add_development_dependency "rails"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"
-  s.add_development_dependency "equivalent-xml"
-  s.add_development_dependency "simplecov", '~> 0.8'
   s.add_development_dependency "rubocop", '~> 0.56.0'
   s.add_development_dependency "rubocop-rspec", '~> 1.12.0'
-
+  s.add_development_dependency "simplecov", '~> 0.8'
+  s.add_development_dependency "solr_wrapper", "~> 2.0"
+  s.add_development_dependency "yard"
 
   s.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec\/?} }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
   s.required_ruby_version = '~> 2.4'
 
-  s.add_dependency "activemodel", '>= 5.2'
-  s.add_dependency "activesupport", '>= 5.2'
+  s.add_dependency "activemodel", '>= 5.1'
+  s.add_dependency "activesupport", '>= 5.1'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
   s.add_dependency "deprecation"
   s.add_dependency 'faraday', '~> 0.12'

--- a/lib/active_fedora/with_metadata/default_schema.rb
+++ b/lib/active_fedora/with_metadata/default_schema.rb
@@ -4,7 +4,7 @@
 module ActiveFedora::WithMetadata
   class DefaultSchema < ActiveTriples::Schema
     property :label, predicate: ::RDF::RDFS.label
-    property :file_name, predicate: ::RDF::Vocab::EBUCore.filename
+    property :file_name, predicate: ::RDF::Vocab::EBUCore.resourceFilename
     property :file_size, predicate: ::RDF::Vocab::EBUCore.fileSize
     property :date_created, predicate: ::RDF::Vocab::EBUCore.dateCreated
     property :date_modified, predicate: ::RDF::Vocab::EBUCore.dateModified


### PR DESCRIPTION
This is necessary given that this term was removed: https://github.com/ruby-rdf/rdf-vocab/blob/develop/lib/rdf/vocab/ebucore.rb#L7117. Please see https://github.com/samvera/hydra-derivatives/pull/221 for context.