### PR TITLE
replaced deprecated URI.escape with updated format

### DIFF
--- a/lib/active_fedora/core/fedora_id_translator.rb
+++ b/lib/active_fedora/core/fedora_id_translator.rb
@@ -2,7 +2,7 @@ module ActiveFedora::Core
   class FedoraIdTranslator
     SLASH = '/'.freeze
     def self.call(id)
-      id = URI.escape(id, '[]'.freeze)
+      id = URI::DEFAULT_PARSER.escape(id, '[]'.freeze)
       id = "/#{id}" unless id.start_with? SLASH
       unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
         id = ActiveFedora.fedora.base_path + id


### PR DESCRIPTION
Ticket - https://github.com/samvera/active_fedora/issues/1454

/usr/local/bundle/gems/active-fedora-13.2.4/lib/active_fedora/core/fedora_id_translator.rb:5: warning: URI.escape is obsolete

Updated code to new format for URI escape