### PR TITLE
don't try to delegate ""system_create_dtsi" to `#indexer`

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -9,7 +9,8 @@ module ActiveFedora
     end
 
     def default_sort_params
-      [indexer.create_time_solr_name + ' asc']
+      [ActiveFedora.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date) +
+       ' asc']
     end
   end
 end


### PR DESCRIPTION
not all models have an indexer (e.g. `ActiveFedora::File` inheritors do
not). trying to query them with `MyModel.all` shouldn't raise a `NameError`.