### PR TITLE
Use to_formatted_s(:db) instead of deprecated and removed to_s(:db)

### DIFF
--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -177,7 +177,7 @@ module ActiveFedora
       if value.is_a?(String) && value.length > 50
         "#{value[0, 50]}...".inspect
       elsif value.is_a?(Date) || value.is_a?(Time)
-        %("#{value.to_s(:db)}")
+        %("#{value.to_formatted_s(:db)}")
       elsif value.is_a?(Array) && value.size > 10
         inspected = value.first(10).inspect
         %(#{inspected[0...-1]}, ...])

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -8,6 +8,7 @@ describe ActiveFedora::Base do
           index.as :symbol
         end
         property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: false
+        property :date, predicate: ::RDF::Vocab::DC.date, multiple: false
       end
     end
 
@@ -16,25 +17,25 @@ describe ActiveFedora::Base do
     end
 
     subject(:history) { obj }
-    let(:obj) { BarHistory4.new(title: ['test1'], id: 'test:123') }
+    let(:obj) { BarHistory4.new(title: ['test1'], id: 'test:123', date: Date.new(2024, 1, 1)) }
 
     describe "#attribute_names" do
       context "on an instance" do
         it "lists the attributes" do
-          expect(history.attribute_names).to eq ["title", "abstract"]
+          expect(history.attribute_names).to eq ["title", "abstract", "date"]
         end
       end
 
       context "on a class" do
         it "lists the attributes" do
-          expect(BarHistory4.attribute_names).to eq ["title", "abstract"]
+          expect(BarHistory4.attribute_names).to eq ["title", "abstract", "date"]
         end
       end
     end
 
     describe "#inspect" do
       it "shows the attributes" do
-        expect(history.inspect).to eq "#<BarHistory4 id: \"test:123\", title: [\"test1\"], abstract: nil>"
+        expect(history.inspect).to eq "#<BarHistory4 id: \"test:123\", title: [\"test1\"], abstract: nil, date: \"2024-01-01 00:00:00\">"
       end
 
       describe "with no attributes" do
@@ -60,7 +61,7 @@ describe ActiveFedora::Base do
         end
 
         it "shows the library_id" do
-          expect(history.inspect).to eq "#<BarHistory2 id: nil, title: [], abstract: nil, library_id: \"#{library.id}\">"
+          expect(history.inspect).to eq "#<BarHistory2 id: nil, title: [], abstract: nil, date: nil, library_id: \"#{library.id}\">"
         end
       end
     end


### PR DESCRIPTION
Found by @randalldfloyd in the Hyrax test suite when attempting to upgrade to rails 7.2.  This is an untested incompatibility with rails 7.1+ that once fixed will need to go into a patch release.