### PR TITLE
Prepare for release

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,3 +1,3 @@
 module ActiveFedora
-  VERSION = '12.2.3'.freeze
+  VERSION = '12.2.4'.freeze
 end


### PR DESCRIPTION
Backports:
- #1456 - Ruby 2.7 deprecation warnings
- #1463 - Ruby 2.7 deprecation warnings
- #1472 - Compatibility with newer rdf 3.2.5