### PR TITLE
Prep for release 13.2.7

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '13.2.6'
+  VERSION = '13.2.7'
 end


### PR DESCRIPTION
ActiveFedora 13.2.6 was yanked due to the change to the rdf monkey-patch losing sub second precision past milliseconds. This patch release would only include #1472, a better fix for this issue.