### PR TITLE
Prepare release 13.2.5

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '13.2.4'
+  VERSION = '13.2.5'
 end


### PR DESCRIPTION
This release would include the changes to handle URI encoding deprecation warnings in ruby 2.7 and the handling server managed properties in file metadata nodes.