### PR TITLE
Ruby3 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,15 +111,6 @@ workflows:
           name: ruby2-6_rails5-2
           ruby_version: 2.6.9
           rails_version: 5.2.8.1
-      # Ruby 2.5 releases
-      - bundle_lint_test:
-          name: ruby2-5_rails6.0
-          ruby_version: 2.5.9
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby2-5_rails5-2
-          ruby_version: 2.5.9
-          rails_version: 5.2.8.1
 
   nightly:
     triggers:
@@ -193,13 +184,4 @@ workflows:
       - bundle_lint_test:
           name: ruby2-6_rails5-2
           ruby_version: 2.6.9
-          rails_version: 5.2.8.1
-      # Ruby 2.5 releases
-      - bundle_lint_test:
-          name: ruby2-5_rails6.0
-          ruby_version: 2.5.9
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby2-5_rails5-2
-          ruby_version: 2.5.9
           rails_version: 5.2.8.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,45 +47,79 @@ jobs:
 workflows:
   ci:
     jobs:
+      # Ruby 3.1 releases
+      - bundle_lint_test:
+          name: ruby3-1_rails7-0
+          ruby_version: 3.1.3
+          rails_version: 7.0.4
+      - bundle_lint_test:
+          name: ruby3-1_rails6-1
+          ruby_version: 3.1.3
+          rails_version: 6.1.7
+      - bundle_lint_test:
+          name: ruby3-1_rails6-0
+          ruby_version: 3.1.3
+          rails_version: 6.0.6
+      - bundle_lint_test:
+          name: ruby3-1_rails5-2
+          ruby_version: 3.1.3
+          rails_version: 5.2.8.1
+      # Ruby 3.0 releases
+      - bundle_lint_test:
+          name: ruby3-0_rails7-0
+          ruby_version: 3.0.5
+          rails_version: 7.0.4
+      - bundle_lint_test:
+          name: ruby3-0_rails6-1
+          ruby_version: 3.0.5
+          rails_version: 6.1.7
+      - bundle_lint_test:
+          name: ruby3-0_rails6-0
+          ruby_version: 3.0.5
+          rails_version: 6.0.6
+      - bundle_lint_test:
+          name: ruby3-0_rails5-2
+          ruby_version: 3.0.5
+          rails_version: 5.2.8.1
       # Ruby 2.7 releases
       - bundle_lint_test:
           name: ruby2-7_rails7-0
           ruby_version: 2.7.5
-          rails_version: 7.0.3.1
+          rails_version: 7.0.4
       - bundle_lint_test:
           name: ruby2-7_rails6-1
           ruby_version: 2.7.5
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7
       - bundle_lint_test:
           name: ruby2-7_rails6-0
           ruby_version: 2.7.5
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1
       # Ruby 2.6 releases
       - bundle_lint_test:
           name: ruby2-6_rails6-1
           ruby_version: 2.6.9
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7
       - bundle_lint_test:
           name: ruby2-6_rails6-0
           ruby_version: 2.6.9
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-6_rails5-2
           ruby_version: 2.6.9
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1
       # Ruby 2.5 releases
       - bundle_lint_test:
           name: ruby2-5_rails6.0
           ruby_version: 2.5.9
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-5_rails5-2
           ruby_version: 2.5.9
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1
 
   nightly:
     triggers:
@@ -96,42 +130,76 @@ workflows:
               only:
                 - main
     jobs:
+      # Ruby 3.1 releases
+      - bundle_lint_test:
+          name: ruby3-1_rails7-0
+          ruby_version: 3.1.3
+          rails_version: 7.0.4
+      - bundle_lint_test:
+          name: ruby3-1_rails6-1
+          ruby_version: 3.1.3
+          rails_version: 6.1.7
+      - bundle_lint_test:
+          name: ruby3-1_rails6-0
+          ruby_version: 3.1.3
+          rails_version: 6.0.6
+      - bundle_lint_test:
+          name: ruby3-1_rails5-2
+          ruby_version: 3.1.3
+          rails_version: 5.2.8.1
+      # Ruby 3.0 releases
+      - bundle_lint_test:
+          name: ruby3-0_rails7-0
+          ruby_version: 3.0.5
+          rails_version: 7.0.4
+      - bundle_lint_test:
+          name: ruby3-0_rails6-1
+          ruby_version: 3.0.5
+          rails_version: 6.1.7
+      - bundle_lint_test:
+          name: ruby3-0_rails6-0
+          ruby_version: 3.0.5
+          rails_version: 6.0.6
+      - bundle_lint_test:
+          name: ruby3-0_rails5-2
+          ruby_version: 3.0.5
+          rails_version: 5.2.8.1
       # Ruby 2.7 releases
       - bundle_lint_test:
           name: ruby2-7_rails7-0
           ruby_version: 2.7.5
-          rails_version: 7.0.3.1
+          rails_version: 7.0.4
       - bundle_lint_test:
           name: ruby2-7_rails6-1
           ruby_version: 2.7.5
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7
       - bundle_lint_test:
           name: ruby2-7_rails6-0
           ruby_version: 2.7.5
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1
       # Ruby 2.6 releases
       - bundle_lint_test:
           name: ruby2-6_rails6-1
           ruby_version: 2.6.9
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7
       - bundle_lint_test:
           name: ruby2-6_rails6-0
           ruby_version: 2.6.9
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-6_rails5-2
           ruby_version: 2.6.9
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1
       # Ruby 2.5 releases
       - bundle_lint_test:
           name: ruby2-5_rails6.0
           ruby_version: 2.5.9
-          rails_version: 6.0.4.7
+          rails_version: 6.0.6
       - bundle_lint_test:
           name: ruby2-5_rails5-2
           ruby_version: 2.5.9
-          rails_version: 5.2.4
+          rails_version: 5.2.8.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,15 @@ workflows:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.7
           rails_version: 5.2.8.1
+      # Ruby 2.6 releases
+      - bundle_lint_test:
+          name: ruby2-6_rails6-0
+          ruby_version: 2.6.10
+          rails_version: 6.0.6.1
+      - bundle_lint_test:
+          name: ruby2-6_rails5-2
+          ruby_version: 2.6.10
+          rails_version: 5.2.8.1
 
   nightly:
     triggers:
@@ -168,4 +177,13 @@ workflows:
       - bundle_lint_test:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.7
+          rails_version: 5.2.8.1
+      # Ruby 2.6 releases
+      - bundle_lint_test:
+          name: ruby2-6_rails6-0
+          ruby_version: 2.6.10
+          rails_version: 6.0.6.1
+      - bundle_lint_test:
+          name: ruby2-6_rails5-2
+          ruby_version: 2.6.10
           rails_version: 5.2.8.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,6 @@ workflows:
           name: ruby3-1_rails6-0
           ruby_version: 3.1.3
           rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby3-1_rails5-2
-          ruby_version: 3.1.3
-          rails_version: 5.2.8.1
       # Ruby 3.0 releases
       - bundle_lint_test:
           name: ruby3-0_rails7-0
@@ -77,10 +73,6 @@ workflows:
           name: ruby3-0_rails6-0
           ruby_version: 3.0.5
           rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby3-0_rails5-2
-          ruby_version: 3.0.5
-          rails_version: 5.2.8.1
       # Ruby 2.7 releases
       - bundle_lint_test:
           name: ruby2-7_rails7-0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,61 +47,61 @@ jobs:
 workflows:
   ci:
     jobs:
+      # Ruby 3.2 releases
+      - bundle_lint_test:
+          name: ruby3-2_rails7-0
+          ruby_version: 3.2.0
+          rails_version: 7.0.4.1
+      - bundle_lint_test:
+          name: ruby3-2_rails6-1
+          ruby_version: 3.2.0
+          rails_version: 6.1.7.1
+      - bundle_lint_test:
+          name: ruby3-2_rails6-0
+          ruby_version: 3.2.0
+          rails_version: 6.0.6.1
       # Ruby 3.1 releases
       - bundle_lint_test:
           name: ruby3-1_rails7-0
           ruby_version: 3.1.3
-          rails_version: 7.0.4
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby3-1_rails6-1
           ruby_version: 3.1.3
-          rails_version: 6.1.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby3-1_rails6-0
           ruby_version: 3.1.3
-          rails_version: 6.0.6
+          rails_version: 6.0.6.1
       # Ruby 3.0 releases
       - bundle_lint_test:
           name: ruby3-0_rails7-0
           ruby_version: 3.0.5
-          rails_version: 7.0.4
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby3-0_rails6-1
           ruby_version: 3.0.5
-          rails_version: 6.1.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby3-0_rails6-0
           ruby_version: 3.0.5
-          rails_version: 6.0.6
+          rails_version: 6.0.6.1
       # Ruby 2.7 releases
       - bundle_lint_test:
           name: ruby2-7_rails7-0
-          ruby_version: 2.7.5
-          rails_version: 7.0.4
+          ruby_version: 2.7.7
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby2-7_rails6-1
-          ruby_version: 2.7.5
-          rails_version: 6.1.7
+          ruby_version: 2.7.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.5
-          rails_version: 6.0.6
+          ruby_version: 2.7.7
+          rails_version: 6.0.6.1
       - bundle_lint_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.5
-          rails_version: 5.2.8.1
-      # Ruby 2.6 releases
-      - bundle_lint_test:
-          name: ruby2-6_rails6-1
-          ruby_version: 2.6.9
-          rails_version: 6.1.7
-      - bundle_lint_test:
-          name: ruby2-6_rails6-0
-          ruby_version: 2.6.9
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby2-6_rails5-2
-          ruby_version: 2.6.9
+          ruby_version: 2.7.7
           rails_version: 5.2.8.1
 
   nightly:
@@ -113,67 +113,59 @@ workflows:
               only:
                 - main
     jobs:
+      # Ruby 3.2 releases
+      - bundle_lint_test:
+          name: ruby3-2_rails7-0
+          ruby_version: 3.2.0
+          rails_version: 7.0.4.1
+      - bundle_lint_test:
+          name: ruby3-2_rails6-1
+          ruby_version: 3.2.0
+          rails_version: 6.1.7.1
+      - bundle_lint_test:
+          name: ruby3-2_rails6-0
+          ruby_version: 3.2.0
+          rails_version: 6.0.6.1
       # Ruby 3.1 releases
       - bundle_lint_test:
           name: ruby3-1_rails7-0
           ruby_version: 3.1.3
-          rails_version: 7.0.4
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby3-1_rails6-1
           ruby_version: 3.1.3
-          rails_version: 6.1.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby3-1_rails6-0
           ruby_version: 3.1.3
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby3-1_rails5-2
-          ruby_version: 3.1.3
-          rails_version: 5.2.8.1
+          rails_version: 6.0.6.1
       # Ruby 3.0 releases
       - bundle_lint_test:
           name: ruby3-0_rails7-0
           ruby_version: 3.0.5
-          rails_version: 7.0.4
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby3-0_rails6-1
           ruby_version: 3.0.5
-          rails_version: 6.1.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby3-0_rails6-0
           ruby_version: 3.0.5
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby3-0_rails5-2
-          ruby_version: 3.0.5
-          rails_version: 5.2.8.1
+          rails_version: 6.0.6.1
       # Ruby 2.7 releases
       - bundle_lint_test:
           name: ruby2-7_rails7-0
-          ruby_version: 2.7.5
-          rails_version: 7.0.4
+          ruby_version: 2.7.7
+          rails_version: 7.0.4.1
       - bundle_lint_test:
           name: ruby2-7_rails6-1
-          ruby_version: 2.7.5
-          rails_version: 6.1.7
+          ruby_version: 2.7.7
+          rails_version: 6.1.7.1
       - bundle_lint_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.5
-          rails_version: 6.0.6
+          ruby_version: 2.7.7
+          rails_version: 6.0.6.1
       - bundle_lint_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.5
-          rails_version: 5.2.8.1
-      # Ruby 2.6 releases
-      - bundle_lint_test:
-          name: ruby2-6_rails6-1
-          ruby_version: 2.6.9
-          rails_version: 6.1.7
-      - bundle_lint_test:
-          name: ruby2-6_rails6-0
-          ruby_version: 2.6.9
-          rails_version: 6.0.6
-      - bundle_lint_test:
-          name: ruby2-6_rails5-2
-          ruby_version: 2.6.9
+          ruby_version: 2.7.7
           rails_version: 5.2.8.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,19 +1,11 @@
-require:
-- rubocop-performance
-- rubocop-rails
-- rubocop-rspec
+inherit_gem:
+  bixby: bixby_default.yml
 
 inherit_from:
 - .rubocop_todo.yml
 
-AllCops:
-  TargetRubyVersion: 2.5
-  DisplayCopNames: true
-  Include:
-    - '**/Rakefile'
-  Exclude:
-    - 'script/**/*'
-    - 'vendor/**/*'
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Lint/SuppressedException:
   Exclude:
@@ -30,6 +22,10 @@ Layout/LineLength:
 
 Metrics/AbcSize:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/active_fedora.rb'
 
 Metrics/BlockNesting:
   Exclude:
@@ -241,6 +237,9 @@ Rails/Date:
   Enabled: false
 
 Rails/TimeZone:
+  Enabled: false
+
+Rails/FilePath:
   Enabled: false
 
 RSpec/AnyInstance:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,13 @@
-require: rubocop-rspec
+require:
+- rubocop-performance
+- rubocop-rails
+- rubocop-rspec
 
 inherit_from:
 - .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   Include:
     - '**/Rakefile'
@@ -12,7 +15,7 @@ AllCops:
     - 'script/**/*'
     - 'vendor/**/*'
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'spec/unit/**/*'
     - 'spec/integration/**/*'
@@ -22,7 +25,7 @@ Lint/HandleExceptions:
 Lint/AssignmentInCondition:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/AbcSize:
@@ -173,7 +176,7 @@ Style/Lambda:
     - 'spec/**/*'
 
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'lib/active_fedora.rb'
+    - 'lib/active_fedora/nested_attributes.rb'
+    - 'lib/active_fedora/rspec_matchers/**/*'
+    - 'lib/tasks/**/*'
 
 Metrics/BlockNesting:
   Exclude:
@@ -242,6 +245,12 @@ Rails/TimeZone:
 Rails/FilePath:
   Enabled: false
 
+Rails/ActiveRecordAliases:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
 RSpec/AnyInstance:
   Enabled: false
 
@@ -272,4 +281,7 @@ RSpec/NotToNot:
   Enabled: false
 
 RSpec/MessageSpies:
+  Enabled: false
+
+Security/MarshalLoad:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,5 +16,5 @@ Style/PercentLiteralDelimiters:
 # Offense count: 1
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 82

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec path: File.expand_path('..', __FILE__)
 
 gem 'active-triples', github: 'samvera-labs/activetriples', branch: 'merge-gitlab-upstream'
 gem 'byebug' unless ENV['TRAVIS']
-gem 'ldp', github: 'samvera/ldp', branch: 'main'
 gem 'pry-byebug' unless ENV['CI']
 
 if ENV['RAILS_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,9 @@ source "https://rubygems.org"
 
 gemspec path: File.expand_path('..', __FILE__)
 
-gem 'ldp', github: 'samvera/ldp', branch: 'main'
+gem 'active-triples', github: 'samvera-labs/activetriples', branch: 'merge-gitlab-upstream'
 gem 'byebug' unless ENV['TRAVIS']
+gem 'ldp', github: 'samvera/ldp', branch: 'main'
 gem 'pry-byebug' unless ENV['CI']
 
 if ENV['RAILS_VERSION']
@@ -17,9 +18,9 @@ else
 end
 
 group :test do
-  gem 'simplecov', require: false
   gem 'coveralls', require: false
   gem 'rspec_junit_formatter'
+  gem 'simplecov', require: false
 end
 
 gem 'jruby-openssl', platform: :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec path: File.expand_path('..', __FILE__)
 
-gem 'active-triples', github: 'samvera-labs/activetriples', branch: 'merge-gitlab-upstream'
+gem 'active-triples', git: 'https://gitlab.com/cjcolvar/ActiveTriples.git', branch: 'ruby3'
 gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec path: File.expand_path('..', __FILE__)
 
+gem 'ldp', github: 'samvera/ldp', branch: 'main'
 gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gemspec path: File.expand_path('..', __FILE__)
 
-gem 'active-triples', git: 'https://gitlab.com/cjcolvar/ActiveTriples.git', branch: 'ruby3'
 gem 'byebug' unless ENV['TRAVIS']
 gem 'pry-byebug' unless ENV['CI']
 

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A convenience libary for manipulating documents in the Fedora Repository.}
   s.description = %q{ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.}
   s.license = "Apache-2.0"
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_dependency "activemodel", '>= 5.1'
   s.add_dependency "activesupport", '>= 5.1'
@@ -28,13 +28,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency "github_changelog_generator"
   s.add_development_dependency "rdoc"
-  s.add_development_dependency "psych", "< 4" # Restricted because 4.0+ do not work with rubocop 0.56.x
   s.add_development_dependency "rails"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"
-  s.add_development_dependency "rubocop", '~> 0.56.0'
-  s.add_development_dependency "rubocop-rspec", '~> 1.12.0'
+  s.add_development_dependency "rubocop", '1.28.2'
+  s.add_development_dependency "rubocop-performance"
+  s.add_development_dependency "rubocop-rails"
+  s.add_development_dependency "rubocop-rspec"
   s.add_development_dependency "simplecov", '~> 0.8'
   s.add_development_dependency "solr_wrapper", "~> 4.0"
   s.add_development_dependency "yard"

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "active_fedora/version"
 
 Gem::Specification.new do |s|
@@ -8,9 +9,9 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Matt Zumwalt", "McClain Looney", "Justin Coyne"]
   s.email       = ["samvera-tech@googlegroups.com"]
-  s.homepage    = %q{https://github.com/samvera/active_fedora}
-  s.summary     = %q{A convenience libary for manipulating documents in the Fedora Repository.}
-  s.description = %q{ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.}
+  s.homepage    = 'https://github.com/samvera/active_fedora'
+  s.summary     = 'A convenience libary for manipulating documents in the Fedora Repository.'
+  s.description = 'ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.'
   s.license = "Apache-2.0"
   s.required_ruby_version = '>= 2.5'
 
@@ -24,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.1.2', '< 3'
   s.add_dependency "ruby-progressbar", '~> 1.0'
 
+  s.add_development_dependency "bixby"
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency "github_changelog_generator"
@@ -32,16 +34,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"
-  s.add_development_dependency "rubocop", '1.28.2'
-  s.add_development_dependency "rubocop-performance"
-  s.add_development_dependency "rubocop-rails"
-  s.add_development_dependency "rubocop-rspec"
   s.add_development_dependency "simplecov", '~> 0.8'
   s.add_development_dependency "solr_wrapper", "~> 4.0"
   s.add_development_dependency "yard"
 
   s.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec\/?} }
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.extra_rdoc_files = [
     "LICENSE",
     "README.md"

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'A convenience libary for manipulating documents in the Fedora Repository.'
   s.description = 'ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.'
   s.license = "Apache-2.0"
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_dependency "activemodel", '>= 5.1'
   s.add_dependency "activesupport", '>= 5.1'

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -25,7 +25,7 @@ module RDF
         @string ||= begin
           # Show nanoseconds but remove trailing zeros
           nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
-          nano = DOT + nano unless nano.blank?
+          nano = DOT + nano if nano.present?
           @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
         end
       end
@@ -33,7 +33,7 @@ module RDF
   end
 end
 
-module ActiveFedora #:nodoc:
+module ActiveFedora # :nodoc:
   extend ActiveSupport::Autoload
 
   eager_autoload do
@@ -156,7 +156,7 @@ module ActiveFedora #:nodoc:
   end
 
   class << self
-    attr_reader :fedora_config, :solr_config, :config_options
+    attr_reader :solr_config, :config_options
     attr_accessor :configurator
 
     def fedora_config
@@ -174,9 +174,7 @@ module ActiveFedora #:nodoc:
       options = {} if options.nil?
       # For backwards compatibility, handle cases where config_path (a String) is passed in as the argument rather than a config_options hash
       # In all other cases, set config_path to config_options[:config_path], which is ok if it's nil
-      if options.is_a? String
-        raise ArgumentError, "Calling ActiveFedora.init with a path as an argument has been removed.  Use ActiveFedora.init(:fedora_config_path=>#{options})"
-      end
+      raise ArgumentError, "Calling ActiveFedora.init with a path as an argument has been removed.  Use ActiveFedora.init(:fedora_config_path=>#{options})" if options.is_a? String
       @fedora_config = nil
       SolrService.reset!
       configurator.init(options)
@@ -199,7 +197,7 @@ module ActiveFedora #:nodoc:
     def environment
       if config_options.fetch(:environment, nil)
         config_options[:environment]
-      elsif defined?(Rails.env) && !Rails.env.nil?
+      elsif defined?(Rails.env) && !Rails.env.nil? # rubocop:disable Rails/UnknownEnv
         Rails.env.to_s
       elsif defined?(ENV['environment']) && !ENV['environment'].nil?
         ENV['environment']

--- a/lib/active_fedora/association_hash.rb
+++ b/lib/active_fedora/association_hash.rb
@@ -84,6 +84,7 @@ module ActiveFedora
       super
     end
   end
+
   ##
   # Represents the result of merging two association hashes.
   # @note As the keys can come from multiple models, the attributes become

--- a/lib/active_fedora/association_hash.rb
+++ b/lib/active_fedora/association_hash.rb
@@ -11,11 +11,11 @@ module ActiveFedora
     end
 
     def [](name)
-      association(name).reader if association(name)
+      association(name)&.reader
     end
 
     def []=(name, object)
-      association(name).writer(object) if association(name)
+      association(name)&.writer(object)
     end
 
     def association(name)
@@ -92,11 +92,13 @@ module ActiveFedora
   class Merged < AssociationHash
     attr_reader :first, :second
 
+    # rubocop:disable Lint/MissingSuper
     def initialize(first, second)
       @first = first
       @base = first.base
       @second = second
     end
+    # rubocop:enable Lint/MissingSuper
 
     def [](name)
       first[name] || second[name]

--- a/lib/active_fedora/associations.rb
+++ b/lib/active_fedora/associations.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/object/blank'
 
 module ActiveFedora
-  class InverseOfAssociationNotFoundError < RuntimeError #:nodoc:
+  class InverseOfAssociationNotFoundError < RuntimeError # :nodoc:
     def initialize(reflection, associated_class = nil)
       super("Could not find the inverse association for #{reflection.name} (#{reflection.options[:inverse_of].inspect} in #{associated_class.nil? ? reflection.class_name : associated_class.name})")
     end
@@ -65,7 +65,7 @@ module ActiveFedora
     end
 
     # Clears out the association cache.
-    def clear_association_cache #:nodoc:
+    def clear_association_cache # :nodoc:
       @association_cache.clear if persisted?
     end
 
@@ -73,7 +73,7 @@ module ActiveFedora
     attr_reader :association_cache
 
     # Returns the association instance for the given name, instantiating it if it doesn't already exist
-    def association(name) #:nodoc:
+    def association(name) # :nodoc:
       association = association_instance_get(name)
 
       if association.nil?

--- a/lib/active_fedora/associations/association.rb
+++ b/lib/active_fedora/associations/association.rb
@@ -119,7 +119,7 @@ module ActiveFedora
         reset
       end
 
-      def initialize_attributes(record, except_from_scope_attributes = nil) #:nodoc:
+      def initialize_attributes(record, except_from_scope_attributes = nil) # :nodoc:
         except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key].compact
         assigned_keys = record.changed
@@ -141,9 +141,7 @@ module ActiveFedora
           if (reflection.has_one? || reflection.collection?) && !options[:through]
             attributes[reflection.foreign_key] = owner[reflection.active_record_primary_key]
 
-            if reflection.options[:as]
-              attributes[reflection.type] = owner.class.base_class.name
-            end
+            attributes[reflection.type] = owner.class.base_class.name if reflection.options[:as]
           end
 
           attributes

--- a/lib/active_fedora/associations/association_scope.rb
+++ b/lib/active_fedora/associations/association_scope.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class AssociationScope #:nodoc:
+    class AssociationScope # :nodoc:
       def self.scope(association)
         new(association).scope
       end

--- a/lib/active_fedora/associations/basic_contains_association.rb
+++ b/lib/active_fedora/associations/basic_contains_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class BasicContainsAssociation < ContainsAssociation #:nodoc:
+    class BasicContainsAssociation < ContainsAssociation # :nodoc:
       def find_target
         uris = owner.resource.query({ predicate: options[:predicate] })
                     .map { |r| r.object.to_s }

--- a/lib/active_fedora/associations/belongs_to_association.rb
+++ b/lib/active_fedora/associations/belongs_to_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class BelongsToAssociation < SingularAssociation #:nodoc:
+    class BelongsToAssociation < SingularAssociation # :nodoc:
       def handle_dependency
         target.send(options[:dependent]) if load_target
       end

--- a/lib/active_fedora/associations/builder/association.rb
+++ b/lib/active_fedora/associations/builder/association.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class Association #:nodoc:
+  class Association # :nodoc:
     class << self
       attr_accessor :extensions
     end
@@ -114,9 +114,7 @@ module ActiveFedora::Associations::Builder
     end
 
     def self.check_dependent_options(dependent)
-      unless valid_dependent_options.include? dependent
-        raise ArgumentError, "The :dependent option must be one of #{valid_dependent_options}, but is :#{dependent}"
-      end
+      raise ArgumentError, "The :dependent option must be one of #{valid_dependent_options}, but is :#{dependent}" unless valid_dependent_options.include? dependent
     end
 
     def self.add_destroy_callbacks(model, reflection)

--- a/lib/active_fedora/associations/builder/association.rb
+++ b/lib/active_fedora/associations/builder/association.rb
@@ -36,7 +36,7 @@ module ActiveFedora::Associations::Builder
     def self.build_scope(scope, extension)
       new_scope = scope
 
-      new_scope = proc { instance_exec(&scope) } if scope && scope.arity.zero?
+      new_scope = proc { instance_exec(&scope) } if scope&.arity&.zero?
 
       new_scope = wrap_scope new_scope, extension if extension
 

--- a/lib/active_fedora/associations/builder/basic_contains.rb
+++ b/lib/active_fedora/associations/builder/basic_contains.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class BasicContains < CollectionAssociation #:nodoc:
+  class BasicContains < CollectionAssociation # :nodoc:
     def self.macro
       :is_a_container
     end

--- a/lib/active_fedora/associations/builder/belongs_to.rb
+++ b/lib/active_fedora/associations/builder/belongs_to.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class BelongsTo < SingularAssociation #:nodoc:
+  class BelongsTo < SingularAssociation # :nodoc:
     def self.macro
       :belongs_to
     end
@@ -19,9 +19,7 @@ module ActiveFedora::Associations::Builder
     end
 
     def self.define_validations(model, reflection)
-      if reflection.options.key?(:required)
-        reflection.options[:optional] = !reflection.options.delete(:required)
-      end
+      reflection.options[:optional] = !reflection.options.delete(:required) if reflection.options.key?(:required)
 
       required = if reflection.options[:optional].nil?
                    model.belongs_to_required_by_default
@@ -31,9 +29,7 @@ module ActiveFedora::Associations::Builder
 
       super
 
-      if required
-        model.validates_presence_of reflection.name, message: :required
-      end
+      model.validates_presence_of reflection.name, message: :required if required
     end
   end
 end

--- a/lib/active_fedora/associations/builder/collection_association.rb
+++ b/lib/active_fedora/associations/builder/collection_association.rb
@@ -15,11 +15,11 @@ module ActiveFedora::Associations::Builder
     end
 
     def self.define_extensions(model, name)
-      if block_given?
-        extension_module_name = "#{model.name.demodulize}#{name.to_s.camelize}AssociationExtension"
-        extension = Module.new(&Proc.new)
-        model.parent.const_set(extension_module_name, extension)
-      end
+      return unless block_given?
+
+      extension_module_name = "#{model.name.demodulize}#{name.to_s.camelize}AssociationExtension"
+      extension = Module.new(&Proc.new)
+      model.parent.const_set(extension_module_name, extension)
     end
 
     def self.define_callback(model, callback_name, name, options)
@@ -44,7 +44,7 @@ module ActiveFedora::Associations::Builder
 
     def self.wrap_scope(scope, mod)
       if scope
-        if scope.arity > 0
+        if scope.arity.positive?
           proc { |owner| instance_exec(owner, &scope).extending(mod) }
         else
           proc { instance_exec(&scope).extending(mod) }

--- a/lib/active_fedora/associations/builder/collection_association.rb
+++ b/lib/active_fedora/associations/builder/collection_association.rb
@@ -1,6 +1,6 @@
 require 'active_fedora/associations'
 module ActiveFedora::Associations::Builder
-  class CollectionAssociation < Association #:nodoc:
+  class CollectionAssociation < Association # :nodoc:
     CALLBACKS = [:before_add, :after_add, :before_remove, :after_remove].freeze
 
     def self.valid_options(options)

--- a/lib/active_fedora/associations/builder/directly_contains.rb
+++ b/lib/active_fedora/associations/builder/directly_contains.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class DirectlyContains < CollectionAssociation #:nodoc:
+  class DirectlyContains < CollectionAssociation # :nodoc:
     def self.macro
       :directly_contains
     end

--- a/lib/active_fedora/associations/builder/directly_contains.rb
+++ b/lib/active_fedora/associations/builder/directly_contains.rb
@@ -10,11 +10,9 @@ module ActiveFedora::Associations::Builder
 
     def self.validate_options(options)
       super
-      if !options[:has_member_relation] && !options[:is_member_of_relation]
-        raise ArgumentError, "You must specify a :has_member_relation or :is_member_of_relation predicate for #{name}"
-      elsif !options[:has_member_relation].is_a?(RDF::URI) && !options[:is_member_of_relation].is_a?(RDF::URI)
-        raise ArgumentError, "Predicate must be a kind of RDF::URI"
-      end
+
+      raise ArgumentError, "You must specify a :has_member_relation or :is_member_of_relation predicate for #{name}" if !options[:has_member_relation] && !options[:is_member_of_relation]
+      raise ArgumentError, "Predicate must be a kind of RDF::URI" if !options[:has_member_relation].is_a?(RDF::URI) && !options[:is_member_of_relation].is_a?(RDF::URI)
     end
   end
 end

--- a/lib/active_fedora/associations/builder/directly_contains_one.rb
+++ b/lib/active_fedora/associations/builder/directly_contains_one.rb
@@ -9,15 +9,13 @@ module ActiveFedora::Associations::Builder
     end
 
     def self.create_reflection(model, name, scope, options, extension = nil)
-      if options[:through]
-        inherit_options_from_association(model, options, options[:through])
-      else
-        raise ArgumentError, "you must specify a :through option on #{name}.  #{name} will use the container from that directly_contains association."
-      end
+      raise ArgumentError, "you must specify a :through option on #{name}.  #{name} will use the container from that directly_contains association." unless options[:through]
+      inherit_options_from_association(model, options, options[:through])
 
       super
     end
 
+    # rubocop:disable Style/GuardClause
     def self.validate_options(options)
       super
       if options[:class_name] == "ActiveFedora::File"
@@ -31,6 +29,7 @@ module ActiveFedora::Associations::Builder
       return if options[:type].is_a?(RDF::URI)
       raise ArgumentError, "You must specify a Type and it must be a kind of RDF::URI"
     end
+    # rubocop:enable Style/GuardClause
 
     # Inherits :has_member_relation from the association corresponding to association_name
     # @param [Symbol] association_name of the association to inherit from

--- a/lib/active_fedora/associations/builder/directly_contains_one.rb
+++ b/lib/active_fedora/associations/builder/directly_contains_one.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class DirectlyContainsOne < SingularAssociation #:nodoc:
+  class DirectlyContainsOne < SingularAssociation # :nodoc:
     def self.macro
       :directly_contains_one
     end

--- a/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
+++ b/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class HasAndBelongsToMany < CollectionAssociation #:nodoc:
+  class HasAndBelongsToMany < CollectionAssociation # :nodoc:
     def self.macro
       :has_and_belongs_to_many
     end

--- a/lib/active_fedora/associations/builder/has_many.rb
+++ b/lib/active_fedora/associations/builder/has_many.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class HasMany < CollectionAssociation #:nodoc:
+  class HasMany < CollectionAssociation # :nodoc:
     def self.macro
       :has_many
     end

--- a/lib/active_fedora/associations/builder/has_subresource.rb
+++ b/lib/active_fedora/associations/builder/has_subresource.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class HasSubresource < SingularAssociation #:nodoc:
+  class HasSubresource < SingularAssociation # :nodoc:
     def self.macro
       :has_subresource
     end

--- a/lib/active_fedora/associations/builder/indirectly_contains.rb
+++ b/lib/active_fedora/associations/builder/indirectly_contains.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class IndirectlyContains < CollectionAssociation #:nodoc:
+  class IndirectlyContains < CollectionAssociation # :nodoc:
     def self.macro
       :indirectly_contains
     end

--- a/lib/active_fedora/associations/builder/indirectly_contains.rb
+++ b/lib/active_fedora/associations/builder/indirectly_contains.rb
@@ -18,12 +18,9 @@ module ActiveFedora::Associations::Builder
 
     def self.validate_options(options)
       super
-      if !options[:has_member_relation] && !options[:is_member_of_relation]
-        raise ArgumentError, "You must specify a predicate for #{name}"
-      elsif !options[:has_member_relation].is_a?(RDF::URI) && !options[:is_member_of_relation].is_a?(RDF::URI)
-        raise ArgumentError, "Predicate must be a kind of RDF::URI"
-      end
 
+      raise ArgumentError, "You must specify a predicate for #{name}" if !options[:has_member_relation] && !options[:is_member_of_relation]
+      raise ArgumentError, "Predicate must be a kind of RDF::URI" if !options[:has_member_relation].is_a?(RDF::URI) && !options[:is_member_of_relation].is_a?(RDF::URI)
       raise ArgumentError, "Missing :through option" unless options[:through]
       raise ArgumentError, "Missing :foreign_key option" unless options[:foreign_key]
     end

--- a/lib/active_fedora/associations/builder/singular_association.rb
+++ b/lib/active_fedora/associations/builder/singular_association.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Associations::Builder
-  class SingularAssociation < Association #:nodoc:
+  class SingularAssociation < Association # :nodoc:
     def self.valid_options(options)
       super + [:dependent, :inverse_of, :required]
     end

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class CollectionAssociation < Association #:nodoc:
+    class CollectionAssociation < Association # :nodoc:
       attr_reader :proxy
 
       # Implements the reader method, e.g. foo.items for Foo.has_many :items

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -336,11 +336,8 @@ module ActiveFedora
 
         def find_reflection
           return reflection if @reflection.options[:predicate]
-          if @reflection.class_name && @reflection.class_name != 'ActiveFedora::Base' && @reflection.macro != :has_and_belongs_to_many
-            @reflection.inverse_of || raise("No :inverse_of or :predicate attribute was set or could be inferred for #{@reflection.macro} #{@reflection.name.inspect} on #{@owner.class}")
-          else
-            raise "Couldn't find reflection"
-          end
+          raise "Couldn't find reflection" unless @reflection.class_name && @reflection.class_name != 'ActiveFedora::Base' && @reflection.macro != :has_and_belongs_to_many
+          @reflection.inverse_of || raise("No :inverse_of or :predicate attribute was set or could be inferred for #{@reflection.macro} #{@reflection.name.inspect} on #{@owner.class}")
         end
 
         def _create_record(attributes, raise = false)

--- a/lib/active_fedora/associations/container_proxy.rb
+++ b/lib/active_fedora/associations/container_proxy.rb
@@ -1,9 +1,11 @@
 module ActiveFedora
   module Associations
     class ContainerProxy < CollectionProxy
+      # rubocop:disable Lint/MissingSuper
       def initialize(association)
         @association = association
       end
+      # rubocop:enable Lint/MissingSuper
     end
   end
 end

--- a/lib/active_fedora/associations/contains_association.rb
+++ b/lib/active_fedora/associations/contains_association.rb
@@ -1,7 +1,7 @@
 # This is the parent class of BasicContainsAssociation, DirectlyContainsAssociation and IndirectlyContainsAssociation
 module ActiveFedora
   module Associations
-    class ContainsAssociation < CollectionAssociation #:nodoc:
+    class ContainsAssociation < CollectionAssociation # :nodoc:
       def insert_record(record, force = true, validate = true)
         if force
           record.save!

--- a/lib/active_fedora/associations/directly_contains_association.rb
+++ b/lib/active_fedora/associations/directly_contains_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class DirectlyContainsAssociation < ContainsAssociation #:nodoc:
+    class DirectlyContainsAssociation < ContainsAssociation # :nodoc:
       def insert_record(record, force = true, validate = true)
         container.save!
         super
@@ -20,18 +20,16 @@ module ActiveFedora
       end
 
       def container
-        @container ||= begin
-          DirectContainer.find_or_initialize(ActiveFedora::Base.uri_to_id(uri)).tap do |container|
-            container.parent = @owner
-            container.has_member_relation = Array(options[:has_member_relation])
-            container.is_member_of_relation = Array(options[:is_member_of_relation])
-          end
+        @container ||= DirectContainer.find_or_initialize(ActiveFedora::Base.uri_to_id(uri)).tap do |container|
+          container.parent = @owner
+          container.has_member_relation = Array(options[:has_member_relation])
+          container.is_member_of_relation = Array(options[:is_member_of_relation])
         end
       end
 
       protected
 
-        def initialize_attributes(record) #:nodoc:
+        def initialize_attributes(record) # :nodoc:
           record.uri = ActiveFedora::Base.id_to_uri(container.mint_id)
           set_inverse_instance(record)
         end

--- a/lib/active_fedora/associations/directly_contains_one_association.rb
+++ b/lib/active_fedora/associations/directly_contains_one_association.rb
@@ -1,7 +1,7 @@
 module ActiveFedora
   module Associations
     # Filters a DirectContainer relationship, returning the first item that matches the given :type
-    class DirectlyContainsOneAssociation < SingularAssociation #:nodoc:
+    class DirectlyContainsOneAssociation < SingularAssociation # :nodoc:
       # Finds objects contained by the container predicate (either the configured has_member_relation or ldp:contains)
       # TODO: Refactor this to use solr (for efficiency) instead of parsing the RDF graph.  Requires indexing ActiveFedora::File objects into solr, including their RDF.type and, if possible, the id of their container
       # See https://github.com/samvera/active_fedora/issues/1335

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -1,7 +1,7 @@
 module ActiveFedora
   # = Active Fedora Has And Belongs To Many Association
   module Associations
-    class HasAndBelongsToManyAssociation < CollectionAssociation #:nodoc:
+    class HasAndBelongsToManyAssociation < CollectionAssociation # :nodoc:
       def initialize(owner, reflection)
         super
       end

--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class HasManyAssociation < CollectionAssociation #:nodoc:
+    class HasManyAssociation < CollectionAssociation # :nodoc:
       def initialize(owner, reflection)
         super
       end

--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -35,7 +35,7 @@ module ActiveFedora
           end
         elsif owner.persisted?
           inverse = reflection.inverse_of
-          if inverse && inverse.collection?
+          if inverse&.collection?
             record[inverse.foreign_key] ||= []
             record[inverse.foreign_key] += [owner.id]
           elsif inverse && inverse.klass == ActiveFedora::Base
@@ -88,6 +88,7 @@ module ActiveFedora
 
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
+          # rubocop:disable Style/GuardClause
           return records.each(&:destroy) if method == :destroy
           # Find all the records that point to this and nullify them
           # keys  = records.map { |r| r[reflection.association_primary_key] }
@@ -115,6 +116,7 @@ module ActiveFedora
           end
 
           # update_counter(-scope.update_all(reflection.foreign_key => nil))
+          # rubocop:enable Style/GuardClause
         end
     end
   end

--- a/lib/active_fedora/associations/has_subresource_association.rb
+++ b/lib/active_fedora/associations/has_subresource_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class HasSubresourceAssociation < SingularAssociation #:nodoc:
+    class HasSubresourceAssociation < SingularAssociation # :nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader(force_reload = false)
         super || build
@@ -50,9 +50,7 @@ module ActiveFedora
 
         def configure_datastream(record)
           # If you called has_metadata with a block, pass the block into the File class
-          if reflection.options[:block].class == Proc
-            reflection.options[:block].call(record)
-          end
+          reflection.options[:block].call(record) if reflection.options[:block].class == Proc
           return unless record.new_record? && reflection.options[:autocreate]
           record.datastream_will_change!
         end

--- a/lib/active_fedora/associations/indirectly_contains_association.rb
+++ b/lib/active_fedora/associations/indirectly_contains_association.rb
@@ -3,7 +3,7 @@ module ActiveFedora
     # TODO: we may want to split this into two subclasses, one for has_member_relation
     # and the other for is_member_of_relation
     # See https://github.com/samvera/active_fedora/issues/1332
-    class IndirectlyContainsAssociation < ContainsAssociation #:nodoc:
+    class IndirectlyContainsAssociation < ContainsAssociation # :nodoc:
       # Add +records+ to this association.  Returns +self+ so method calls may be chained.
       # Since << flattens its argument list and inserts each record, +push+ and +concat+ behave identically.
       def concat(*records)
@@ -49,19 +49,17 @@ module ActiveFedora
       end
 
       def container
-        @container ||= begin
-          IndirectContainer.find_or_initialize(ActiveFedora::Base.uri_to_id(uri)).tap do |container|
-            container.parent = @owner
-            container.has_member_relation = Array(options[:has_member_relation])
-            container.is_member_of_relation = Array(options[:is_member_of_relation])
-            container.inserted_content_relation = Array(options[:inserted_content_relation])
-          end
+        @container ||= IndirectContainer.find_or_initialize(ActiveFedora::Base.uri_to_id(uri)).tap do |container|
+          container.parent = @owner
+          container.has_member_relation = Array(options[:has_member_relation])
+          container.is_member_of_relation = Array(options[:is_member_of_relation])
+          container.inserted_content_relation = Array(options[:inserted_content_relation])
         end
       end
 
       protected
 
-        def initialize_attributes(_record) #:nodoc:
+        def initialize_attributes(_record) # :nodoc:
           # record.uri = ActiveFedora::Base.id_to_uri(container.mint_id)
           # set_inverse_instance(record)
         end

--- a/lib/active_fedora/associations/orders_association.rb
+++ b/lib/active_fedora/associations/orders_association.rb
@@ -52,9 +52,7 @@ module ActiveFedora::Associations
     # Append a target node to the end of the order.
     # @param [ActiveFedora::Base] record Record to append
     def append_target(record, _skip_callbacks = false)
-      unless unordered_association.target.include?(record)
-        unordered_association.concat(record)
-      end
+      unordered_association.concat(record) unless unordered_association.target.include?(record)
       target.append_target(record, proxy_in: owner)
     end
 
@@ -62,9 +60,7 @@ module ActiveFedora::Associations
     # @param [Integer] loc Position to insert record.
     # @param [ActiveFedora::Base] record Record to insert
     def insert_target_at(loc, record)
-      unless unordered_association.target.include?(record)
-        unordered_association.concat(record)
-      end
+      unordered_association.concat(record) unless unordered_association.target.include?(record)
       target.insert_at(loc, record, proxy_in: owner)
     end
 
@@ -73,9 +69,7 @@ module ActiveFedora::Associations
     # @param [String] id ID of record to insert.
     def insert_target_id_at(loc, id)
       raise ArgumentError, "ID can not be nil" if id.nil?
-      unless unordered_association.ids_reader.include?(id)
-        raise ArgumentError, "#{id} is not a part of #{unordered_association.reflection.name}"
-      end
+      raise ArgumentError, "#{id} is not a part of #{unordered_association.reflection.name}" unless unordered_association.ids_reader.include?(id)
       target.insert_proxy_for_at(loc, ActiveFedora::Base.id_to_uri(id), proxy_in: owner)
     end
 

--- a/lib/active_fedora/associations/orders_association.rb
+++ b/lib/active_fedora/associations/orders_association.rb
@@ -100,11 +100,10 @@ module ActiveFedora::Associations
       list_container.save
       # NOTE: This turns out to be pretty cheap, but should we be doing it
       # elsewhere?
-      unless list_container.changed?
-        owner.head = [list_container.head_id.first]
-        owner.tail = [list_container.tail_id.first]
-        owner.save
-      end
+      return if list_container.changed?
+      owner.head = [list_container.head_id.first]
+      owner.tail = [list_container.tail_id.first]
+      owner.save
     end
 
     def scope(*_args)

--- a/lib/active_fedora/associations/rdf.rb
+++ b/lib/active_fedora/associations/rdf.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class RDF < SingularAssociation #:nodoc:
+    class RDF < SingularAssociation # :nodoc:
       def replace(values)
         ids = Array(values).reject(&:blank?)
         raise "can't modify frozen #{owner.class}" if owner.frozen?

--- a/lib/active_fedora/associations/record_composite.rb
+++ b/lib/active_fedora/associations/record_composite.rb
@@ -18,6 +18,7 @@ module ActiveFedora::Associations
     def delete
       each(&:delete)
     end
+
     ##
     # A Repository which returns a composite from #find instead of a single
     # record. Delegates find to a base repository.

--- a/lib/active_fedora/associations/singular_association.rb
+++ b/lib/active_fedora/associations/singular_association.rb
@@ -2,6 +2,7 @@ module ActiveFedora
   module Associations
     class SingularAssociation < Association # :nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
+      # rubocop:disable Style/GuardClause
       def reader(force_reload = false)
         if force_reload
           raise NotImplementedError, "Need to define the uncached method" # TODO
@@ -11,6 +12,7 @@ module ActiveFedora
         end
         target
       end
+      # rubocop:enable Style/GuardClause
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items
       def writer(record)

--- a/lib/active_fedora/associations/singular_association.rb
+++ b/lib/active_fedora/associations/singular_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class SingularAssociation < Association #:nodoc:
+    class SingularAssociation < Association # :nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader(force_reload = false)
         if force_reload

--- a/lib/active_fedora/associations/singular_rdf.rb
+++ b/lib/active_fedora/associations/singular_rdf.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class SingularRDF < RDF #:nodoc:
+    class SingularRDF < RDF # :nodoc:
       def replace(value)
         super(Array(value))
       end

--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -8,9 +8,11 @@ module ActiveFedora
 
     # Returns only the attached_files that are declared with 'contains'
     def declared_attached_files
-      attached_files.reflections.keys.index_with do |k|
-        attached_files[k]
+      result = {}
+      attached_files.reflections.keys.each do |k|
+        result[k] = attached_files[k]
       end
+      result
     end
 
     #

--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -8,8 +8,8 @@ module ActiveFedora
 
     # Returns only the attached_files that are declared with 'contains'
     def declared_attached_files
-      attached_files.reflections.keys.each_with_object({}) do |k, h|
-        h[k] = attached_files[k]
+      attached_files.reflections.keys.index_with do |k|
+        attached_files[k]
       end
     end
 

--- a/lib/active_fedora/attribute_assignment.rb
+++ b/lib/active_fedora/attribute_assignment.rb
@@ -30,7 +30,7 @@ module ActiveFedora
     #   cat.status => 'sleeping'
     def assign_attributes(new_attributes)
       raise ArgumentError, "When assigning attributes, you must pass a hash as an argument." unless new_attributes.respond_to?(:stringify_keys)
-      return if new_attributes.nil? || new_attributes.empty?
+      return if new_attributes.blank?
 
       attributes = new_attributes.stringify_keys
       _assign_attributes(sanitize_for_mass_assignment(attributes))

--- a/lib/active_fedora/attribute_assignment.rb
+++ b/lib/active_fedora/attribute_assignment.rb
@@ -29,9 +29,7 @@ module ActiveFedora
     #   cat.name # => 'Gorby'
     #   cat.status => 'sleeping'
     def assign_attributes(new_attributes)
-      unless new_attributes.respond_to?(:stringify_keys)
-        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
-      end
+      raise ArgumentError, "When assigning attributes, you must pass a hash as an argument." unless new_attributes.respond_to?(:stringify_keys)
       return if new_attributes.nil? || new_attributes.empty?
 
       attributes = new_attributes.stringify_keys

--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -146,9 +146,11 @@ module ActiveFedora
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
     def attributes
-      attribute_names.index_with do |name|
-        read_attribute(name)
+      result = {}
+      attribute_names.each do |name|
+        result[name] = read_attribute(name)
       end
+      result
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -13,12 +13,12 @@ module ActiveFedora
       end
     end
 
-    BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass).freeze
+    BLACKLISTED_CLASS_METHODS = %w[private public protected allocate new name parent superclass].freeze
 
     class GeneratedAttributeMethods < Module; end # :nodoc:
 
     module ClassMethods
-      def inherited(child_class) #:nodoc:
+      def inherited(child_class) # :nodoc:
         child_class.initialize_generated_modules
         super
       end
@@ -46,9 +46,7 @@ module ActiveFedora
       #   Person.instance_method_already_implemented?(:name)
       #   # => false
       def instance_method_already_implemented?(method_name)
-        if dangerous_attribute_method?(method_name)
-          raise DangerousAttributeError, "#{method_name} is defined by Active Fedora. Check to make sure that you don't have an attribute or method with the same name."
-        end
+        raise DangerousAttributeError, "#{method_name} is defined by Active Fedora. Check to make sure that you don't have an attribute or method with the same name." if dangerous_attribute_method?(method_name)
 
         if superclass == Base
           super
@@ -148,8 +146,8 @@ module ActiveFedora
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
     def attributes
-      attribute_names.each_with_object({}) do |name, attrs|
-        attrs[name] = read_attribute(name)
+      attribute_names.index_with do |name|
+        read_attribute(name)
       end
     end
 

--- a/lib/active_fedora/attribute_methods/read.rb
+++ b/lib/active_fedora/attribute_methods/read.rb
@@ -4,7 +4,7 @@ module ActiveFedora
       module ClassMethods
         protected
 
-          def define_method_attribute(name, owner: nil)
+          def define_method_attribute(name, owner: nil) # rubocop:disable Lint/UnusedMethodArgument
             name = name.to_s
             safe_name = name.unpack('h*'.freeze).first
             temp_method = "__temp__#{safe_name}"

--- a/lib/active_fedora/attribute_methods/write.rb
+++ b/lib/active_fedora/attribute_methods/write.rb
@@ -4,7 +4,7 @@ module ActiveFedora
       module ClassMethods
         protected
 
-          def define_method_attribute=(name, owner: nil)
+          def define_method_attribute=(name, owner: nil) # rubocop:disable Lint/UnusedMethodArgument
             name = name.to_s
             safe_name = name.unpack('h*'.freeze).first
             ActiveFedora::AttributeMethods::AttrNames.set_name_cache safe_name, name
@@ -27,11 +27,9 @@ module ActiveFedora
       end
 
       def write_attribute(attribute_name, value)
-        if self.class.properties.key?(attribute_name)
-          attributes[attribute_name] = value
-        else
-          raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attribute_name}'"
-        end
+        raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attribute_name}'" unless self.class.properties.key?(attribute_name)
+
+        attributes[attribute_name] = value
       end
 
       private

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -77,7 +77,7 @@ module ActiveFedora
       # override activemodel so it doesn't trigger a load of all the attributes.
       # the callback methods seem to trigger this, which means just initing an object (after_init)
       # causes a load of all the datastreams.
-      def attribute_method?(attr_name) #:nodoc:
+      def attribute_method?(attr_name) # :nodoc:
         respond_to_without_attributes?(:attributes) && self.class.delegated_attributes.include?(attr_name)
       end
 

--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -1,5 +1,5 @@
 module ActiveFedora::Attributes
-  class PropertyBuilder < ActiveTriples::PropertyBuilder #:nodoc:
+  class PropertyBuilder < ActiveTriples::PropertyBuilder # :nodoc:
     def self.define_accessors(model, reflection, options = {})
       if reflection.multiple?
         super

--- a/lib/active_fedora/autosave_association.rb
+++ b/lib/active_fedora/autosave_association.rb
@@ -77,7 +77,7 @@ module ActiveFedora
 
     ASSOCIATION_TYPES = [:has_many, :belongs_to, :has_and_belongs_to_many, :directly_contains, :indirectly_contains, :is_a_container].freeze
 
-    module AssociationBuilderExtension #:nodoc:
+    module AssociationBuilderExtension # :nodoc:
       def self.valid_options
         [:autosave]
       end

--- a/lib/active_fedora/autosave_association.rb
+++ b/lib/active_fedora/autosave_association.rb
@@ -199,7 +199,7 @@ module ActiveFedora
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
         if new_record
-          association && association.target
+          association&.target
         elsif autosave
           association.target.find_all(&:changed_for_autosave?)
         else
@@ -220,7 +220,7 @@ module ActiveFedora
       # turned on for the association.
       def validate_single_association(reflection)
         association = association_instance_get(reflection.name)
-        record      = association && association.target
+        record      = association&.target
         association_valid?(reflection, record) if record
       end
 
@@ -306,7 +306,7 @@ module ActiveFedora
       # In addition, it will destroy the association if it was marked for destruction.
       def save_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
-        record      = association && association.load_target
+        record      = association&.load_target
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 

--- a/lib/active_fedora/callbacks.rb
+++ b/lib/active_fedora/callbacks.rb
@@ -227,7 +227,7 @@ module ActiveFedora
       define_model_callbacks :save, :create, :update, :destroy, :update_index
     end
 
-    def destroy(*) #:nodoc:
+    def destroy(*) # :nodoc:
       _run_destroy_callbacks { super }
     end
 
@@ -241,11 +241,11 @@ module ActiveFedora
         _run_save_callbacks { super }
       end
 
-      def _create_record(*) #:nodoc:
+      def _create_record(*) # :nodoc:
         _run_create_callbacks { super }
       end
 
-      def _update_record(*) #:nodoc:
+      def _update_record(*) # :nodoc:
         _run_update_callbacks { super }
       end
   end

--- a/lib/active_fedora/change_set.rb
+++ b/lib/active_fedora/change_set.rb
@@ -48,9 +48,7 @@ module ActiveFedora
         objects.each do |object|
           graph.query({ subject: object }).each do |statement|
             # Have to filter out Fedora triples.
-            unless FedoraStatement.new(statement).internal?
-              child_graphs << statement
-            end
+            child_graphs << statement unless FedoraStatement.new(statement).internal?
           end
         end
         child_graphs

--- a/lib/active_fedora/cleaner.rb
+++ b/lib/active_fedora/cleaner.rb
@@ -35,7 +35,7 @@ module ActiveFedora
     end
 
     def self.solr_connection
-      ActiveFedora::SolrService.instance && ActiveFedora::SolrService.instance.conn
+      ActiveFedora::SolrService.instance&.conn
     end
 
     def self.cleanout_solr

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -132,9 +132,7 @@ module ActiveFedora
         # Returns a suitable string representation for :has_model
         # @deprecated use to_rdf_representation instead
         def to_class_uri(attrs = nil)
-          if attrs
-            Deprecation.warn ActiveFedora::Core, "to_class_uri no longer acceps an argument"
-          end
+          Deprecation.warn ActiveFedora::Core, "to_class_uri no longer acceps an argument" if attrs
           to_rdf_representation
         end
         deprecation_deprecate to_class_uri: "use 'to_rdf_representation()' instead"

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -47,11 +47,9 @@ module ActiveFedora
     #   to.
     # @note This can only be run on an unpersisted resource.
     def uri=(uri)
-      if persisted?
-        raise AlreadyPersistedError, "You can not set a URI for a persisted ActiveFedora object."
-      else
-        @ldp_source = build_ldp_resource(self.class.uri_to_id(uri))
-      end
+      raise AlreadyPersistedError, "You can not set a URI for a persisted ActiveFedora object." if persisted?
+
+      @ldp_source = build_ldp_resource(self.class.uri_to_id(uri))
     end
 
     # Reloads the object from Fedora.
@@ -157,11 +155,8 @@ module ActiveFedora
       end
 
       def check_persistence
-        if destroyed?
-          raise ActiveFedora::ObjectNotFoundError, "Can't reload an object that has been destroyed"
-        else
-          raise ActiveFedora::ObjectNotFoundError, "Can't reload an object that hasn't been saved"
-        end
+        raise ActiveFedora::ObjectNotFoundError, "Can't reload an object that has been destroyed" if destroyed?
+        raise ActiveFedora::ObjectNotFoundError, "Can't reload an object that hasn't been saved"
       end
   end
 end

--- a/lib/active_fedora/core/fedora_id_translator.rb
+++ b/lib/active_fedora/core/fedora_id_translator.rb
@@ -4,9 +4,7 @@ module ActiveFedora::Core
     def self.call(id)
       id = URI::DEFAULT_PARSER.escape(id, '[]'.freeze)
       id = "/#{id}" unless id.start_with? SLASH
-      unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
-        id = ActiveFedora.fedora.base_path + id
-      end
+      id = ActiveFedora.fedora.base_path + id unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
       ActiveFedora.fedora.host + id
     end
   end

--- a/lib/active_fedora/errors.rb
+++ b/lib/active_fedora/errors.rb
@@ -1,4 +1,4 @@
-module ActiveFedora #:nodoc:
+module ActiveFedora # :nodoc:
   # Generic ActiveFedora exception class
   class ActiveFedoraError < StandardError
   end
@@ -37,7 +37,7 @@ module ActiveFedora #:nodoc:
   class AssociationTypeMismatch < ActiveFedoraError
   end
 
-  class AssociationNotFoundError < ConfigurationError #:nodoc:
+  class AssociationNotFoundError < ConfigurationError # :nodoc:
   end
 
   # Raised when an object is loaded from Fedora by an incompatible class
@@ -47,7 +47,7 @@ module ActiveFedora #:nodoc:
   # This error is raised when trying to destroy a parent instance in N:1 or 1:1 associations
   # (has_many, has_one) when there is at least 1 child associated instance.
   # ex: if @project.tasks.size > 0, DeleteRestrictionError will be raised when trying to destroy @project
-  class DeleteRestrictionError < ActiveFedoraError #:nodoc:
+  class DeleteRestrictionError < ActiveFedoraError # :nodoc:
     def initialize(name = nil)
       if name
         super("Cannot delete record because of dependent #{name}")

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -54,9 +54,7 @@ module ActiveFedora
     end
 
     def connection
-      @connection ||= begin
-        build_connection
-      end
+      @connection ||= build_connection
     end
 
     def clean_connection
@@ -99,9 +97,7 @@ module ActiveFedora
     end
 
     def validate_options
-      unless host.downcase.end_with?("/rest")
-        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
-      end
+      ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config" unless host.downcase.end_with?("/rest")
     end
 
     def ntriples_connection

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -111,7 +111,7 @@ module ActiveFedora
     end
 
     def content_changed?
-      return true if new_record? && !local_or_remote_content(false).blank?
+      return true if new_record? && local_or_remote_content(false).present?
       local_or_remote_content(false) != @ds_content
     end
 

--- a/lib/active_fedora/file/attributes.rb
+++ b/lib/active_fedora/file/attributes.rb
@@ -37,7 +37,7 @@ module ActiveFedora::File::Attributes
   end
 
   def has_content?
-    size && size > 0
+    size&.positive?
   end
 
   def empty?
@@ -46,12 +46,12 @@ module ActiveFedora::File::Attributes
 
   def create_date
     created = metadata.attributes["http://fedora.info/definitions/v4/repository#created"]
-    created && created.first
+    created&.first
   end
 
   def modified_date
     modified = metadata.attributes["http://fedora.info/definitions/v4/repository#lastModified"]
-    modified && modified.first
+    modified&.first
   end
 
   private

--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -107,10 +107,10 @@ module ActiveFedora
 
       begin
         fedora_yml = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
-          YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
-        else
-          YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
-        end
+                       YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
+                     else
+                       YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+                     end
       rescue Psych::SyntaxError => e
         raise "fedora.yml was found, but could not be parsed. " \
               "Error #{e.message}"
@@ -135,10 +135,10 @@ module ActiveFedora
 
       begin
         solr_yml = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
-          YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
-        else
-          YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
-        end
+                     YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
+                   else
+                     YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+                   end
       rescue StandardError
         raise("solr.yml was found, but could not be parsed.\n")
       end
@@ -191,12 +191,10 @@ module ActiveFedora
 
       # Last choice, check for the default config file
       config_path = ::File.join(ActiveFedora.root, "config", "#{config_type}.yml")
-      if ::File.file? config_path
-        ActiveFedora::Base.logger.warn "Using the default #{config_type}.yml that comes with active-fedora.  If you want to override this, pass the path to #{config_type}.yml to ActiveFedora - ie. ActiveFedora.init(:#{config_type}_config_path => '/path/to/#{config_type}.yml') - or set Rails.root and put #{config_type}.yml into \#{Rails.root}/config."
-        config_path
-      else
-        raise ConfigurationError, "Couldn't load #{config_type} config file!"
-      end
+      raise ConfigurationError, "Couldn't load #{config_type} config file!" unless ::File.file?(config_path)
+
+      ActiveFedora::Base.logger.warn "Using the default #{config_type}.yml that comes with active-fedora.  If you want to override this, pass the path to #{config_type}.yml to ActiveFedora - ie. ActiveFedora.init(:#{config_type}_config_path => '/path/to/#{config_type}.yml') - or set Rails.root and put #{config_type}.yml into \#{Rails.root}/config."
+      config_path
     end
 
     # Checks the existing fedora_config.path to see if there is a solr.yml there

--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -54,9 +54,7 @@ module ActiveFedora
     end
 
     def init(options = {})
-      if options.is_a?(String)
-        raise ArgumentError, "Calling ActiveFedora.init with a path as an argument has been removed.  Use ActiveFedora.init(:fedora_config_path=>#{options})"
-      end
+      raise ArgumentError, "Calling ActiveFedora.init with a path as an argument has been removed.  Use ActiveFedora.init(:fedora_config_path=>#{options})" if options.is_a?(String)
       reset!
       @config_options = options
       load_configs
@@ -108,7 +106,11 @@ module ActiveFedora
       end
 
       begin
-        fedora_yml = YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+        fedora_yml = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
+          YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
+        else
+          YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+        end
       rescue Psych::SyntaxError => e
         raise "fedora.yml was found, but could not be parsed. " \
               "Error #{e.message}"
@@ -132,7 +134,11 @@ module ActiveFedora
       end
 
       begin
-        solr_yml = YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+        solr_yml = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
+          YAML.safe_load(config_erb, permitted_classes: [], permitted_symbols: [], aliases: true)
+        else
+          YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
+        end
       rescue StandardError
         raise("solr.yml was found, but could not be parsed.\n")
       end
@@ -181,15 +187,13 @@ module ActiveFedora
         return config_path if ::File.file? config_path
       end
 
-      if ::File.file? "#{Dir.getwd}/config/#{config_type}.yml"
-        return "#{Dir.getwd}/config/#{config_type}.yml"
-      end
+      return "#{Dir.getwd}/config/#{config_type}.yml" if ::File.file? "#{Dir.getwd}/config/#{config_type}.yml"
 
       # Last choice, check for the default config file
       config_path = ::File.join(ActiveFedora.root, "config", "#{config_type}.yml")
       if ::File.file? config_path
         ActiveFedora::Base.logger.warn "Using the default #{config_type}.yml that comes with active-fedora.  If you want to override this, pass the path to #{config_type}.yml to ActiveFedora - ie. ActiveFedora.init(:#{config_type}_config_path => '/path/to/#{config_type}.yml') - or set Rails.root and put #{config_type}.yml into \#{Rails.root}/config."
-        return config_path
+        config_path
       else
         raise ConfigurationError, "Couldn't load #{config_type} config file!"
       end

--- a/lib/active_fedora/file_io.rb
+++ b/lib/active_fedora/file_io.rb
@@ -49,7 +49,7 @@ module ActiveFedora
 
       if amount.nil?
         read_to_buf(nil, buf) # read the entire file, returns buf
-      elsif amount < 0
+      elsif amount.negative?
         raise(ArgumentError, "negative length #{amount} given")
       elsif amount.zero?
         ''

--- a/lib/active_fedora/file_io.rb
+++ b/lib/active_fedora/file_io.rb
@@ -89,9 +89,7 @@ module ActiveFedora
     private
 
       def read_to_buf(amount, buf)
-        while (amount.nil? || buf.length < amount) && fill_buffer
-          buf << consume_buffer(amount.nil? ? nil : (amount - buf.length))
-        end
+        buf << consume_buffer(amount.nil? ? nil : (amount - buf.length)) while (amount.nil? || buf.length < amount) && fill_buffer
         buf
       end
 

--- a/lib/active_fedora/files_hash.rb
+++ b/lib/active_fedora/files_hash.rb
@@ -1,7 +1,7 @@
 module ActiveFedora
   class FilesHash < AssociationHash
-    def initialize(model)
-      @base = model
+    def initialize(model, reflections = nil)
+      super
     end
 
     def reflections

--- a/lib/active_fedora/fixity_service.rb
+++ b/lib/active_fedora/fixity_service.rb
@@ -83,7 +83,7 @@ module ActiveFedora
       # See https://jira.duraspace.org/browse/FCREPO-1247
       # @param [String] uri
       def encoded_url(uri)
-        if uri =~ /fcr:versions/
+        if /fcr:versions/.match?(uri)
           uri.gsub(/fcr:versions/, "fcr%3aversions")
         else
           uri

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -47,9 +47,11 @@ module ActiveFedora
     end
 
     # Updates Solr index with self.
+    # rubocop:disable Naming/VariableName
     def update_index
       SolrService.add(to_solr, softCommit: true)
     end
+    # rubocop:enable Naming/VariableName
 
     protected
 
@@ -91,6 +93,7 @@ module ActiveFedora
                             end
         end
 
+        # rubocop:disable Naming/VariableName
         # @param [Integer] batch_size - The number of Fedora objects to process for each SolrService.add call. Default 50.
         # @param [Boolean] softCommit - Do we perform a softCommit when we add the to_solr objects to SolrService. Default true.
         # @param [Boolean] progress_bar - If true output progress bar information. Default false.
@@ -113,7 +116,7 @@ module ActiveFedora
               batch.clear
             end
 
-            progress_bar_controller.increment if progress_bar_controller
+            progress_bar_controller&.increment
           end
 
           if batch.present?
@@ -121,11 +124,12 @@ module ActiveFedora
             batch.clear
           end
 
-          if final_commit
-            logger.debug "Solr hard commit..."
-            SolrService.commit
-          end
+          return unless final_commit
+
+          logger.debug "Solr hard commit..."
+          SolrService.commit
         end
+        # rubocop:enable Naming/VariableName
 
         def descendant_uris(uri, exclude_uri: false)
           DescendantFetcher.new(uri, exclude_self: exclude_uri).descendant_and_self_uris

--- a/lib/active_fedora/indexing/default_descriptors.rb
+++ b/lib/active_fedora/indexing/default_descriptors.rb
@@ -104,11 +104,9 @@ module ActiveFedora
         def dateable_converter
           lambda do |_type|
             lambda do |val|
-              begin
-                iso8601_date(Date.parse(val))
-              rescue ArgumentError
-                nil
-              end
+              iso8601_date(Date.parse(val))
+            rescue ArgumentError
+              nil
             end
           end
         end

--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -23,7 +23,7 @@ module ActiveFedora
       HAS_MODEL_PREDICATE = ActiveFedora::RDF::Fcrepo::Model.hasModel
 
       class_attribute :default_priority_models, instance_accessor: false
-      self.default_priority_models = %w(Hydra::AccessControl Hydra::AccessControl::Permissions).freeze
+      self.default_priority_models = %w[Hydra::AccessControl Hydra::AccessControl::Permissions].freeze
 
       attr_reader :uri, :priority_models
 

--- a/lib/active_fedora/indexing/descriptor.rb
+++ b/lib/active_fedora/indexing/descriptor.rb
@@ -37,7 +37,7 @@ module ActiveFedora
         end
 
         def converter(field_type)
-          @converter.call(field_type) if @converter
+          @converter&.call(field_type)
         end
     end
   end

--- a/lib/active_fedora/indexing/field_mapper.rb
+++ b/lib/active_fedora/indexing/field_mapper.rb
@@ -122,11 +122,9 @@ module ActiveFedora
         # search through the descriptors (class attribute) until a module is found that responds to index_type, then call it.
         def index_type_macro(index_type)
           klass = self.class.descriptors.find { |descriptor_klass| descriptor_klass.respond_to? index_type }
-          if klass
-            klass.send(index_type)
-          else
-            raise UnknownIndexMacro, "Unable to find `#{index_type}' in #{self.class.descriptors}"
-          end
+          raise UnknownIndexMacro, "Unable to find `#{index_type}' in #{self.class.descriptors}" unless klass
+
+          klass.send(index_type)
         end
 
         def extract_type(value)

--- a/lib/active_fedora/indexing_service.rb
+++ b/lib/active_fedora/indexing_service.rb
@@ -47,13 +47,13 @@ module ActiveFedora
     protected
 
       def c_time
-        c_time = object.create_date.present? ? object.create_date : DateTime.now
+        c_time = object.create_date.presence || DateTime.now
         c_time = DateTime.parse(c_time) unless c_time.is_a?(DateTime)
         c_time
       end
 
       def m_time
-        m_time = object.modified_date.present? ? object.modified_date : DateTime.now
+        m_time = object.modified_date.presence || DateTime.now
         m_time = DateTime.parse(m_time) unless m_time.is_a?(DateTime)
         m_time
       end

--- a/lib/active_fedora/inheritance.rb
+++ b/lib/active_fedora/inheritance.rb
@@ -14,9 +14,7 @@ module ActiveFedora
       def base_class
         return File if self <= File
 
-        unless self <= Base
-          raise ActiveFedoraError, "#{name} doesn't belong in a hierarchy descending from ActiveFedora"
-        end
+        raise ActiveFedoraError, "#{name} doesn't belong in a hierarchy descending from ActiveFedora" unless self <= Base
 
         if self == Base || superclass == Base || superclass.abstract_class?
           self

--- a/lib/active_fedora/ldp_resource.rb
+++ b/lib/active_fedora/ldp_resource.rb
@@ -23,8 +23,8 @@ module ActiveFedora
 
     private
 
-    def response_as_graph(resp)
-      graph_class.new(subject_uri, data: resp.graph.data)
-    end
+      def response_as_graph(resp)
+        graph_class.new(subject_uri, data: resp.graph.data)
+      end
   end
 end

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -147,9 +147,11 @@ module ActiveFedora
       # @param attrs [Hash] attributes read from Solr
       # @return [Hash] the adapted attributes
       def adapt_attributes(attrs)
-        self.class.attribute_names.index_with do |attribute_name|
-          adapt_attribute_value(attrs, attribute_name)
+        result = {}
+        self.class.attribute_names.each do |attribute_name|
+          result[attribute_name] = adapt_attribute_value(attrs, attribute_name)
         end
+        result
       end
 
       # Adapts a single attribute from the given attributes hash to fit the data

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -194,7 +194,7 @@ module ActiveFedora
       # @return [Object] the adapted value
       def adapt_single_attribute_value(value, attribute_name)
         if value && date_attribute?(attribute_name)
-          return nil unless value.present?
+          return nil if value.blank?
           DateTime.parse(value)
         else
           value

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -147,8 +147,8 @@ module ActiveFedora
       # @param attrs [Hash] attributes read from Solr
       # @return [Hash] the adapted attributes
       def adapt_attributes(attrs)
-        self.class.attribute_names.each_with_object({}) do |attribute_name, new_attributes|
-          new_attributes[attribute_name] = adapt_attribute_value(attrs, attribute_name)
+        self.class.attribute_names.index_with do |attribute_name|
+          adapt_attribute_value(attrs, attribute_name)
         end
       end
 

--- a/lib/active_fedora/model_classifier.rb
+++ b/lib/active_fedora/model_classifier.rb
@@ -69,9 +69,9 @@ module ActiveFedora
       def class_exists?(class_name)
         return false if class_name.empty?
         klass = class_name.constantize
-        return klass.is_a?(Class)
+        klass.is_a?(Class)
       rescue NameError
-        return false
+        false
       end
   end
 end

--- a/lib/active_fedora/nested_attributes.rb
+++ b/lib/active_fedora/nested_attributes.rb
@@ -192,16 +192,14 @@ module ActiveFedora
         elsif !reject_new_record?(association_name, attributes)
           assignable_attributes = attributes.except(*UNASSIGNABLE_KEYS)
 
-          if existing_record && existing_record.new_record?
+          if existing_record&.new_record?
             existing_record.assign_attributes(assignable_attributes)
             association(association_name).initialize_attributes(existing_record)
           else
             method = "build_#{association_name}"
-            if respond_to?(method)
-              send(method, assignable_attributes)
-            else
-              raise ArgumentError, "Cannot build association `#{association_name}'. Are you trying to build a polymorphic one-to-one association?"
-            end
+            raise ArgumentError, "Cannot build association `#{association_name}'. Are you trying to build a polymorphic one-to-one association?" unless respond_to?(method)
+
+            send(method, assignable_attributes)
           end
         end
       end

--- a/lib/active_fedora/nested_attributes.rb
+++ b/lib/active_fedora/nested_attributes.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/blank'
 
 module ActiveFedora
-  module NestedAttributes #:nodoc:
+  module NestedAttributes # :nodoc:
     class TooManyRecords < RuntimeError
     end
 
@@ -160,7 +160,7 @@ module ActiveFedora
 
       # Attribute hash keys that should not be assigned as normal attributes.
       # These hash keys are nested attributes implementation details.
-      UNASSIGNABLE_KEYS = %w(id _destroy).freeze
+      UNASSIGNABLE_KEYS = %w[id _destroy].freeze
 
       # Assigns the given attributes to the association.
       #
@@ -182,7 +182,7 @@ module ActiveFedora
         attributes = attributes.with_indifferent_access
         existing_record = send(association_name)
 
-        if (options[:update_only] || !attributes['id'].blank?) && existing_record &&
+        if (options[:update_only] || attributes['id'].present?) && existing_record &&
            (options[:update_only] || existing_record.id.to_s == attributes['id'].to_s)
           assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
@@ -209,13 +209,9 @@ module ActiveFedora
       def assign_nested_attributes_for_collection_association(association_name, attributes_collection)
         options = nested_attributes_options[association_name]
 
-        if attributes_collection.respond_to?(:permitted?)
-          attributes_collection = attributes_collection.to_h
-        end
+        attributes_collection = attributes_collection.to_h if attributes_collection.respond_to?(:permitted?)
 
-        unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
-          raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
-        end
+        raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})" unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
 
         check_record_limit!(options[:limit], attributes_collection)
 
@@ -242,16 +238,12 @@ module ActiveFedora
           attributes = attributes.with_indifferent_access
 
           if attributes['id'].blank?
-            unless reject_new_record?(association_name, attributes)
-              association.build(attributes.except(*UNASSIGNABLE_KEYS))
-            end
+            association.build(attributes.except(*UNASSIGNABLE_KEYS)) unless reject_new_record?(association_name, attributes)
 
           elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes['id'].to_s }
             association.send(:add_record_to_target_with_callbacks, existing_record) if !association.loaded? && !call_reject_if(association_name, attributes)
 
-            unless call_reject_if(association_name, attributes)
-              assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
-            end
+            assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
           else
             raise_nested_attributes_record_not_found!(association_name, attributes['id'])

--- a/lib/active_fedora/null_logger.rb
+++ b/lib/active_fedora/null_logger.rb
@@ -1,6 +1,8 @@
 module ActiveFedora
   class NullLogger < Logger
+    # rubocop:disable Lint/MissingSuper
     def initialize(*); end
+    # rubocop:enable Lint/MissingSuper
 
     # allows all the usual logger method calls (warn, info, error, etc.)
     def add(*); end

--- a/lib/active_fedora/orders/list_node.rb
+++ b/lib/active_fedora/orders/list_node.rb
@@ -1,8 +1,7 @@
 module ActiveFedora::Orders
   class ListNode
     attr_reader :rdf_subject
-    attr_accessor :prev, :next, :target
-    attr_writer :next_uri, :prev_uri
+    attr_writer :prev, :next, :target, :next_uri, :prev_uri
     attr_accessor :proxy_in, :proxy_for
     def initialize(node_cache, rdf_subject, graph = RDF::Repository.new)
       @rdf_subject = rdf_subject
@@ -120,7 +119,7 @@ module ActiveFedora::Orders
     end
 
     def new_record?
-      @target && @target.new_record?
+      @target&.new_record?
     end
 
     private

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -111,14 +111,14 @@ module ActiveFedora
       # @param [ListNode] node Node to delete
       def delete_node(node)
         node = ordered_reader.find { |x| x == node }
-        if node
-          prev_node = node.prev
-          next_node = node.next
-          node.prev.next = next_node
-          node.next.prev = prev_node
-          @changed = true
-          node
-        end
+        return unless node
+
+        prev_node = node.prev
+        next_node = node.next
+        node.prev.next = next_node
+        node.next.prev = prev_node
+        @changed = true
+        node
       end
 
       # @param [Integer] loc Index of node to delete.

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -35,12 +35,10 @@ module ActiveFedora
       #   empty, tail.prev is the first element.
       def tail
         @tail ||=
-          begin
-            if tail_subject
-              TailSentinel.new(self, prev_node: build_node(tail_subject))
-            else
-              head.next
-            end
+          if tail_subject
+            TailSentinel.new(self, prev_node: build_node(tail_subject))
+          else
+            head.next
           end
       end
 
@@ -173,9 +171,7 @@ module ActiveFedora
       #   the first.
       def proxy_in
         proxies = to_a.map(&:proxy_in_id).compact.uniq
-        if proxies.length > 1
-          ActiveFedora::Base.logger.warn "WARNING: List contains nodes aggregated under different URIs. Returning only the first."
-        end
+        ActiveFedora::Base.logger.warn "WARNING: List contains nodes aggregated under different URIs. Returning only the first." if proxies.length > 1
         proxies.first
       end
 
@@ -208,9 +204,7 @@ module ActiveFedora
 
         def new_node_subject
           node = ::RDF::URI("##{::RDF::Node.new.id}")
-          while node_cache.key?(node)
-            node = ::RDF::URI("##{::RDF::Node.new.id}")
-          end
+          node = ::RDF::URI("##{::RDF::Node.new.id}") while node_cache.key?(node)
           node
         end
 

--- a/lib/active_fedora/orders/target_proxy.rb
+++ b/lib/active_fedora/orders/target_proxy.rb
@@ -32,7 +32,7 @@ module ActiveFedora
       # the index is out of range.
       def delete_at(loc)
         result = association.delete_at(loc)
-        result.target if result
+        result&.target
       end
 
       # Deletes all items from self that are equal to obj.

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -10,7 +10,7 @@ module ActiveFedora
 
     def default_sort_params
       [ActiveFedora.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date) +
-       ' asc']
+        ' asc']
     end
   end
 end

--- a/lib/active_fedora/rdf/fcrepo.rb
+++ b/lib/active_fedora/rdf/fcrepo.rb
@@ -26,6 +26,7 @@ module ActiveFedora::RDF
            subClassOf: "info:fedora/fedora-system:def/model#FedoraObject".freeze,
            type: "info:fedora/fedora-system:def/model#FedoraObject".freeze
     end
+
     class Model < ::RDF::StrictVocabulary("info:fedora/fedora-system:def/model#")
       # Class definitions
       term :FedoraObject,
@@ -176,6 +177,7 @@ module ActiveFedora::RDF
                range: "xsd:boolean".freeze,
                type: "rdf:Property".freeze
     end
+
     class RelsExt < ::RDF::StrictVocabulary("info:fedora/fedora-system:def/relations-external#")
       # Property definitions
       property :fedoraRelationship,
@@ -293,6 +295,7 @@ module ActiveFedora::RDF
                "owl:inverseOf" => %(info:fedora/fedora-system:def/relations-external#hasSubset).freeze,
                type: "rdf:Property".freeze
     end
+
     class View < ::RDF::StrictVocabulary("info:fedora/fedora-system:def/view#")
       property :disseminates,
                comment: %(A property used to indicate that an object contains a datastream).freeze,

--- a/lib/active_fedora/rdf/field_map.rb
+++ b/lib/active_fedora/rdf/field_map.rb
@@ -35,7 +35,6 @@ module ActiveFedora::RDF
         @index_field_config = index_field_config
         @object             = object
         @name               = name
-        self
       end
 
       def build

--- a/lib/active_fedora/rdf/persistence.rb
+++ b/lib/active_fedora/rdf/persistence.rb
@@ -19,7 +19,7 @@ module ActiveFedora
 
       # Overrides ActiveTriples::Resource
       def persist!
-        return false unless datastream && datastream.respond_to?(:save)
+        return false unless datastream&.respond_to?(:save)
         @persisted ||= datastream.save
       end
 

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -183,9 +183,8 @@ module ActiveFedora
       end
 
       def check_validity_of_inverse!
-        unless polymorphic?
-          raise InverseOfAssociationNotFoundError, self if has_inverse? && inverse_of.nil?
-        end
+        return if polymorphic?
+        raise InverseOfAssociationNotFoundError, self if has_inverse? && inverse_of.nil?
       end
 
       def alias_candidate(name)
@@ -212,6 +211,7 @@ module ActiveFedora
 
       attr_reader :active_fedora
 
+      # rubocop:disable Lint/MissingSuper
       def initialize(name, scope, options, active_fedora)
         @name = name
         @scope = scope
@@ -220,6 +220,7 @@ module ActiveFedora
         @klass         = options[:anonymous_class]
         @automatic_inverse_of = nil
       end
+      # rubocop:enable Lint/MissingSuper
 
       def autosave=(autosave)
         @options[:autosave] = autosave
@@ -441,7 +442,7 @@ module ActiveFedora
             "#{name.to_s.singularize}_ids"
           elsif options[:as]
             "#{options[:as]}_id"
-          elsif inverse_of && inverse_of.collection?
+          elsif inverse_of&.collection?
             # for a has_many that is the inverse of a has_and_belongs_to_many
             "#{options[:inverse_of].to_s.singularize}_ids"
           else

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -184,9 +184,7 @@ module ActiveFedora
 
       def check_validity_of_inverse!
         unless polymorphic?
-          if has_inverse? && inverse_of.nil?
-            raise InverseOfAssociationNotFoundError, self
-          end
+          raise InverseOfAssociationNotFoundError, self if has_inverse? && inverse_of.nil?
         end
       end
 
@@ -262,7 +260,7 @@ module ActiveFedora
 
     # Holds all the meta-data about an association as it was specified in the
     # Active Record class.
-    class AssociationReflection < MacroReflection #:nodoc:
+    class AssociationReflection < MacroReflection # :nodoc:
       attr_accessor :parent_reflection # Reflection
 
       def initialize(name, scope, options, active_fedora)
@@ -295,9 +293,7 @@ module ActiveFedora
       end
 
       def solr_key
-        @solr_key ||= begin
-          ActiveFedora.index_field_mapper.solr_name(predicate_for_solr, :symbol)
-        end
+        @solr_key ||= ActiveFedora.index_field_mapper.solr_name(predicate_for_solr, :symbol)
       end
 
       def check_validity!
@@ -314,7 +310,7 @@ module ActiveFedora
       def collect_join_chain
         [self]
       end
-      alias chain collect_join_chain # TODO Remove alias, See https://github.com/samvera/active_fedora/issues/1347
+      alias chain collect_join_chain # TODO: Remove alias, See https://github.com/samvera/active_fedora/issues/1347
 
       def has_inverse?
         inverse_name

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -103,9 +103,7 @@ module ActiveFedora
     def search_by_id(id, opts = {})
       opts[:rows] = 1
       result = search_with_conditions({ id: id }, opts)
-      if result.empty?
-        raise ActiveFedora::ObjectNotFoundError, "Object '#{id}' not found in solr"
-      end
+      raise ActiveFedora::ObjectNotFoundError, "Object '#{id}' not found in solr" if result.empty?
       result.first
     end
 
@@ -118,11 +116,9 @@ module ActiveFedora
       cast = opts.delete(:cast)
       search_in_batches(conditions, opts.merge(fl: ActiveFedora.id_field)) do |group|
         group.each do |hit|
-          begin
-            yield(load_from_fedora(hit[ActiveFedora.id_field], cast))
-          rescue Ldp::Gone, ActiveFedora::ObjectNotFoundError
-            ActiveFedora::Base.logger.error "Although #{hit[ActiveFedora.id_field]} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch."
-          end
+          yield(load_from_fedora(hit[ActiveFedora.id_field], cast))
+        rescue Ldp::Gone, ActiveFedora::ObjectNotFoundError
+          ActiveFedora::Base.logger.error "Although #{hit[ActiveFedora.id_field]} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch."
         end
       end
     end
@@ -194,9 +190,7 @@ module ActiveFedora
           ActiveFedora::Base
         else
           resource_class = ActiveFedora.model_mapper.classifier(resource).best_model
-          unless equivalent_class?(resource_class)
-            raise ActiveFedora::ModelMismatch, "Expected #{@klass}. Got: #{resource_class}"
-          end
+          raise ActiveFedora::ModelMismatch, "Expected #{@klass}. Got: #{resource_class}" unless equivalent_class?(resource_class)
           resource_class
         end
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -141,7 +141,7 @@ module ActiveFedora
       opts[:q] = create_query(conditions)
       opts[:qt] = @klass.solr_query_handler
       # set default sort to created date ascending
-      opts[:sort] = @klass.default_sort_params unless opts[:sort].present?
+      opts[:sort] = @klass.default_sort_params if opts[:sort].blank?
 
       batch_size = opts.delete(:batch_size) || 1000
       select_path = ActiveFedora::SolrService.select_path

--- a/lib/active_fedora/relation/spawn_methods.rb
+++ b/lib/active_fedora/relation/spawn_methods.rb
@@ -3,7 +3,7 @@ require 'active_fedora/relation/merger'
 module ActiveFedora
   module SpawnMethods
     # This is overridden by Associations::CollectionProxy
-    def spawn #:nodoc:
+    def spawn # :nodoc:
       clone
     end
 

--- a/lib/active_fedora/scoping.rb
+++ b/lib/active_fedora/scoping.rb
@@ -10,11 +10,11 @@ module ActiveFedora
     end
 
     module ClassMethods
-      def current_scope #:nodoc:
+      def current_scope # :nodoc:
         ScopeRegistry.value_for(:current_scope, self)
       end
 
-      def current_scope=(scope) #:nodoc:
+      def current_scope=(scope) # :nodoc:
         ScopeRegistry.set_value_for(:current_scope, self, scope)
       end
 

--- a/lib/active_fedora/scoping/default.rb
+++ b/lib/active_fedora/scoping/default.rb
@@ -46,7 +46,7 @@ module ActiveFedora
           super || default_scopes.any? || respond_to?(:default_scope)
         end
 
-        def before_remove_const #:nodoc:
+        def before_remove_const # :nodoc:
           self.current_scope = nil
         end
 
@@ -110,9 +110,7 @@ module ActiveFedora
           def build_default_scope(base_rel = nil) # :nodoc:
             return if abstract_class?
 
-            if default_scope_override.nil?
-              self.default_scope_override = !Base.is_a?(method(:default_scope).owner)
-            end
+            self.default_scope_override = !Base.is_a?(method(:default_scope).owner) if default_scope_override.nil?
 
             if default_scope_override
               # The user has defined their own default scope method, so call that

--- a/lib/active_fedora/scoping/named.rb
+++ b/lib/active_fedora/scoping/named.rb
@@ -138,9 +138,7 @@ module ActiveFedora
         #   Article.published.featured.latest_article
         #   Article.featured.titles
         def scope(name, body, &block)
-          unless body.respond_to?(:call)
-            raise ArgumentError, 'The scope body needs to be callable.'
-          end
+          raise ArgumentError, 'The scope body needs to be callable.' unless body.respond_to?(:call)
 
           if dangerous_class_method?(name)
             raise ArgumentError, "You tried to define a scope named \"#{name}\" " \

--- a/lib/active_fedora/serialization.rb
+++ b/lib/active_fedora/serialization.rb
@@ -1,4 +1,4 @@
-module ActiveFedora #:nodoc:
+module ActiveFedora # :nodoc:
   # = Active Fedora Serialization
   module Serialization
     extend ActiveSupport::Concern

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -32,9 +32,7 @@ module ActiveFedora
       def instance
         # Register Solr
 
-        unless ActiveFedora::RuntimeRegistry.solr_service
-          register(ActiveFedora.solr_config)
-        end
+        register(ActiveFedora.solr_config) unless ActiveFedora::RuntimeRegistry.solr_service
 
         ActiveFedora::RuntimeRegistry.solr_service
       end

--- a/lib/active_fedora/versions_graph.rb
+++ b/lib/active_fedora/versions_graph.rb
@@ -2,9 +2,7 @@ module ActiveFedora
   class VersionsGraph < ::RDF::Graph
     def all(opts = {})
       versions = fedora_versions
-      unless opts[:include_auto_save]
-        versions.reject! { |version| version.label =~ /auto/ }
-      end
+      versions.reject! { |version| version.label =~ /auto/ } unless opts[:include_auto_save]
       versions.sort_by { |version| DateTime.parse(version.created) }
     rescue ArgumentError, NoMethodError
       raise ActiveFedora::VersionLacksCreateDate

--- a/lib/active_fedora/with_metadata.rb
+++ b/lib/active_fedora/with_metadata.rb
@@ -22,7 +22,7 @@ module ActiveFedora
       return unless super && !new_record?
       # TODOs captured as https://github.com/samvera/active_fedora/issues/1331
       metadata_node.metadata_uri = described_by # TODO: only necessary if the URI was < > before
-      metadata_node.save # TODO if changed?
+      metadata_node.save # TODO: if changed?
     end
 
     module ClassMethods

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -71,7 +71,7 @@ module ActiveFedora
         end
 
         def server_managed_properties
-          @server_managed_properties ||= properties.select { |k,v| v[:server_managed] }.keys.map(&:to_sym)
+          @server_managed_properties ||= properties.select { |_k, v| v[:server_managed] }.keys.map(&:to_sym)
         end
 
         class << self

--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -14,7 +14,7 @@ namespace :active_fedora do
 
     YARD::Rake::YardocTask.new(:doc) do |yt|
       yt.files   = Dir.glob(File.join(project_root, 'lib', '**', '*.rb')) +
-                   [ '-', File.join(project_root, 'README.md')]
+                   ['-', File.join(project_root, 'README.md')]
       yt.options = ['--output-dir', doc_destination, '--readme', 'README.md']
     end
   rescue LoadError

--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -19,7 +19,7 @@ namespace :active_fedora do
     end
   rescue LoadError
     desc "Generate YARD Documentation"
-    task :doc do
+    task doc: :environment do
       abort "Please install the YARD gem to generate rdoc."
     end
   end
@@ -42,7 +42,7 @@ namespace :active_fedora do
   end
 
   desc "CI build"
-  task :ci do
+  task ci: :environment do
     Rake::Task['active_fedora:rubocop'].invoke unless ENV['NO_RUBOCOP']
     ENV['environment'] = "test"
     with_test_server do
@@ -51,7 +51,7 @@ namespace :active_fedora do
   end
 
   desc "Execute specs with coverage"
-  task :coverage do
+  task coverage: :environment do
     # Put spec opts in a file named .rspec in root
     ruby_engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : "ruby"
     ENV['COVERAGE'] = 'true' unless ruby_engine == 'jruby'
@@ -59,7 +59,7 @@ namespace :active_fedora do
   end
 
   desc "Execute specs with coverage"
-  task :spec do
+  task spec: :environment do
     with_test_server do
       Rake::Task["active_fedora:rspec"].invoke
     end

--- a/spec/integration/associations/rdf_spec.rb
+++ b/spec/integration/associations/rdf_spec.rb
@@ -5,6 +5,7 @@ describe "rdf associations" do
     before do
       class Foo < ActiveFedora::Base
       end
+
       class Library < ActiveFedora::Base
         has_and_belongs_to_many :foos, predicate: ::RDF::URI('http://example.com')
       end
@@ -38,8 +39,10 @@ describe "rdf associations" do
     before do
       class Foo < ActiveFedora::Base
       end
+
       class Bar < ActiveFedora::Base
       end
+
       class Library < ActiveFedora::Base
         has_and_belongs_to_many :foos, predicate: ::RDF::URI('http://example.com')
         has_and_belongs_to_many :bars, predicate: ::RDF::URI('http://example.com')

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -59,11 +59,10 @@ describe ActiveFedora::Base do
     before do
       class EnsureBanana
         def self.validate!(_reflection, object)
-          unless object.try(:banana?)
-            raise ActiveFedora::AssociationTypeMismatch, "#{object} must be a banana"
-          end
+          raise ActiveFedora::AssociationTypeMismatch, "#{object} must be a banana" unless object.try(:banana?)
         end
       end
+
       class FooThing < ActiveFedora::Base
         attr_accessor :banana
         has_many :bars, class_name: 'BarThing', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, as: :foothing, type_validator: EnsureBanana
@@ -442,6 +441,7 @@ describe ActiveFedora::Base do
       class Course < ActiveFedora::Base
         has_and_belongs_to_many :textbooks, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
       end
+
       class Textbook < ActiveFedora::Base
         has_many :courses, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
       end
@@ -513,6 +513,7 @@ describe ActiveFedora::Base do
 
           def say_hi(_var); end
         end
+
         class Page < ActiveFedora::Base
           has_many :library_books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
         end
@@ -545,6 +546,7 @@ describe ActiveFedora::Base do
         class LibraryBook < ActiveFedora::Base
           has_many :pages, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, after_remove: :say_hi
         end
+
         class Page < ActiveFedora::Base
           belongs_to :library_book, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
         end
@@ -573,6 +575,7 @@ describe ActiveFedora::Base do
         class Bauble < ActiveFedora::Base
           belongs_to :media_object, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
         end
+
         class MediaObject < ActiveFedora::Base
           has_many :baubles
         end
@@ -592,6 +595,7 @@ describe ActiveFedora::Base do
         class MasterFile < ActiveFedora::Base
           belongs_to :media_object, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
         end
+
         class MediaObject < ActiveFedora::Base
           has_many :parts, class_name: 'MasterFile'
         end
@@ -612,6 +616,7 @@ describe ActiveFedora::Base do
         class Bauble < ActiveFedora::Base
           belongs_to :media_object, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
         end
+
         class MediaObject < ActiveFedora::Base
           has_many :baubles, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasEquivalent
         end
@@ -634,12 +639,15 @@ describe ActiveFedora::Base do
         class Novel < ActiveFedora::Base
           has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
+
         class TextBook < ActiveFedora::Base
           has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
+
         class Text < ActiveFedora::Base
           has_many :books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end
+
         class Image < ActiveFedora::Base
           has_many :books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
         end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -282,14 +282,14 @@ describe ActiveFedora::Base do
         end
 
         it "has a count once it has been saved" do
-          @book_2 = Book.create
-          @library.books << @book << @book_2
+          @book2 = Book.create
+          @library.books << @book << @book2
           @library.save
 
           @library2 = Library.find(@library.id)
           expect(@library2.books.size).to eq 2
-          @book_2.reload
-          @book_2.delete
+          @book2.reload
+          @book2.delete
         end
 
         it "respects the :class_name parameter" do

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -107,6 +107,7 @@ describe ActiveFedora::Base do
       class ExampleSchema < ActiveTriples::Schema
         property :title, predicate: RDF::Vocab::DC.title
       end
+
       class ExampleBase < ActiveFedora::Base
         apply_schema ExampleSchema, ActiveFedora::SchemaIndexingStrategy.new(ActiveFedora::Indexers::GlobalIndexer.new(:symbol))
       end
@@ -176,6 +177,7 @@ describe ActiveFedora::Base do
     before do
       class TestResource < ActiveTriples::Resource
       end
+
       class TestBase < ActiveFedora::Base
         def self.resource_class_factory
           TestResource

--- a/spec/integration/basic_contains_association_spec.rb
+++ b/spec/integration/basic_contains_association_spec.rb
@@ -43,6 +43,7 @@ describe ActiveFedora::Associations::BasicContainsAssociation do
       class Thing < ActiveFedora::Base
         property :title, predicate: ::RDF::Vocab::DC.title
       end
+
       class Source < ActiveFedora::Base
         is_a_container class_name: 'Thing'
       end

--- a/spec/integration/belongs_to_association_spec.rb
+++ b/spec/integration/belongs_to_association_spec.rb
@@ -9,6 +9,7 @@ describe ActiveFedora::Base do
     class Book < ActiveFedora::Base
       belongs_to :library, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasConstituent
     end
+
     class SpecialInheritedBook < Book
       def assert_content_model
         self.has_model = [self.class.to_s, self.class.superclass.to_s]

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -5,6 +5,7 @@ describe ActiveFedora::Base do
     class Library < ActiveFedora::Base
       has_many :books
     end
+
     class Book < ActiveFedora::Base
       belongs_to :library, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasMember
     end
@@ -125,6 +126,7 @@ describe ActiveFedora::Base do
       before do
         class Item < ActiveFedora::Base
         end
+
         class SpecContainer < ActiveFedora::Base
           has_many :items
         end
@@ -146,6 +148,7 @@ describe ActiveFedora::Base do
         class Item < ActiveFedora::Base
           has_and_belongs_to_many :container, predicate: ::RDF::Vocab::DC.extent, class_name: 'Foo::Container'
         end
+
         module Foo
           class Container < ActiveFedora::Base
             has_many :items

--- a/spec/integration/direct_container_spec.rb
+++ b/spec/integration/direct_container_spec.rb
@@ -77,6 +77,7 @@ describe "Direct containers" do
     context "when the class is a subclass of ActiveFedora::File" do
       before do
         class SubFile < ActiveFedora::File; end
+
         class FooHistory < ActiveFedora::Base
           directly_contains :files, has_member_relation: ::RDF::URI.new("http://example.com/hasFiles"), class_name: 'SubFile'
         end

--- a/spec/integration/directly_contains_one_association_spec.rb
+++ b/spec/integration/directly_contains_one_association_spec.rb
@@ -11,6 +11,7 @@ describe ActiveFedora::Base do
     class FileWithMetadata < ActiveFedora::File
       include ActiveFedora::WithMetadata
     end
+
     class AlternativeFileWithMetadata < ActiveFedora::File
       include ActiveFedora::WithMetadata
     end

--- a/spec/integration/file_spec.rb
+++ b/spec/integration/file_spec.rb
@@ -211,7 +211,7 @@ describe ActiveFedora::File do
             test_object.save!
           end
           it "raises a HTTP redirect too deep Error" do
-            expect { test_object.three.stream.each { |chunk| chunk } }.to raise_error('HTTP redirect too deep')
+            expect { test_object.three.stream.each }.to raise_error('HTTP redirect too deep')
           end
         end
       end

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -169,6 +169,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
       class Permissionable1 < ActiveFedora::Base
         has_many :permissions, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, inverse_of: :access_to
       end
+
       class Permissionable2 < ActiveFedora::Base
         has_many :permissions, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, inverse_of: :access_to
       end
@@ -248,6 +249,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
       class Item < ActiveFedora::Base
         has_many :components
       end
+
       class Component < ActiveFedora::Base
         belongs_to :item, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
       end
@@ -314,6 +316,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
             has_many :components
             property :title, predicate: ::RDF::Vocab::DC.title
           end
+
           class Component < ActiveFedora::Base
             belongs_to :item, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
             property :description, predicate: ::RDF::Vocab::DC.description
@@ -351,6 +354,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
               has_many :books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
               has_and_belongs_to_many :contents, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
             end
+
             class Text < ActiveFedora::Base
               has_many :books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, class_name: 'ActiveFedora::Base'
             end

--- a/spec/integration/indexing/descendant_fetcher_spec.rb
+++ b/spec/integration/indexing/descendant_fetcher_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ActiveFedora::Indexing::DescendantFetcher do
     class Thing < ActiveFedora::Base
       property :title, predicate: ::RDF::Vocab::DC.title
     end
+
     class Source < ActiveFedora::Base
       is_a_container class_name: 'Thing'
     end

--- a/spec/integration/indirect_container_spec.rb
+++ b/spec/integration/indirect_container_spec.rb
@@ -5,6 +5,7 @@ describe "Indirect containers" do
     class RelatedObject < ActiveFedora::Base
       property :title, predicate: ::RDF::Vocab::DC.title, multiple: false
     end
+
     class Proxy < ActiveFedora::Base
       belongs_to :proxy_for, predicate: ::RDF::URI.new('http://www.openarchives.org/ore/terms/proxyFor'), class_name: 'ActiveFedora::Base'
     end
@@ -216,6 +217,7 @@ describe "Indirect containers" do
         class Different < ActiveFedora::Base
           property :title, predicate: ::RDF::Vocab::DC.title, multiple: false
         end
+
         class FooHistory < ActiveFedora::Base
           indirectly_contains :related_objects, has_member_relation: ::RDF::URI.new('http://www.openarchives.org/ore/terms/aggregates'), inserted_content_relation: ::RDF::URI.new('http://www.openarchives.org/ore/terms/proxyFor'), class_name: 'Different', through: 'Proxy', foreign_key: :proxy_for
         end

--- a/spec/integration/nested_hash_resources_spec.rb
+++ b/spec/integration/nested_hash_resources_spec.rb
@@ -18,6 +18,7 @@ describe "nested hash resources" do
         parent
       end
     end
+
     class ExampleOwner < ActiveFedora::Base
       property :relation, predicate: ::RDF::Vocab::DC.relation, class_name: NestedResource
       accepts_nested_attributes_for :relation

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -5,6 +5,7 @@ describe ActiveFedora::Base do
     class Library < ActiveFedora::Base
       has_many :books
     end
+
     class Book < ActiveFedora::Base
       belongs_to :library, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
     end

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -49,7 +49,7 @@ describe ActiveFedora::Base do
 
       it "does not reload" do
         expect_any_instance_of(ActiveFedora::Relation).to_not receive :find_each
-        libraries.each { |l| l.id }
+        libraries.each(&:id)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,10 +11,6 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   ]
 )
 
-SimpleCov.start "rails" do
-  add_filter "/spec/"
-end
-
 require 'active-fedora'
 require 'rspec'
 require 'rspec/its'
@@ -40,11 +36,9 @@ require 'active_fedora/cleaner'
 RSpec.configure do |config|
   # Stub out test stuff.
   config.before(:each) do
-    begin
-      ActiveFedora::Cleaner.clean!
-    rescue Faraday::ConnectionFailed, RSolr::Error::ConnectionRefused => e
-      $stderr.puts e.message
-    end
+    ActiveFedora::Cleaner.clean!
+  rescue Faraday::ConnectionFailed, RSolr::Error::ConnectionRefused => e
+    $stderr.puts e.message
   end
 
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/an_active_model.rb
+++ b/spec/support/an_active_model.rb
@@ -7,7 +7,7 @@ shared_examples_for "An ActiveModel" do
     expect(inspected_object).to be_kind_of(klass)
   end
 
-  def assert_equal(the_other, one, description = nil)
+  def assert_equal(the_other, one, _description = nil)
     expect(one).to eq the_other
   end
 

--- a/spec/unit/active_fedora/indexing/inserter_spec.rb
+++ b/spec/unit/active_fedora/indexing/inserter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ActiveFedora::Indexing::Inserter do
   end
 
   it "handles floating point integers" do
-    described_class.create_and_insert_terms('my_number', (6.022140857*10**23).to_f, [:displayable, :searchable], solr_doc)
+    described_class.create_and_insert_terms('my_number', (6.022140857 * 10**23).to_f, [:displayable, :searchable], solr_doc)
     expect(solr_doc).to eq('my_number_ssm' => ['6.0221408569999995e+23'], 'my_number_fim' => ['6.0221408569999995e+23'])
   end
 end

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -6,8 +6,10 @@ describe ActiveFedora::AttachedFiles do
     before do
       class Sample1 < ActiveFedora::File
       end
+
       class Sample2 < ActiveFedora::File
       end
+
       class FooHistory < ActiveFedora::Base
         has_subresource 'dsid', class_name: 'Sample2'
         has_subresource 'complex_ds', autocreate: true, class_name: 'Sample1'

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -74,10 +74,12 @@ describe ActiveFedora::Base do
           rdf_label ::RDF::Vocab::FOAF.name
           property :foaf_name, predicate: ::RDF::Vocab::FOAF.name
         end
+
         class Person < Agent
           rdf_label ::RDF::URI('http://example.com/foo')
           property :job, predicate: ::RDF::URI('http://example.com/foo')
         end
+
         class Creator < Person
         end
       end

--- a/spec/unit/callback_spec.rb
+++ b/spec/unit/callback_spec.rb
@@ -23,7 +23,7 @@ describe ActiveFedora::Base do
     end
   end
   after do
-    @cb.destroy if @cb && @cb.persisted? # this only is called if the test failed to run all the way through.
+    @cb.destroy if @cb&.persisted? # this only is called if the test failed to run all the way through.
     Object.send(:remove_const, :CallbackStub)
   end
 

--- a/spec/unit/collection_proxy_spec.rb
+++ b/spec/unit/collection_proxy_spec.rb
@@ -4,6 +4,7 @@ describe ActiveFedora::Associations::CollectionProxy do
   before do
     class Book < ActiveFedora::Base
     end
+
     class Page < ActiveFedora::Base
     end
   end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -4,6 +4,7 @@ describe ActiveFedora::Base do
   before do
     class Library < ActiveFedora::Base
     end
+
     class Book < ActiveFedora::Base
       belongs_to :library, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasConstituent
       property :title, predicate: ::RDF::Vocab::DC.title, multiple: false

--- a/spec/unit/fedora_spec.rb
+++ b/spec/unit/fedora_spec.rb
@@ -11,7 +11,7 @@ describe ActiveFedora::Fedora do
           ssl: { ca_path: '/path/to/certs' } }
       }
       specify {
-        expect(Faraday).to receive(:new).with("https://example.com", { ssl: { ca_path: '/path/to/certs' }}).and_call_original
+        expect(Faraday).to receive(:new).with("https://example.com", { ssl: { ca_path: '/path/to/certs' } }).and_call_original
         fedora.authorized_connection
       }
     end
@@ -23,7 +23,7 @@ describe ActiveFedora::Fedora do
           request: { timeout: 600, open_timeout: 60 } }
       }
       specify {
-        expect(Faraday).to receive(:new).with("https://example.com", { request: { timeout: 600, open_timeout: 60 }}).and_call_original
+        expect(Faraday).to receive(:new).with("https://example.com", { request: { timeout: 600, open_timeout: 60 } }).and_call_original
         fedora.authorized_connection
       }
     end

--- a/spec/unit/finder_methods_spec.rb
+++ b/spec/unit/finder_methods_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe ActiveFedora::FinderMethods do
   end
 
   let(:finder_class) do
-    # this = self
     Class.new do
       include ActiveFedora::FinderMethods
       def initialize(object_class:)

--- a/spec/unit/finder_methods_spec.rb
+++ b/spec/unit/finder_methods_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ActiveFedora::FinderMethods do
   end
 
   let(:finder_class) do
-    this = self
+    # this = self
     Class.new do
       include ActiveFedora::FinderMethods
       def initialize(object_class:)

--- a/spec/unit/has_and_belongs_to_many_association_spec.rb
+++ b/spec/unit/has_and_belongs_to_many_association_spec.rb
@@ -5,6 +5,7 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
     before do
       class Book < ActiveFedora::Base
       end
+
       class Page < ActiveFedora::Base
       end
 

--- a/spec/unit/has_many_association_spec.rb
+++ b/spec/unit/has_many_association_spec.rb
@@ -4,6 +4,7 @@ describe ActiveFedora::Associations::HasManyAssociation do
   before do
     class Book < ActiveFedora::Base
     end
+
     class Page < ActiveFedora::Base
     end
   end

--- a/spec/unit/indexing_spec.rb
+++ b/spec/unit/indexing_spec.rb
@@ -61,10 +61,9 @@ describe ActiveFedora::Indexing do
     end
 
     it "adds id, system_create_date, system_modified_date from object attributes" do
-      expect(test_object).to receive(:create_date).and_return(DateTime.parse("2012-03-04T03:12:02Z")).twice
-      expect(test_object).to receive(:modified_date).and_return(DateTime.parse("2012-03-07T03:12:02Z")).twice
+      expect(test_object).to receive(:create_date).and_return(DateTime.parse("2012-03-04T03:12:02Z"))
+      expect(test_object).to receive(:modified_date).and_return(DateTime.parse("2012-03-07T03:12:02Z"))
       allow(test_object).to receive(:id).and_return('changeme:123')
-      solr_doc = test_object.to_solr
       expect(solr_doc[ActiveFedora.index_field_mapper.solr_name("system_create", :stored_sortable, type: :date)]).to eql("2012-03-04T03:12:02Z")
       expect(solr_doc[ActiveFedora.index_field_mapper.solr_name("system_modified", :stored_sortable, type: :date)]).to eql("2012-03-07T03:12:02Z")
       expect(solr_doc[:id]).to eql("changeme:123")

--- a/spec/unit/model_classifier_spec.rb
+++ b/spec/unit/model_classifier_spec.rb
@@ -4,8 +4,10 @@ describe ActiveFedora::ModelClassifier do
   module ParentClass
     class SiblingClass
     end
+
     class OtherSiblingClass
     end
+
     class SubclassClass < SiblingClass
     end
   end

--- a/spec/unit/ordered_spec.rb
+++ b/spec/unit/ordered_spec.rb
@@ -5,8 +5,10 @@ describe ActiveFedora::Orders do
   before do
     class Member < ActiveFedora::Base
     end
+
     class BadClass < ActiveFedora::Base
     end
+
     class Image < ActiveFedora::Base
       ordered_aggregation :members, through: :list_source
     end
@@ -82,52 +84,52 @@ describe ActiveFedora::Orders do
     describe "#=" do
       it "sets ordered members" do
         member = Member.new
-        member_2 = Member.new
+        member2 = Member.new
         image.ordered_members << member
         expect(image.ordered_members).to eq [member]
-        image.ordered_members = [member_2, member_2]
-        expect(image.ordered_members).to eq [member_2, member_2]
+        image.ordered_members = [member2, member2]
+        expect(image.ordered_members).to eq [member2, member2]
         # Removing from ordering is not the same as removing from aggregation.
-        expect(image.members).to contain_exactly member, member_2
+        expect(image.members).to contain_exactly member, member2
       end
     end
     describe "+=" do
       it "appends ordered members" do
         member = Member.new
-        member_2 = Member.new
+        member2 = Member.new
         image.ordered_members << member
-        expect(image.ordered_members += [member, member_2]).to eq [member, member, member_2]
-        expect(image.ordered_members).to eq [member, member, member_2]
-        expect(image.ordered_member_proxies.map(&:target)).to eq [member, member, member_2]
+        expect(image.ordered_members += [member, member2]).to eq [member, member, member2]
+        expect(image.ordered_members).to eq [member, member, member2]
+        expect(image.ordered_member_proxies.map(&:target)).to eq [member, member, member2]
       end
     end
     describe "#delete_at" do
       it "deletes that position" do
         member = Member.new
-        member_2 = Member.new
-        image.ordered_members += [member, member_2]
+        member2 = Member.new
+        image.ordered_members += [member, member2]
 
         expect(image.ordered_members.delete_at(0)).to eq member
-        expect(image.ordered_members).to eq [member_2]
+        expect(image.ordered_members).to eq [member2]
       end
     end
 
     describe "#delete" do
       let(:member) { Member.create }
-      let(:member_2) { Member.create }
+      let(:member2) { Member.create }
       before do
-        image.ordered_members += [member, member_2, member]
+        image.ordered_members += [member, member2, member]
         image.save!
       end
 
       context "with an object found in the list" do
         it "deletes all occurences of the object" do
           expect(image.ordered_members.delete(member)).to eq member
-          expect(image.ordered_members.to_a).to eq [member_2]
+          expect(image.ordered_members.to_a).to eq [member2]
         end
         it "can delete all" do
           expect(image.ordered_members.delete(member)).to eq member
-          expect(image.ordered_members.delete(member_2)).to eq member_2
+          expect(image.ordered_members.delete(member2)).to eq member2
           image.save!
           expect(image.reload.ordered_members.to_a).to eq []
         end
@@ -136,7 +138,7 @@ describe ActiveFedora::Orders do
       context "with an object not found in the list" do
         it "returns nil" do
           expect(image.ordered_members.delete(Member.create)).to be_nil
-          expect(image.ordered_members.to_a).to eq [member, member_2, member]
+          expect(image.ordered_members.to_a).to eq [member, member2, member]
         end
       end
     end
@@ -144,45 +146,45 @@ describe ActiveFedora::Orders do
     describe "#insert_at" do
       it "adds at a given position" do
         member = Member.new
-        member_2 = Member.new
-        image.ordered_members += [member, member_2]
+        member2 = Member.new
+        image.ordered_members += [member, member2]
 
-        image.ordered_members.insert_at(0, member_2)
-        expect(image.ordered_members).to eq [member_2, member, member_2]
+        image.ordered_members.insert_at(0, member2)
+        expect(image.ordered_members).to eq [member2, member, member2]
       end
       it "adds a proxy_in statement" do
         member = Member.new
-        member_2 = Member.new
-        image.ordered_members += [member, member_2]
+        member2 = Member.new
+        image.ordered_members += [member, member2]
 
-        image.ordered_members.insert_at(0, member_2)
+        image.ordered_members.insert_at(0, member2)
         expect(image.ordered_member_proxies.map(&:proxy_in).uniq).to eq [image]
       end
     end
     describe "lazy loading" do
       it "does not instantiate every record on append" do
         member = Member.new
-        member_2 = Member.new
-        image.ordered_members += [member, member_2]
+        member2 = Member.new
+        image.ordered_members += [member, member2]
         image.save
         allow(ActiveFedora::Base).to receive(:find).and_call_original
 
         reloaded = image.class.find(image.id)
         reloaded.ordered_members << member
 
-        expect(ActiveFedora::Base).not_to have_received(:find).with(member_2.id)
+        expect(ActiveFedora::Base).not_to have_received(:find).with(member2.id)
       end
       it "does not instantiate every record on #insert_at" do
         member = Member.new
-        member_2 = Member.new
-        image.ordered_members += [member, member_2]
+        member2 = Member.new
+        image.ordered_members += [member, member2]
         image.save
         allow(ActiveFedora::Base).to receive(:find).and_call_original
 
         reloaded = image.class.find(image.id)
         reloaded.ordered_members.insert_at(0, member)
 
-        expect(ActiveFedora::Base).not_to have_received(:find).with(member_2.id)
+        expect(ActiveFedora::Base).not_to have_received(:find).with(member2.id)
       end
     end
   end
@@ -240,11 +242,11 @@ describe ActiveFedora::Orders do
       image.ordered_member_proxies.append_target member
       image.save
       image.reload
-      member_2 = Member.new
-      image.ordered_member_proxies.append_target member_2
+      member2 = Member.new
+      image.ordered_member_proxies.append_target member2
       image.save
       image.reload
-      expect(image.ordered_members).to eq [member, member_2]
+      expect(image.ordered_members).to eq [member, member2]
     end
   end
   describe "insert_target_at" do
@@ -297,9 +299,9 @@ describe ActiveFedora::Orders do
     end
     it "can remove proxies in the middle" do
       member = Member.new
-      member_2 = Member.new
+      member2 = Member.new
       image.ordered_member_proxies.append_target member
-      image.ordered_member_proxies.append_target member_2
+      image.ordered_member_proxies.append_target member2
       image.ordered_member_proxies.append_target member
       image.ordered_member_proxies -= [image.ordered_member_proxies[1]]
       expect(image.ordered_members).to eq [member, member]

--- a/spec/unit/orders/ordered_list_spec.rb
+++ b/spec/unit/orders/ordered_list_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     context "with two nodes" do
       it "is the last node" do
         member = instance_double(ActiveFedora::Base)
-        member_2 = instance_double(ActiveFedora::Base)
+        member2 = instance_double(ActiveFedora::Base)
         ordered_list.append_target member
-        ordered_list.append_target member_2
+        ordered_list.append_target member2
 
-        expect(ordered_list.last.target).to eq member_2
+        expect(ordered_list.last.target).to eq member2
       end
     end
   end
@@ -106,16 +106,16 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     context "with two nodes" do
       let(:member) { instance_double(ActiveFedora::Base) }
-      let(:member_2) { instance_double(ActiveFedora::Base) }
+      let(:member2) { instance_double(ActiveFedora::Base) }
       before do
         ordered_list.append_target member
-        ordered_list.append_target member_2
+        ordered_list.append_target member2
       end
       it "can return the first" do
         expect(ordered_list[0].target).to eq member
       end
       it "can return the last" do
-        expect(ordered_list[1].target).to eq member_2
+        expect(ordered_list[1].target).to eq member2
       end
       it "returns nil for out of bounds values" do
         expect(ordered_list[3]).to eq nil
@@ -199,35 +199,35 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
   describe "#insert_at" do
     it "can insert in the middle" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       3.times do
         ordered_list.append_target member
       end
 
-      ordered_list.insert_at(1, member_2)
+      ordered_list.insert_at(1, member2)
 
-      expect(ordered_list.to_a.map(&:target)).to eq [member, member_2, member, member]
+      expect(ordered_list.to_a.map(&:target)).to eq [member, member2, member, member]
       expect(ordered_list).to be_changed
     end
     it "can insert at the beginning" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       2.times do
         ordered_list.append_target member
       end
 
-      ordered_list.insert_at(0, member_2)
+      ordered_list.insert_at(0, member2)
 
-      expect(ordered_list.to_a.map(&:target)).to eq [member_2, member, member]
+      expect(ordered_list.to_a.map(&:target)).to eq [member2, member, member]
     end
   end
 
   describe "#delete_node" do
     it "can delete a node in the middle" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       ordered_list.append_target member
-      ordered_list.append_target member_2
+      ordered_list.append_target member2
       ordered_list.append_target member
 
       ordered_list.delete_node(ordered_list.to_a[1])
@@ -236,8 +236,8 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     it "can delete a node at the start" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
-      ordered_list.append_target member_2
+      member2 = instance_double(ActiveFedora::Base)
+      ordered_list.append_target member2
       ordered_list.append_target member
       ordered_list.append_target member
 
@@ -247,10 +247,10 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     it "can delete a node at the end" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       ordered_list.append_target member
       ordered_list.append_target member
-      ordered_list.append_target member_2
+      ordered_list.append_target member2
 
       ordered_list.delete_node(ordered_list.to_a[2])
 
@@ -261,9 +261,9 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
   describe "#delete_at" do
     it "can delete a node in the middle" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       ordered_list.append_target member
-      ordered_list.append_target member_2
+      ordered_list.append_target member2
       ordered_list.append_target member
 
       ordered_list.delete_at(1)
@@ -272,8 +272,8 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     it "can delete a node at the start" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
-      ordered_list.append_target member_2
+      member2 = instance_double(ActiveFedora::Base)
+      ordered_list.append_target member2
       ordered_list.append_target member
       ordered_list.append_target member
 
@@ -283,10 +283,10 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     it "can delete a node at the end" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       ordered_list.append_target member
       ordered_list.append_target member
-      ordered_list.append_target member_2
+      ordered_list.append_target member2
 
       ordered_list.delete_at(2)
 
@@ -294,15 +294,15 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
     it "does not delete nodes if the loc is out of bounds" do
       member = instance_double(ActiveFedora::Base)
-      member_2 = instance_double(ActiveFedora::Base)
+      member2 = instance_double(ActiveFedora::Base)
       ordered_list.append_target member
       ordered_list.append_target member
-      ordered_list.append_target member_2
+      ordered_list.append_target member2
 
       ordered_list.delete_at(3)
       ordered_list.delete_at(nil)
 
-      expect(ordered_list.map(&:target)).to eq [member, member, member_2]
+      expect(ordered_list.map(&:target)).to eq [member, member, member2]
     end
   end
 

--- a/spec/unit/query_result_builder_spec.rb
+++ b/spec/unit/query_result_builder_spec.rb
@@ -19,6 +19,7 @@ describe ActiveFedora::QueryResultBuilder do
         described_class.reify_solr_results(@sample_solr_hits)
       end
     end
+    # rubocop:disable Lint/Void
     describe ".lazy_reify_solr_results" do
       it "lazilies reify solr results" do
         expect(AudioRecord).to receive(:find).with("my:_ID1_", cast: true)
@@ -27,5 +28,6 @@ describe ActiveFedora::QueryResultBuilder do
         described_class.lazy_reify_solr_results(@sample_solr_hits).each { |r| r }
       end
     end
+    # rubocop:enable Lint/Void
   end
 end

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -21,9 +21,9 @@ describe ActiveFedora::Base do
 
       it "queries solr for all objects with has_model_ssim of self.class" do
         expect(relation).to receive(:load_from_fedora).with("changeme:30", nil)
-          .and_return("Fake Object1")
+                                                      .and_return("Fake Object1")
         expect(relation).to receive(:load_from_fedora).with("changeme:22", nil)
-          .and_return("Fake Object2")
+                                                      .and_return("Fake Object2")
         mock_docs = [{ "id" => "changeme:30" }, { "id" => "changeme:22" }]
         expect(mock_docs).to receive(:has_next?).and_return(false)
         expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate)
@@ -38,9 +38,9 @@ describe ActiveFedora::Base do
       let(:relation) { ActiveFedora::Relation.new(described_class) }
       it "specifies a q parameter" do
         expect(relation).to receive(:load_from_fedora).with("changeme:30", true)
-          .and_return("Fake Object1")
+                                                      .and_return("Fake Object1")
         expect(relation).to receive(:load_from_fedora).with("changeme:22", true)
-          .and_return("Fake Object2")
+                                                      .and_return("Fake Object2")
         mock_docs = [{ "id" => "changeme:30" }, { "id" => "changeme:22" }]
         expect(mock_docs).to receive(:has_next?).and_return(false)
         expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate)
@@ -104,13 +104,13 @@ describe ActiveFedora::Base do
 
     it "adds options" do
       expect(relation).to receive(:load_from_fedora).with("changeme:30", nil)
-        .and_return("Fake Object1")
+                                                    .and_return("Fake Object1")
       expect(relation).to receive(:load_from_fedora).with("changeme:22", nil)
-        .and_return("Fake Object2")
+                                                    .and_return("Fake Object2")
 
       expect(mock_docs).to receive(:has_next?).and_return(false)
       expect(solr).to receive(:paginate).with(1, 1000, 'select', expected_sort_params)
-        .and_return('response' => { 'docs' => mock_docs })
+                                        .and_return('response' => { 'docs' => mock_docs })
       expect(SpecModel::Basic.where(foo: 'bar', baz: ['quix', 'quack'])
                                 .order('title_t desc')).to eq ["Fake Object1", "Fake Object2"]
     end
@@ -128,9 +128,9 @@ describe ActiveFedora::Base do
         .and_return('response' => { 'docs' => mock_docs })
 
       allow(relation).to receive(:load_from_fedora).with("changeme-30", nil)
-        .and_return(SpecModel::Basic.new(id: 'changeme-30'))
+                                                   .and_return(SpecModel::Basic.new(id: 'changeme-30'))
       allow(relation).to receive(:load_from_fedora).with("changeme-22", nil)
-        .and_return(SpecModel::Basic.new(id: 'changeme-22'))
+                                                   .and_return(SpecModel::Basic.new(id: 'changeme-22'))
       SpecModel::Basic.find_each { |obj| obj.class == SpecModel::Basic }
     end
 

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -15,6 +15,7 @@ describe ActiveFedora::Base do
       def before_validation_callback
         # no-op
       end
+
       def after_validation_callback
         # no-op
       end


### PR DESCRIPTION
This PR adds support for ruby 3 by upgrading ldp and ActiveTriples as well switching to bixby in order to upgrade rubocop to a version with support for ruby 3.  The upgrade to bixby required extensive styling fixes, but brings ActiveFedora in line with the rest of the core components.