### PR TITLE
Conditionally apply monkey patch to handle versions of RDF 3.2.5+

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -11,21 +11,26 @@ require 'active_triples'
 # Monkey patching RDF::Literal::DateTime to support fractional seconds.
 # See https://github.com/samvera/active_fedora/issues/497
 # Also monkey patches in a fix for timezones to be stored properly.
-module RDF
-  class Literal
-    class DateTime < Literal
-      ALTERNATIVE_FORMAT   = '%Y-%m-%dT%H:%M:%S'.freeze
-      DOT                  = '.'.freeze
-      EMPTY                = ''.freeze
-      TIMEZONE_FORMAT      = '%:z'.freeze
+#
+# RDF 3.2.5 changes the superclass of DateTime to RDF::Temporal
+# TODO: Determine if this monkey-patch is needed even with RDF pre-3.2.5 (All the tests pass without it)
+if RDF::Literal::DateTime.superclass == RDF::Literal
+  module RDF
+    class Literal
+      class DateTime < Literal
+	ALTERNATIVE_FORMAT   = '%Y-%m-%dT%H:%M:%S'.freeze
+	DOT                  = '.'.freeze
+	EMPTY                = ''.freeze
+	TIMEZONE_FORMAT      = '%:z'.freeze
 
-      def to_s
-        @string ||= begin
-          # Show nanoseconds but remove trailing zeros
-          nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
-          nano = DOT + nano unless nano.blank?
-          @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
-        end
+	def to_s
+	  @string ||= begin
+	    # Show nanoseconds but remove trailing zeros
+	    nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
+	    nano = DOT + nano unless nano.blank?
+	    @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
+	  end
+	end
       end
     end
   end


### PR DESCRIPTION
Resolves #1466 

RDF 3.2.5 changed the superclass of DateTime which broke the monkey patch in ActiveFedora.  This PR conditionally applies the monkey patch if the class exists.  

It appears that the monkey patch might not be necessary with RDF 3.2.5 due to the changes to the class in RDF (see https://github.com/ruby-rdf/rdf/releases/tag/3.2.5) so I didn't attempt to create a new version of the monkey patch.  But I removed the monkey patch and all the tests passed locally with RDF 3.2.4 so maybe the changes aren't actually being tested properly or aren't necessary anymore due to improvements in Fedora 4 or ActiveFedora since the monkey patch was applied in 2014? :man_shrugging: 

Within the CI environment the monkey patch should still be getting applied for the ruby 2.5 build because RDF 3.2.5 requires 2.6+.