### PR TITLE
Allow initializing OrderedList with an existing NodeCache

### DIFF
--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -12,7 +12,7 @@ module ActiveFedora
       #   stored.
       # @param [::RDF::URI] head_subject URI of head node in list.
       # @param [::RDF::URI] tail_subject URI of tail node in list.
-      def initialize(graph, head_subject, tail_subject, node_cache = NodeCache.new)
+      def initialize(graph, head_subject, tail_subject, node_cache: NodeCache.new)
         @graph = if graph.respond_to?(:graph)
                    graph.graph.data
                  else

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -12,7 +12,7 @@ module ActiveFedora
       #   stored.
       # @param [::RDF::URI] head_subject URI of head node in list.
       # @param [::RDF::URI] tail_subject URI of tail node in list.
-      def initialize(graph, head_subject, tail_subject)
+      def initialize(graph, head_subject, tail_subject, node_cache = NodeCache.new)
         @graph = if graph.respond_to?(:graph)
                    graph.graph.data
                  else
@@ -20,7 +20,7 @@ module ActiveFedora
                  end
         @head_subject = head_subject
         @tail_subject = tail_subject
-        @node_cache ||= NodeCache.new
+        @node_cache = node_cache
         @changed = false
         tail
       end


### PR DESCRIPTION
The initialization line:
```ruby
        @node_cache ||= NodeCache.new
```
suggests that the node cache might have been supplied through other means, but there's currently not possible; the proposed change allows for it.

This is a change we made within a project to fix a production bug in the component that built an arbitrarily large and deep set of nested OrderedList objects, before saving it -- without the ability to pass along an existing, paritlally-populated, node cache, we were getting collisions on ids once the whole set was persisted.