### PR TITLE
Don't track changes or attempt to persist server-managed properties on file metadata nodes

### DIFF
--- a/lib/active_fedora/with_metadata/default_schema.rb
+++ b/lib/active_fedora/with_metadata/default_schema.rb
@@ -21,6 +21,6 @@ module ActiveFedora::WithMetadata
     property :date_modified, predicate: ::RDF::Vocab::EBUCore.dateModified
     property :byte_order, predicate: SweetJPLTerms.byteOrder
     # This is a server-managed predicate which means Fedora does not let us change it.
-    property :file_hash, predicate: ::RDF::Vocab::PREMIS.hasMessageDigest
+    property :file_hash, predicate: ::RDF::Vocab::PREMIS.hasMessageDigest, server_managed: true
   end
 end

--- a/lib/active_fedora/with_metadata/default_strategy.rb
+++ b/lib/active_fedora/with_metadata/default_strategy.rb
@@ -1,6 +1,6 @@
 module ActiveFedora::WithMetadata
   class DefaultStrategy < ActiveTriples::ExtensionStrategy
-    # override apply method to check if property already exists or reciever already has predicate defined.
+    # override apply method to check if property already exists or receiver already has predicate defined.
     # Do not add property if the rdf_resource already responds to the property name
     # Do not add property if the rdf_resource already has a property with the same predicate.
     def self.apply(resource, property)

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -33,7 +33,7 @@ module ActiveFedora
 
       def set_value(*args)
         super
-        attribute_will_change! args.first
+        attribute_will_change! args.first unless server_managed_properties.include?(args.first)
       end
 
       def ldp_source
@@ -68,6 +68,10 @@ module ActiveFedora
 
         def changes_for_update
           ChangeSet.new(self, self, changed_attributes.keys).changes
+        end
+
+        def server_managed_properties
+          @server_managed_properties ||= properties.select { |k,v| v[:server_managed] }.symbolize_keys.keys
         end
 
         class << self

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -71,7 +71,7 @@ module ActiveFedora
         end
 
         def server_managed_properties
-          @server_managed_properties ||= properties.select { |k,v| v[:server_managed] }.symbolize_keys.keys
+          @server_managed_properties ||= properties.select { |k,v| v[:server_managed] }.keys.map(&:to_sym)
         end
 
         class << self


### PR DESCRIPTION
Upstream port of monkey-patch in Hyrax required for wings (https://github.com/samvera/hyrax/pull/5320)

This PR introduces an attribute on properties in the metadata schemas called `:server_managed`.  When this attribute is set to true on a property it allows a value to be set via the generated setter but the change isn't tracked by `ActiveModel::Dirty` and subsequently isn't sent to the server as part of the changed values when saving.