### PR TITLE
Remove the explicit superclass from monkey-patch

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -11,26 +11,23 @@ require 'active_triples'
 # Monkey patching RDF::Literal::DateTime to support fractional seconds.
 # See https://github.com/samvera/active_fedora/issues/497
 # Also monkey patches in a fix for timezones to be stored properly.
-#
-# RDF 3.2.5 changes the superclass of DateTime to RDF::Temporal
-# TODO: Determine if this monkey-patch is needed even with RDF pre-3.2.5 (All the tests pass without it)
-if RDF::Literal::DateTime.superclass == RDF::Literal
-  module RDF
-    class Literal
-      class DateTime < Literal
-	ALTERNATIVE_FORMAT   = '%Y-%m-%dT%H:%M:%S'.freeze
-	DOT                  = '.'.freeze
-	EMPTY                = ''.freeze
-	TIMEZONE_FORMAT      = '%:z'.freeze
+# This is needed in both RDF <= 3.2.4 and RDF >= 3.2.5
+# TODO: Figure out how to contribute something upstream to avoid monkey-patching
+module RDF
+  class Literal
+    class DateTime
+      ALTERNATIVE_FORMAT   = '%Y-%m-%dT%H:%M:%S'.freeze
+      DOT                  = '.'.freeze
+      EMPTY                = ''.freeze
+      TIMEZONE_FORMAT      = '%:z'.freeze
 
-	def to_s
-	  @string ||= begin
-	    # Show nanoseconds but remove trailing zeros
-	    nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
-	    nano = DOT + nano unless nano.blank?
-	    @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
-	  end
-	end
+      def to_s
+        @string ||= begin
+          # Show nanoseconds but remove trailing zeros
+          nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
+          nano = DOT + nano unless nano.blank?
+          @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1466 an d #1471 

This allows the monkey-patch to work with either rdf <= 3.2.4 or rdf >= 3.2.5
The monkey-patch is necessary to maintain the current behavior of nanosecond precision in dates
Failing tests in hyrax revealed this so tests were added here to test this functionality

Note that rdf 3.2.0+ require ruby >= 2.6 so the ruby 2.5 circleci builds should be testing with rdf < 3.2.5 while the ruby 2.6 and 2.7 builds should be testing with rdf = 3.2.5.