### PR TITLE
Bump version for major release

### DIFF
--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFedora
-  VERSION = '15.0.1'
+  VERSION = '16.0.0'
 end


### PR DESCRIPTION
This release starts support for Fedora 6+ (#1504).  Support for Fedora 4 will continue with limited releases as needed in the 15.x line.