### PR TITLE
Pinning rdf-vocab to versions previous to 3.1.5

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 0.12'
   s.add_dependency 'faraday-encoding', '>= 0.0.5'
   s.add_dependency "ldp", '>= 0.7.0', '< 2'
+  s.add_dependency 'rdf-vocab', '< 3.1.5'
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
   s.add_dependency "ruby-progressbar", '~> 1.0'
 

--- a/lib/active_fedora/with_metadata/default_schema.rb
+++ b/lib/active_fedora/with_metadata/default_schema.rb
@@ -4,7 +4,7 @@
 module ActiveFedora::WithMetadata
   class DefaultSchema < ActiveTriples::Schema
     property :label, predicate: ::RDF::RDFS.label
-    property :file_name, predicate: ::RDF::Vocab::EBUCore.resourceFilename
+    property :file_name, predicate: ::RDF::Vocab::EBUCore.filename
     property :file_size, predicate: ::RDF::Vocab::EBUCore.fileSize
     property :date_created, predicate: ::RDF::Vocab::EBUCore.dateCreated
     property :date_modified, predicate: ::RDF::Vocab::EBUCore.dateModified


### PR DESCRIPTION
Introduces the solution proposed in https://github.com/samvera/active_fedora/pull/1421#issuecomment-642817917