### PR TITLE
Prepare for release 13.2.6

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '13.2.5'
+  VERSION = '13.2.6'
 end


### PR DESCRIPTION
This release would only include the fix for working with rdf  version 3.2.5+ (https://github.com/samvera/active_fedora/pull/1468)