### PR TITLE
Avoid modifying frozen array

### DIFF
--- a/lib/active_fedora/autosave_association.rb
+++ b/lib/active_fedora/autosave_association.rb
@@ -243,10 +243,9 @@ module ActiveFedora
 
         unless valid = record.valid?
           if reflection.options[:autosave]
-            record.errors.each do |attribute, message|
+            record.errors.messages.each do |attribute, messages|
               attribute = "#{reflection.name}.#{attribute}"
-              errors[attribute] << message
-              errors[attribute].uniq!
+              messages.map { |message| errors.add(attribute, message: message) }
             end
           else
             errors.add(reflection.name)

--- a/spec/unit/ordered_spec.rb
+++ b/spec/unit/ordered_spec.rb
@@ -366,4 +366,27 @@ describe ActiveFedora::Orders do
       expect(image.ordered_members).to eq [member, member]
     end
   end
+
+  describe ".valid" do
+    before do
+      class Container < ActiveFedora::Base
+        ordered_aggregation :members, through: :list_source
+        accepts_nested_attributes_for :members
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :Container)
+    end
+
+    it "records errors" do
+      container = Container.new
+      member = Member.new
+      member.errors.add(:foo, "bar")
+      allow(member).to receive(:valid?).and_return(false)
+      container.ordered_members << member
+      expect(container.valid?).to eq false
+      expect(container.errors.include?("members.foo")).to eq true
+    end
+  end
 end


### PR DESCRIPTION
When attempting to upgrade Avalon to rails 7.0, I ran into an error about modification of frozen arrays, but the real issue was that Rails 6.1 included a major change in `ActiveModel::Error` turning it into an array of objects instead of a simple hash.  The API changed and I had to find an approach that worked for all versions of Rails that ActiveFedora supports.  I think the approach I took is a stop gap and that we'll want to rework this using the new API more and possibly rethinking this section entirely.  Currently the errors are surfaced on the parent object by composing the child association name with the attribute of the child which has the error.  This is problematic because the new `ActiveModel::Error` implementation checks if error keys are actual attributes on the model object.  For example, ```errors.messages_for("members.foo")` raises `NoMethodError Exception: undefined method `members.foo'```.

It appears that there weren't any tests for this part of the code so it slipped by the prior work on supporting rails 7.