### PR TITLE
Release 14.0.0

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'A convenience libary for manipulating documents in the Fedora Repository.'
   s.description = 'ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.'
   s.license = "Apache-2.0"
-  s.metadata      = { "rubygems_mfa_required" => "true" }
+  s.metadata = { "rubygems_mfa_required" => "true" }
   s.required_ruby_version = '>= 2.6'
 
   s.add_dependency "activemodel", '>= 5.1'

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A convenience libary for manipulating documents in the Fedora Repository.}
   s.description = %q{ActiveFedora provides for creating and managing objects in the Fedora Repository Architecture.}
   s.license = "Apache-2.0"
+  s.metadata      = { "rubygems_mfa_required" => "true" }
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency "activemodel", '>= 5.1'

--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '13.3.0'
+  VERSION = '14.0.0'
 end


### PR DESCRIPTION
Includes:
- #1489 
Also resolves #1481 

Making this a major release (14.0.0) because ruby 2.4 and 2.5 are explicitly being dropped in order to bring in a newer version of `json-ld`.