### PR TITLE
Replace deprecated URI.encode with updated call

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency "github_changelog_generator"
   s.add_development_dependency "rdoc"
+  s.add_development_dependency "psych", "< 4" # Restricted because 4.0+ do not work with rubocop 0.56.x
   s.add_development_dependency "rails"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.5"

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -174,7 +174,7 @@ module ActiveFedora
 
       def ldp_headers
         headers = { 'Content-Type'.freeze => mime_type, 'Content-Length'.freeze => content.size.to_s }
-        headers['Content-Disposition'.freeze] = "attachment; filename=\"#{URI.encode(@original_name)}\"" if @original_name
+        headers['Content-Disposition'.freeze] = "attachment; filename=\"#{URI::DEFAULT_PARSER.escape(@original_name)}\"" if @original_name
         headers
       end
 


### PR DESCRIPTION
Replaces the other instance of deprecated URI encoding following the same pattern as in #1456