### PR TITLE
pin `rdf-vocab` to versions prior to 3.1.5

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '>= 0.7.0', '< 2'
+  s.add_dependency 'rdf-vocab', '< 3.1.5'
   s.add_dependency "ruby-progressbar", '~> 1.0'
   s.add_dependency 'faraday', '~> 0.12'
   s.add_dependency 'faraday-encoding', '0.0.4'


### PR DESCRIPTION
avoids changes to the EBUCore vocabulary that would force data migrations for
downstream users.