### PR TITLE
Prepare for release 13.3.0

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '13.2.7'
+  VERSION = '13.3.0'
 end


### PR DESCRIPTION
Includes:

- #1483 (Rails 6.1 Support)
- #1480 (README Badges)
- #1462 (Handle RSolr Deprecation of read_timeout)
- #1460 (Don't delegate system_dtsi to #indexer)
- #1453 (Update README/CONTRIBUTING)