### PR TITLE
re-add optimization from ldp 1.0.2

### DIFF
--- a/lib/active_fedora/ldp_resource.rb
+++ b/lib/active_fedora/ldp_resource.rb
@@ -20,5 +20,11 @@ module ActiveFedora
     def marshal_load(data)
       data.each { |name, val| instance_variable_set(name, val) }
     end
+
+    private
+
+    def response_as_graph(resp)
+      graph_class.new(subject_uri, data: resp.graph.data)
+    end
   end
 end


### PR DESCRIPTION
LDP tried to add an optimization reusing the underlying data structure from the
response's already existing parsed graph. our implementation in prior releases
blocked that. but since we're overriding anyway, no harm in adding it back.