### PR TITLE
Copy newer rails code for rewording or removing constants

### DIFF
--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -14,7 +14,7 @@ module ActiveFedora
       end
     end
 
-    BLACKLISTED_CLASS_METHODS = %w[private public protected allocate new name parent superclass].freeze
+    RESTRICTED_CLASS_METHODS = %w[private public protected allocate new name parent superclass].freeze
 
     class GeneratedAttributeMethods < Module; end # :nodoc:
 
@@ -81,7 +81,7 @@ module ActiveFedora
       # A class method is 'dangerous' if it is already (re)defined by Active Record, but
       # not by any ancestors. (So 'puts' is not dangerous but 'new' is.)
       def dangerous_class_method?(method_name)
-        BLACKLISTED_CLASS_METHODS.include?(method_name.to_s) || class_method_defined_within?(method_name, Base)
+        RESTRICTED_CLASS_METHODS.include?(method_name.to_s) || class_method_defined_within?(method_name, Base)
       end
 
       def class_method_defined_within?(name, klass, superklass = klass.superclass) # :nodoc:

--- a/lib/active_fedora/relation/delegation.rb
+++ b/lib/active_fedora/relation/delegation.rb
@@ -7,32 +7,7 @@ module ActiveFedora
     # may vary depending on the klass of a relation, so we create a subclass of Relation
     # for each different klass, and the delegations are compiled into that subclass only.
 
-    BLACKLISTED_ARRAY_METHODS = [
-      :compact!, :flatten!, :reject!, :reverse!, :rotate!, :map!,
-      :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
-      :keep_if, :pop, :shift, :delete_at, :select!
-    ].to_set
-
-    delegate :length, :map, :to_ary, to: :to_a
+    delegate :length, :map, :to_ary, :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :shuffle, :slice, :index, :rindex, :size, to: :to_a
     delegate :any?, :all?, :collect, :include?, to: :each
-
-    protected
-
-      def array_delegable?(method)
-        Array.method_defined?(method) && BLACKLISTED_ARRAY_METHODS.exclude?(method)
-      end
-
-      def method_missing(method, *args, &block)
-        if array_delegable?(method)
-          self.class.delegate method, to: :to_a
-          to_a.public_send(method, *args, &block)
-        else
-          super
-        end
-      end
-
-      def respond_to_missing?(method, *args)
-        array_delegable?(method) || super
-      end
   end
 end


### PR DESCRIPTION
Since the changes in #1500 are preparing for a major release the changes proposed in #1430 can be merged without backwards compatibility concerns.  I favored the approaches rails took as pointed out by @jcoyne .

Alternative to #1430