### PR TITLE
improve configurability of Fedora for downstream apps

### DIFF
--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,14 +1,14 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
-  base_path: /dev
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || ENV['FCREPO_PORT'] || 8984 %>/rest
+  base_path: <%= ENV['FCREPO_BASE_PATH'] || '/dev' %>
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
-  base_path: /test
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_TEST_PORT'] || ENV['FCREPO_PORT'] || 8986 %>/rest
+  base_path: <%= ENV['FCREPO_BASE_PATH'] || '/test' %>
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_PORT'] || 8983 %>/rest

--- a/lib/generators/active_fedora/config/fedora/templates/fedora.yml
+++ b/lib/generators/active_fedora/config/fedora/templates/fedora.yml
@@ -1,15 +1,15 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
-  base_path: /dev
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || ENV['FCREPO_PORT'] || 8984 %>/rest
+  base_path: <%= ENV['FCREPO_BASE_PATH'] || '/dev' %>
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
-  base_path: /test
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_TEST_PORT'] || ENV['FCREPO_PORT'] || 8986 %>/rest
+  base_path: <%= ENV['FCREPO_BASE_PATH'] || '/test' %>
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
-  base_path: /prod
+  url: http://<%= ENV['FCREPO_HOST'] || 'localhost' %>:<%= ENV['FCREPO_PORT'] || 8983 %>/rest
+  base_path: <%= ENV['FCREPO_BASE_PATH'] || '/prod' %>


### PR DESCRIPTION
in general, we'd like to support 12-factor style configuration:
https://12factor.net/config

the older, rails-influenced approach makes it challenging to handle different
configurations across many environments for one app. by using generic ENV
variables, but supporting more specific ones, and falling back on  hard coded
values we can have it both ways.

this implementation should continue to support older configurations in exactly
the same way, but also allow users to adopt one variable name across
environments.