### PR TITLE
Fix obsolete URI.encode call

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", '>= 4.2.4', '< 5.3'
   s.add_dependency "activemodel", '>= 4.2.10', '< 5.3'
   s.add_dependency "active-triples", '>= 0.11.0', '< 2.0.0'
+  s.add_dependency "addressable"
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '>= 0.7.0', '< 2'
   s.add_dependency 'rdf-vocab', '< 3.1.5'

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -7,6 +7,7 @@ require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/except'
 require 'active_triples'
+require 'addressable/uri'
 
 # Monkey patching RDF::Literal::DateTime to support fractional seconds.
 # See https://github.com/samvera/active_fedora/issues/497

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -179,7 +179,7 @@ module ActiveFedora
 
       def ldp_headers
         headers = { 'Content-Type'.freeze => mime_type, 'Content-Length'.freeze => content.size.to_s }
-        headers['Content-Disposition'.freeze] = "attachment; filename=\"#{URI::DEFAULT_PARSER.escape(@original_name)}\"" if @original_name
+        headers['Content-Disposition'.freeze] = "attachment; filename=\"#{Addressable::URI.escape(@original_name)}\"" if @original_name
         headers
       end
 


### PR DESCRIPTION
Derived from rebasing https://github.com/samvera/active_fedora/pull/1461